### PR TITLE
Fix invisible export buttons

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -270,6 +270,12 @@ td {
 		background-color: rgb(55, 55, 55) !important;
 	}
 
+	.ant-dropdown-menu {
+		.ds-text {
+			color: rgba(0, 0, 0, 0.88);
+		}
+	}
+
 	.ant-popover {
 		.ant-popover-arrow:after,
 		.ant-popover-inner {


### PR DESCRIPTION
In order to fix https://github.com/andyaiken/forgesteel/issues/25

Adds a `.ds-text` css override to the `.ant-dropdown-menu` class when `@media (prefers-color-scheme: dark) {` to set the text color to black.

### Screenshots

Before:

![Screenshot 2024-11-17 at 22 05 07](https://github.com/user-attachments/assets/3be0ca36-79f6-436d-8a44-443448015a96)

After:

![Screenshot 2024-11-17 at 22 11 00](https://github.com/user-attachments/assets/828aed6b-fb7b-4d41-bf99-cff28abfc5be)
