### PR TITLE
malice panel styling

### DIFF
--- a/src/components/panels/elements/feature-panel/feature-panel.tsx
+++ b/src/components/panels/elements/feature-panel/feature-panel.tsx
@@ -1,5 +1,5 @@
 import { Alert, Select, Space } from 'antd';
-import { Feature, FeatureAbilityCostData, FeatureAbilityData, FeatureBonusData, FeatureChoiceData, FeatureClassAbilityData, FeatureDamageModifierData, FeatureData, FeatureDomainData, FeatureDomainFeatureData, FeatureKitData, FeatureKitTypeData, FeatureLanguageChoiceData, FeatureLanguageData, FeatureMaliceData, FeatureMultipleData, FeaturePerkData, FeatureSizeData, FeatureSkillChoiceData, FeatureSkillData, FeatureSpeedData, FeatureTitleData } from '../../../../models/feature';
+import { Feature, FeatureAbilityCostData, FeatureBonusData, FeatureChoiceData, FeatureClassAbilityData, FeatureDamageModifierData, FeatureData, FeatureDomainData, FeatureDomainFeatureData, FeatureKitData, FeatureKitTypeData, FeatureLanguageChoiceData, FeatureLanguageData, FeatureMultipleData, FeaturePerkData, FeatureSizeData, FeatureSkillChoiceData, FeatureSkillData, FeatureSpeedData, FeatureTitleData } from '../../../../models/feature';
 import { Ability } from '../../../../models/ability';
 import { AbilityPanel } from '../ability-panel/ability-panel';
 import { Collections } from '../../../../utils/collections';
@@ -980,15 +980,6 @@ export const FeaturePanel = (props: Props) => {
 	// #endregion
 
 	try {
-		let cost = 0;
-		if (props.cost) {
-			cost = props.cost;
-		}
-		if (props.feature.type === FeatureType.Malice) {
-			const data = props.feature.data as FeatureMaliceData;
-			cost = data.cost;
-		}
-
 		const tags = [];
 		const list = (props.feature as Perk).list;
 		if (list !== undefined) {
@@ -996,9 +987,8 @@ export const FeaturePanel = (props: Props) => {
 		}
 
 		if (props.feature.type === FeatureType.Ability) {
-			const data = props.feature.data as FeatureAbilityData;
 			return (
-				<AbilityPanel ability={data.ability} hero={props.hero} cost={cost > 0 ? cost : undefined} mode={props.mode} tags={tags} />
+				<AbilityPanel ability={props.feature.data.ability} hero={props.hero} cost={props.cost} mode={props.mode} tags={tags} />
 			);
 		}
 
@@ -1014,7 +1004,7 @@ export const FeaturePanel = (props: Props) => {
 
 		return (
 			<div className='feature-panel' id={props.mode === PanelMode.Full ? props.feature.id : undefined}>
-				<HeaderText ribbon={cost ? <HeroicResourceBadge value={cost} /> : null} tags={tags}>
+				<HeaderText ribbon={props.cost ? <HeroicResourceBadge value={props.cost} /> : null} tags={tags}>
 					{props.feature.name || 'Unnamed Feature'}
 				</HeaderText>
 				{props.feature.description ? <div dangerouslySetInnerHTML={{ __html: Utils.showdownConverter.makeHtml(props.feature.description) }} /> : null}

--- a/src/components/panels/elements/monster-group-panel/monster-group-panel.tsx
+++ b/src/components/panels/elements/monster-group-panel/monster-group-panel.tsx
@@ -1,4 +1,5 @@
 import { FeaturePanel } from '../feature-panel/feature-panel';
+import { FeatureType } from '../../../../enums/feature-type';
 import { Field } from '../../../controls/field/field';
 import { HeaderText } from '../../../controls/header-text/header-text';
 import { MonsterGroup } from '../../../../models/monster';
@@ -41,10 +42,18 @@ export const MonsterGroupPanel = (props: Props) => {
 				}
 				{
 					(props.mode === PanelMode.Full) && (props.monsterGroup.malice.length > 0) ?
-						<div>
-							<HeaderText level={1}>Malice</HeaderText>
-							{props.monsterGroup.malice.map(m => <FeaturePanel key={m.id} feature={m} mode={PanelMode.Full} />)}
-						</div>
+						<SelectablePanel>
+							<HeaderText level={1}>{props.monsterGroup.name} Malice</HeaderText>
+							At the start of any {props.monsterGroup.name}'s turn, you can spend malice to activate one of the following features.
+							{props.monsterGroup.malice.map(m =>
+								<FeaturePanel
+									key={m.id}
+									feature={m}
+									mode={PanelMode.Full}
+									cost={m.type === FeatureType.Ability ? m.data.ability.cost : m.data.cost}
+								/>
+							)}
+						</SelectablePanel>
 						: null
 				}
 				{


### PR DESCRIPTION
* Pass cost prop to FeaturePanel rather than checking for it on FeatureMaliceData in FeaturePanel
* Put Malice panel inside SelectablePanel for styling
* Add header description for Malice panel.

![image](https://github.com/user-attachments/assets/1c02578d-b53c-4e95-a581-3ad88a93bf87)
