### PR TITLE
Color fix for Fields/DS Text in selects

### DIFF
--- a/src/components/controls/field/field.tsx
+++ b/src/components/controls/field/field.tsx
@@ -3,12 +3,13 @@ import './field.scss';
 interface Props {
 	label: string | number | JSX.Element | JSX.Element[];
 	value: string | number | JSX.Element | JSX.Element[];
+	className?: string;
 };
 
 export const Field = (props: Props) => {
 	try {
 		return (
-			<div className='field'>
+			<div className={`field ${props.className || ''}`}> {/* for feature panel fields */}
 				<span className='field-label'>{props.label}</span>
 				<span className='field-value'>{props.value}</span>
 			</div>

--- a/src/components/pages/heroes/hero-edit/hero-edit-page.scss
+++ b/src/components/pages/heroes/hero-edit/hero-edit-page.scss
@@ -85,4 +85,15 @@
 			}
 		}
 	}
+	.feature-field {
+		.field-label {
+			color: rgb(80, 80, 80);
+		}
+		.field-value {
+			color: rgb(80, 80, 80);
+		}
+	}
+	.ds-text.culture {
+		color: rgb(80, 80, 80);
+	}
 }

--- a/src/components/pages/heroes/hero-edit/hero-edit-page.scss
+++ b/src/components/pages/heroes/hero-edit/hero-edit-page.scss
@@ -85,7 +85,7 @@
 			}
 		}
 	}
-	.feature-field {
+	.subclass-field {
 		.field-label {
 			color: rgb(80, 80, 80);
 		}

--- a/src/components/pages/heroes/hero-edit/hero-edit-page.tsx
+++ b/src/components/pages/heroes/hero-edit/hero-edit-page.tsx
@@ -456,7 +456,7 @@ const CultureSection = (props: CultureSectionProps) => {
 							allowClear={true}
 							placeholder='Select'
 							options={languages.map(l => ({ label: l.name, value: l.name, desc: l.description }))}
-							optionRender={option => <Field label={option.data.label} value={option.data.desc} />}
+							optionRender={option => <Field className={`feature-field`} label={option.data.label} value={option.data.desc} />}
 							value={props.hero.culture.languages.length > 0 ? props.hero.culture.languages[0] : null}
 							onChange={value => props.selectLanguages([ value ])}
 						/>
@@ -466,8 +466,8 @@ const CultureSection = (props: CultureSectionProps) => {
 								style={{ width: '100%' }}
 								allowClear={true}
 								placeholder='Select'
-								options={EnvironmentData.getEnvironments().map(s => ({ value: s.id, label: s.name }))}
-								optionRender={option => <div className='ds-text'>{option.data.label}</div>}
+								options={EnvironmentData.getEnvironments().map(s => ({ value: s.id, label: s.name}))}
+								optionRender={option => <div className='ds-text culture'>{option.data.label}</div>}
 								value={props.hero.culture.environment ? props.hero.culture.environment.id : null}
 								onChange={props.selectEnvironment}
 							/>
@@ -475,8 +475,8 @@ const CultureSection = (props: CultureSectionProps) => {
 								style={{ width: '100%' }}
 								allowClear={true}
 								placeholder='Select'
-								options={OrganizationData.getOrganizations().map(s => ({ value: s.id, label: s.name }))}
-								optionRender={option => <div className='ds-text'>{option.data.label}</div>}
+								options={OrganizationData.getOrganizations().map(s => ({ value: s.id, label: s.name}))}
+								optionRender={option => <div className='ds-text culture'>{option.data.label}</div>}
 								value={props.hero.culture.organization ? props.hero.culture.organization.id : null}
 								onChange={props.selectOrganization}
 							/>
@@ -484,8 +484,8 @@ const CultureSection = (props: CultureSectionProps) => {
 								style={{ width: '100%' }}
 								allowClear={true}
 								placeholder='Select'
-								options={UpbringingData.getUpbringings().map(s => ({ value: s.id, label: s.name }))}
-								optionRender={option => <div className='ds-text'>{option.data.label}</div>}
+								options={UpbringingData.getUpbringings().map(s => ({ value: s.id, label: s.name}))}
+								optionRender={option => <div className='ds-text culture'>{option.data.label}</div>}
 								value={props.hero.culture.upbringing ? props.hero.culture.upbringing.id : null}
 								onChange={props.selectUpbringing}
 							/>
@@ -630,7 +630,7 @@ const ClassSection = (props: ClassSectionProps) => {
 							allowClear={true}
 							placeholder='Select'
 							options={props.hero.class.subclasses.map(s => ({ value: s.id, label: s.name, desc: s.description }))}
-							optionRender={option => <Field label={option.data.label} value={option.data.desc} />}
+							optionRender={option => <Field className={`feature-field`} label={option.data.label} value={option.data.desc} />}
 							value={props.hero.class.subclasses.filter(sc => sc.selected).map(sc => sc.id)}
 							onChange={props.selectSubclasses}
 						/>

--- a/src/components/pages/heroes/hero-edit/hero-edit-page.tsx
+++ b/src/components/pages/heroes/hero-edit/hero-edit-page.tsx
@@ -630,7 +630,7 @@ const ClassSection = (props: ClassSectionProps) => {
 							allowClear={true}
 							placeholder='Select'
 							options={props.hero.class.subclasses.map(s => ({ value: s.id, label: s.name, desc: s.description }))}
-							optionRender={option => <Field className={`feature-field`} label={option.data.label} value={option.data.desc} />}
+							optionRender={option => <Field className={`subclass-field`} label={option.data.label} value={option.data.desc} />}
 							value={props.hero.class.subclasses.filter(sc => sc.selected).map(sc => sc.id)}
 							onChange={props.selectSubclasses}
 						/>

--- a/src/components/panels/feature-panel/feature-panel.scss
+++ b/src/components/panels/feature-panel/feature-panel.scss
@@ -1,3 +1,12 @@
 .feature-panel {
 	display: block;
 }
+
+.feature-field {
+	.field-label {
+		color: rgb(80, 80, 80);
+	}
+	.field-value {
+		color: rgb(80, 80, 80);
+	}
+}

--- a/src/components/panels/feature-panel/feature-panel.scss
+++ b/src/components/panels/feature-panel/feature-panel.scss
@@ -1,13 +1,3 @@
 .feature-panel {
 	display: block;
 }
-@media (prefers-color-scheme: dark) {
-	.feature-field {
-		.field-label {
-			color: rgb(80, 80, 80);
-		}
-		.field-value {
-			color: rgb(80, 80, 80);
-		}
-	}
-}

--- a/src/components/panels/feature-panel/feature-panel.scss
+++ b/src/components/panels/feature-panel/feature-panel.scss
@@ -1,3 +1,13 @@
 .feature-panel {
 	display: block;
 }
+@media (prefers-color-scheme: dark) {
+	.feature-field {
+		.field-label {
+			color: rgb(80, 80, 80);
+		}
+		.field-value {
+			color: rgb(80, 80, 80);
+		}
+	}
+}

--- a/src/components/panels/feature-panel/feature-panel.tsx
+++ b/src/components/panels/feature-panel/feature-panel.tsx
@@ -37,7 +37,7 @@ export const FeaturePanel = (props: Props) => {
 					allowClear={true}
 					placeholder='Select'
 					options={data.options.map(o => ({ label: o.feature.name, value: o.feature.id, desc: o.feature.description }))}
-					optionRender={option => <Field label={option.data.label} value={option.data.desc} />}
+					optionRender={option => <Field className={`feature-field`} label={option.data.label} value={option.data.desc} />}
 					value={data.count === 1 ? (data.selected.length > 0 ? data.selected[0].id : null) : data.selected.map(f => f.id)}
 					onChange={value => {
 						let ids: string[] = [];
@@ -85,7 +85,7 @@ export const FeaturePanel = (props: Props) => {
 					allowClear={true}
 					placeholder='Select'
 					options={sortedAbilities.map(a => ({ label: a.name, value: a.id, desc: a.description }))}
-					optionRender={option => <Field label={option.data.label} value={option.data.desc} />}
+					optionRender={option => <Field className='feature-field' label={option.data.label} value={option.data.desc} />}
 					value={data.count === 1 ? (data.selectedIDs.length > 0 ? data.selectedIDs[0] : null) : data.selectedIDs}
 					onChange={value => {
 						let ids: string[] = [];
@@ -127,7 +127,7 @@ export const FeaturePanel = (props: Props) => {
 					allowClear={true}
 					placeholder='Select'
 					options={sortedKits.map(a => ({ label: a.name, value: a.id, desc: a.description }))}
-					optionRender={option => <Field label={option.data.label} value={option.data.desc} />}
+					optionRender={option => <Field className='feature-field' label={option.data.label} value={option.data.desc} />}
 					value={data.count === 1 ? (data.selected.length > 0 ? data.selected[0].id : null) : data.selected.map(k => k.id)}
 					onChange={value => {
 						let ids: string[] = [];
@@ -174,7 +174,7 @@ export const FeaturePanel = (props: Props) => {
 					allowClear={true}
 					placeholder='Select'
 					options={sortedLanguages.map(l => ({ label: l.name, value: l.name, desc: l.description }))}
-					optionRender={option => <Field label={option.data.label} value={option.data.desc} />}
+					optionRender={option => <Field className='feature-field' label={option.data.label} value={option.data.desc} />}
 					value={data.count === 1 ? (data.selected.length > 0 ? data.selected[0] : null) : data.selected}
 					onChange={value => {
 						let ids: string[] = [];
@@ -227,7 +227,7 @@ export const FeaturePanel = (props: Props) => {
 					allowClear={true}
 					placeholder='Select'
 					options={sortedSkills.map(s => ({ label: s.name, value: s.name, desc: s.description }))}
-					optionRender={option => <Field label={option.data.label} value={option.data.desc} />}
+					optionRender={option => <Field className='feature-field' label={option.data.label} value={option.data.desc} />}
 					value={data.count === 1 ? (data.selected.length > 0 ? data.selected[0] : null) : data.selected}
 					onChange={value => {
 						let ids: string[] = [];
@@ -292,7 +292,7 @@ export const FeaturePanel = (props: Props) => {
 					allowClear={true}
 					placeholder='Select'
 					options={options.map(o => ({ label: o.name, value: o.id, desc: o.description }))}
-					optionRender={option => <Field label={option.data.label} value={option.data.desc} />}
+					optionRender={option => <Field className='feature-field' label={option.data.label} value={option.data.desc} />}
 					value={data.count === 1 ? (data.selected.length > 0 ? data.selected[0].id : null) : data.selected.map(f => f.id)}
 					onChange={value => {
 						let ids: string[] = [];
@@ -407,7 +407,7 @@ export const FeaturePanel = (props: Props) => {
 		}
 
 		return (
-			<Field label='Selected' value={data.selected.join(', ')} />
+			<Field className='feature-field' label='Selected' value={data.selected.join(', ')} />
 		);
 	};
 
@@ -421,7 +421,7 @@ export const FeaturePanel = (props: Props) => {
 		}
 
 		return (
-			<Field label='Selected' value={data.selected.join(', ')} />
+			<Field className='feature-field' label='Selected' value={data.selected.join(', ')} />
 		);
 	};
 


### PR DESCRIPTION
Added `classNames + styling` to Ancestry, Culture, Career, and Class `fields` & `ds-texts` for dark mode clarity