### PR TITLE
Hash Routing

### DIFF
--- a/src/components/main/main.tsx
+++ b/src/components/main/main.tsx
@@ -992,7 +992,7 @@ export const Main = (props: Props) => {
 	return (
 		<Routes>
 			<Route
-				path={navigation.rootRoute}
+				path='/'
 				element={
 					<MainLayout
 						section='hero'

--- a/src/hooks/use-navigation.ts
+++ b/src/hooks/use-navigation.ts
@@ -2,33 +2,31 @@ import type { SourcebookElementKind } from '../models/sourcebook-element-kind';
 import { useNavigate } from 'react-router';
 
 export const useNavigation = () => {
-	const rootRoute = '/forgesteel';
 	const navigate = useNavigate();
 	return {
-		rootRoute,
 		goToWelcome() {
-			return navigate(rootRoute);
+			return navigate('/');
 		},
 		goToHeroList() {
-			return navigate(`${rootRoute}/hero/list`);
+			return navigate('/hero/list');
 		},
 		goToHeroView(heroId: string) {
-			return navigate(`${rootRoute}/hero/view/${heroId}`);
+			return navigate(`/hero/view/${heroId}`);
 		},
 		goToHeroEdit(heroId: string, tab?: string) {
-			return navigate(`${rootRoute}/hero/edit/${heroId}${tab ? `/${tab}` : ''}`);
+			return navigate(`/hero/edit/${heroId}${tab ? `/${tab}` : ''}`);
 		},
 		goToLibraryList(tab?: SourcebookElementKind) {
-			return navigate(`${rootRoute}/library/list${tab ? `/${tab}` : ''}`);
+			return navigate(`/library/list${tab ? `/${tab}` : ''}`);
 		},
 		goToLibraryEdit(sourcebookId: string, kind: SourcebookElementKind, elementId: string) {
-			return navigate(`${rootRoute}/library/edit/${sourcebookId}/${kind}/${elementId}`);
+			return navigate(`/library/edit/${sourcebookId}/${kind}/${elementId}`);
 		},
 		goToEncounterList() {
-			return navigate(`${rootRoute}/encounter/list`);
+			return navigate('/encounter/list');
 		},
 		goToEncounterEdit(encounterId: string) {
-			return navigate(`${rootRoute}/encounter/edit/${encounterId}`);
+			return navigate(`/encounter/edit/${encounterId}`);
 		}
 	};
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
-import { BrowserRouter } from 'react-router';
 import { FactoryLogic } from './logic/factory-logic.ts';
+import { HashRouter } from 'react-router';
 import { Hero } from './models/hero.ts';
 import { HeroLogic } from './logic/hero-logic.ts';
 import { Main } from './components/main/main.tsx';
@@ -75,7 +75,7 @@ Promise.all(promises).then(results => {
 
 	createRoot(document.getElementById('root')!).render(
 		<StrictMode>
-			<BrowserRouter>
+			<HashRouter>
 				<Main
 					heroes={heroes}
 					homebrewSourcebooks={sourcebooks}
@@ -83,7 +83,7 @@ Promise.all(promises).then(results => {
 					playbook={playbook}
 					options={options}
 				/>
-			</BrowserRouter>
+			</HashRouter>
 		</StrictMode>
 	);
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-	base: '/forgesteel',
+	base: '/forgesteel/',
 	build: {
 		chunkSizeWarningLimit: 3000
 	},


### PR DESCRIPTION
Follow-up to #31

Regular browser routing doesn't work on initial load from github pages, because different routes don't point to actual paths on the static host:

![image](https://github.com/user-attachments/assets/ae3fa49b-3196-4aaf-81a4-58c1cf07134b)

Hash routing works, because every route loads from /forgesteel/:

![image](https://github.com/user-attachments/assets/d0728901-6da4-412b-9f81-3d5e3fc888a0)
