### PR TITLE
Fully Implement Former Life and Revenant trait points

### DIFF
--- a/src/components/pages/heroes/hero-edit/hero-edit-page.tsx
+++ b/src/components/pages/heroes/hero-edit/hero-edit-page.tsx
@@ -307,7 +307,7 @@ export const HeroEditPage = (props: Props) => {
 			if (feature) {
 				feature.data = data;
 				if (feature.type === FeatureType.InheritedAncestry) {
-					HeroLogic.updateInheritedSize(heroCopy, feature, props.sourcebooks);
+					HeroLogic.updateInheritedFeatures(heroCopy, feature, props.sourcebooks);
 				}
 			}
 			setHero(heroCopy);

--- a/src/components/pages/heroes/hero-edit/hero-edit-page.tsx
+++ b/src/components/pages/heroes/hero-edit/hero-edit-page.tsx
@@ -307,6 +307,7 @@ export const HeroEditPage = (props: Props) => {
 			if (feature) {
 				feature.data = data;
 			}
+			// TODO: Set size here if feature is Inherited Ancestry
 			setHero(heroCopy);
 			setDirty(true);
 		};
@@ -550,7 +551,7 @@ const AncestrySection = (props: AncestrySectionProps) => {
 					props.hero.ancestry ?
 						<div className='hero-edit-content-column selected' id='ancestry-selected'>
 							<SelectablePanel showShadow={false} onUnselect={() => props.selectAncestry(null)}>
-								<AncestryPanel ancestry={props.hero.ancestry} mode={PanelMode.Full} />
+								<AncestryPanel ancestry={props.hero.ancestry} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
 							</SelectablePanel>
 						</div>
 						: null

--- a/src/components/pages/heroes/hero-edit/hero-edit-page.tsx
+++ b/src/components/pages/heroes/hero-edit/hero-edit-page.tsx
@@ -306,8 +306,10 @@ export const HeroEditPage = (props: Props) => {
 			const feature = HeroLogic.getFeatures(heroCopy).find(f => f.id === featureID);
 			if (feature) {
 				feature.data = data;
+				if (feature.type === FeatureType.InheritedAncestry) {
+					HeroLogic.updateInheritedSize(heroCopy, feature, props.sourcebooks);
+				}
 			}
-			// TODO: Set size here if feature is Inherited Ancestry
 			setHero(heroCopy);
 			setDirty(true);
 		};

--- a/src/components/panels/elements/feature-panel/feature-panel.tsx
+++ b/src/components/panels/elements/feature-panel/feature-panel.tsx
@@ -1,5 +1,5 @@
 import { Alert, Select, Space } from 'antd';
-import { Feature, FeatureAbilityCostData, FeatureBonusData, FeatureChoiceData, FeatureClassAbilityData, FeatureDamageModifierData, FeatureData, FeatureDomainData, FeatureDomainFeatureData, FeatureKitData, FeatureKitTypeData, FeatureLanguageChoiceData, FeatureLanguageData, FeatureMaliceData, FeatureMultipleData, FeaturePerkData, FeatureSizeData, FeatureSkillChoiceData, FeatureSkillData, FeatureSpeedData, FeatureTitleData } from '../../../../models/feature';
+import { Feature, FeatureAbilityCostData, FeatureBonusData, FeatureChoiceData, FeatureClassAbilityData, FeatureDamageModifierData, FeatureData, FeatureDomainData, FeatureDomainFeatureData, FeatureFormerLifeData, FeatureKitData, FeatureKitTypeData, FeatureLanguageChoiceData, FeatureLanguageData, FeatureMaliceData, FeatureMultipleData, FeaturePerkData, FeatureSizeData, FeatureSkillChoiceData, FeatureSkillData, FeatureSpeedData, FeatureTitleData } from '../../../../models/feature';
 import { Ability } from '../../../../models/ability';
 import { AbilityPanel } from '../ability-panel/ability-panel';
 import { Badge } from '../../../controls/badge/badge';
@@ -292,6 +292,68 @@ export const FeaturePanel = (props: Props) => {
 					))
 				}
 			</Space>
+		);
+	};
+
+	const getEditableFormerLife = (data: FeatureFormerLifeData) => {
+		if (!props.hero) {
+			return null;
+		}
+
+		const ancestries = SourcebookLogic.getAncestries(props.sourcebooks as Sourcebook[])
+			.filter(a => !a.features.some(f => f.type === FeatureType.FormerLife));
+		const sortedAncestries = Collections.sort(ancestries, a => a.name);
+
+		if (sortedAncestries.length === 0) {
+			return (
+				<Alert
+					type='info'
+					showIcon={true}
+					message='There are no options to choose for this feature.'
+				/>
+			);
+		}
+
+		return (
+			<div>
+				<Select
+					style={{ width: '100%' }}
+					className={data.selected.length === 0 ? 'selection-empty' : ''}
+					mode={data.count === 1 ? undefined : 'multiple'}
+					maxCount={data.count === 1 ? undefined : data.count}
+					allowClear={true}
+					placeholder={data.count === 1 ? 'Select an ancestry' : 'Select ancestries'}
+					options={sortedAncestries.map(a => ({ label: a.name, value: a.id, desc: a.description}))}
+					optionRender={option => <Field label={option.data.label} value={option.data.desc} />}
+					value={data.count === 1 ? (data.selected.length > 0 ? data.selected[0].id : null) : data.selected.map(a => a.id)}
+					onChange={value => {
+						let ids: string[] = [];
+						if (data.count === 1) {
+							ids = value !== undefined ? [ value as string ] : [];
+						} else {
+							ids = value as string[];
+						}
+						const dataCopy = JSON.parse(JSON.stringify(data)) as FeatureFormerLifeData;
+						dataCopy.selected = [];
+						ids.forEach(id => {
+							const ancestry = ancestries.find(a => a.id === id);
+							if (ancestry) {
+								dataCopy.selected.push(ancestry);
+							}
+						});
+						if (props.setData) {
+							props.setData(props.feature.id, dataCopy);
+						}
+					}}
+				/>
+				{
+					data.selected.map(a => {
+						return (
+							<Field label={a.name} value={a.description} />
+						);
+					})
+				}
+			</div>
 		);
 	};
 
@@ -630,6 +692,8 @@ export const FeaturePanel = (props: Props) => {
 				return getEditableDomain(props.feature.data as FeatureDomainData);
 			case FeatureType.DomainFeature:
 				return getEditableDomainFeature(props.feature.data as FeatureDomainFeatureData);
+			case FeatureType.FormerLife:
+				return getEditableFormerLife(props.feature.data as FeatureFormerLifeData);
 			case FeatureType.Kit:
 				return getEditableKit(props.feature.data as FeatureKitData);
 			case FeatureType.LanguageChoice:
@@ -791,6 +855,25 @@ export const FeaturePanel = (props: Props) => {
 
 		return null;
 	};
+
+	const getExtraFormerLife = (data: FeatureFormerLifeData) => {
+		if (data.selected.length > 0) {
+			return (
+				<Space direction='vertical' style={{ width: '100%' }}>
+					{
+						data.selected.map(a => <Field label={a.name} value={a.description} />)
+					}
+				</Space>
+			)
+		}
+		if (data.selected[0]) {
+			return (
+				<Field label={data.selected[0].name} value={data.selected[0].description} />
+			);
+		}
+
+		return null;
+	}
 
 	const getExtraKit = (data: FeatureKitData) => {
 		if (data.selected.length > 0) {
@@ -962,6 +1045,8 @@ export const FeaturePanel = (props: Props) => {
 				return getExtraDomain(props.feature.data as FeatureDomainData);
 			case FeatureType.DomainFeature:
 				return getExtraDomainFeature(props.feature.data as FeatureDomainFeatureData);
+			case FeatureType.FormerLife:
+				return getExtraFormerLife(props.feature.data as FeatureFormerLifeData);
 			case FeatureType.Kit:
 				return getExtraKit(props.feature.data as FeatureKitData);
 			case FeatureType.KitType:

--- a/src/components/panels/elements/feature-panel/feature-panel.tsx
+++ b/src/components/panels/elements/feature-panel/feature-panel.tsx
@@ -39,13 +39,22 @@ export const FeaturePanel = (props: Props) => {
 
 	const getEditableAncestryTraits = (data: FeatureAncestryTraitsData) => {
 		const allOptions = [...data.options, ...data.inheritedOptions];
+		let pointCount = data.count;
+		if (data.overrides.length > 0) {
+			data.overrides.forEach(o => {
+				if (o.overrideTarget === 'count' && props.hero && HeroLogic.shouldDoOverride(props.hero, o)) {
+					pointCount = o.overrideValue;
+				}
+			});
+		}
+
 		const selectedIDs = data.selected.map(f => f.id);
 
 		const pointsUsed = Collections.sum(selectedIDs, id => {
 			const original = allOptions.find(o => o.feature.id === id);
 			return original ? original.value : 0;
 		});
-		const pointsLeft = data.count - pointsUsed;
+		const pointsLeft = pointCount - pointsUsed;
 
 		const availableOptions = allOptions.filter(o => allOptions.every(o => o.value === 1) || selectedIDs.includes(o.feature.id) || (o.value <= pointsLeft));
 		const sortedOptions = Collections.sort(availableOptions, opt => opt.feature.name);
@@ -67,18 +76,18 @@ export const FeaturePanel = (props: Props) => {
 				<div className='ds-text'>
 					{
 						showCosts ?
-							`You have ${data.count} points to spend on the following options:`
+							`You have ${pointCount} points to spend on the following options:`
 							:
-							`Choose ${data.count} of the following options:`
+							`Choose ${pointCount} of the following options:`
 					}
 				</div>
 				<Select
 					style={{ width: '100%' }}
 					className={data.selected.length === 0 ? 'selection-empty' : ''}
-					mode={data.count === 1 ? undefined : 'multiple'}
-					maxCount={data.count === 1 ? undefined : data.count}
+					mode={pointCount === 1 ? undefined : 'multiple'}
+					maxCount={pointCount === 1 ? undefined : pointCount}
 					allowClear={true}
-					placeholder={data.count === 1 ? 'Select an option' : 'Select options'}
+					placeholder={pointCount === 1 ? 'Select an option' : 'Select options'}
 					options={sortedOptions.map(o => ({ label: o.feature.name, value: o.feature.id, desc: o.feature.description, cost: o.value }))}
 					optionRender={option => (
 						<Field
@@ -91,10 +100,10 @@ export const FeaturePanel = (props: Props) => {
 							value={option.data.desc}
 						/>
 					)}
-					value={data.count === 1 ? (data.selected.length > 0 ? data.selected[0].id : null) : data.selected.map(f => f.id)}
+					value={pointCount === 1 ? (data.selected.length > 0 ? data.selected[0].id : null) : data.selected.map(f => f.id)}
 					onChange={value => {
 						let ids: string[] = [];
-						if (data.count === 1) {
+						if (pointCount === 1) {
 							ids = value !== undefined ? [ value as string ] : [];
 						} else {
 							ids = value as string[];

--- a/src/components/panels/elements/feature-panel/feature-panel.tsx
+++ b/src/components/panels/elements/feature-panel/feature-panel.tsx
@@ -1,5 +1,5 @@
 import { Alert, Select, Space } from 'antd';
-import { Feature, FeatureAbilityCostData, FeatureBonusData, FeatureChoiceData, FeatureClassAbilityData, FeatureDamageModifierData, FeatureData, FeatureDomainData, FeatureDomainFeatureData, FeatureInheritedAncestryData, FeatureKitData, FeatureKitTypeData, FeatureLanguageChoiceData, FeatureLanguageData, FeatureMaliceData, FeatureMultipleData, FeaturePerkData, FeatureSizeData, FeatureSkillChoiceData, FeatureSkillData, FeatureSpeedData, FeatureTitleData } from '../../../../models/feature';
+import { Feature, FeatureAbilityCostData, FeatureAncestryTraitsData, FeatureBonusData, FeatureChoice, FeatureChoiceData, FeatureClassAbilityData, FeatureDamageModifierData, FeatureData, FeatureDomainData, FeatureDomainFeatureData, FeatureInheritedAncestryData, FeatureKitData, FeatureKitTypeData, FeatureLanguageChoiceData, FeatureLanguageData, FeatureMaliceData, FeatureMultipleData, FeaturePerkData, FeatureSizeData, FeatureSkillChoiceData, FeatureSkillData, FeatureSpeedData, FeatureTitleData } from '../../../../models/feature';
 import { Ability } from '../../../../models/ability';
 import { AbilityPanel } from '../ability-panel/ability-panel';
 import { Badge } from '../../../controls/badge/badge';
@@ -36,6 +36,11 @@ interface Props {
 
 export const FeaturePanel = (props: Props) => {
 	// #region Editable
+
+	const getEditableAncestryTraits = (data: FeatureAncestryTraitsData) => {
+		// TODO: Add in any inherited traits before passing through
+		return getEditableChoice(data as FeatureChoiceData);
+	};
 
 	const getEditableChoice = (data: FeatureChoiceData) => {
 		const selectedIDs = data.selected.map(f => f.id);
@@ -680,6 +685,8 @@ export const FeaturePanel = (props: Props) => {
 
 	const getEditable = () => {
 		switch (props.feature.type) {
+			case FeatureType.AncestryTraits:
+				return getEditableAncestryTraits(props.feature.data as FeatureAncestryTraitsData);
 			case FeatureType.Choice:
 				return getEditableChoice(props.feature.data as FeatureChoiceData);
 			case FeatureType.ClassAbility:
@@ -713,6 +720,10 @@ export const FeaturePanel = (props: Props) => {
 		return (
 			<Field label={data.keywords.join(', ')} value={`Heroic resource cost ${data.modifier >= 0 ? '+' : ''}${data.modifier}`} />
 		);
+	};
+
+	const getExtraAncestryTraits = (data: FeatureAncestryTraitsData) => {
+		return getExtraChoice(data as FeatureChoiceData);
 	};
 
 	const getExtraBonus = (data: FeatureBonusData) => {
@@ -1025,6 +1036,8 @@ export const FeaturePanel = (props: Props) => {
 		switch (props.feature.type) {
 			case FeatureType.AbilityCost:
 				return getExtraAbilityCost(props.feature.data as FeatureAbilityCostData);
+			case FeatureType.AncestryTraits:
+				return getExtraAncestryTraits(props.feature.data as FeatureAncestryTraitsData);
 			case FeatureType.Bonus:
 				return getExtraBonus(props.feature.data as FeatureBonusData);
 			case FeatureType.Choice:

--- a/src/components/panels/elements/feature-panel/feature-panel.tsx
+++ b/src/components/panels/elements/feature-panel/feature-panel.tsx
@@ -38,7 +38,7 @@ export const FeaturePanel = (props: Props) => {
 	// #region Editable
 
 	const getEditableAncestryTraits = (data: FeatureAncestryTraitsData) => {
-		const allOptions = [...data.options, ...data.inheritedOptions];
+		const allOptions = [...data.options, ...data.inheritedOptions].filter(o => o.feature.data.selectable !== false);
 		let pointCount = data.count;
 		if (data.overrides.length > 0) {
 			data.overrides.forEach(o => {
@@ -395,7 +395,6 @@ export const FeaturePanel = (props: Props) => {
 			return null;
 		}
 
-		// TODO: Move the filter callback to an AncestryLogic file?
 		const ancestries = SourcebookLogic.getAncestries(props.sourcebooks as Sourcebook[])
 			.filter(a => !a.features.some(f => f.type === FeatureType.InheritedAncestry));
 		const sortedAncestries = Collections.sort(ancestries, a => a.name);

--- a/src/components/panels/elements/feature-panel/feature-panel.tsx
+++ b/src/components/panels/elements/feature-panel/feature-panel.tsx
@@ -866,11 +866,6 @@ export const FeaturePanel = (props: Props) => {
 				</Space>
 			)
 		}
-		if (data.selected[0]) {
-			return (
-				<Field label={data.selected[0].name} value={data.selected[0].description} />
-			);
-		}
 
 		return null;
 	}

--- a/src/components/panels/elements/hero-panel/hero-panel.tsx
+++ b/src/components/panels/elements/hero-panel/hero-panel.tsx
@@ -112,7 +112,7 @@ export const HeroPanel = (props: Props) => {
 						<div className='overview-tile clickable' onClick={onSelectAncestry}>
 							<HeaderText>Ancestry</HeaderText>
 							<Field label='Ancestry' value={props.hero.ancestry.name} />
-							{ inheritedAncestryFeature !== undefined && inheritedAncestryFeature.data.selected.length > 0 ?
+							{ inheritedAncestryFeature !== undefined && inheritedAncestries.length > 0 ?
 								<Field label={inheritedAncestryFeature.name} value={inheritedAncestries.map(a => a.name).join(', ')}/> :
 								null
 							}

--- a/src/components/panels/elements/hero-panel/hero-panel.tsx
+++ b/src/components/panels/elements/hero-panel/hero-panel.tsx
@@ -97,6 +97,8 @@ export const HeroPanel = (props: Props) => {
 			incitingIncident = props.hero.career.incitingIncidents.options.find(o => o.id === props.hero.career?.incitingIncidents.selectedID) || null;
 		}
 
+		const formerLife = HeroLogic.getFormerLife(props.hero);
+
 		return (
 			<div className='hero-left-column'>
 				{
@@ -104,6 +106,7 @@ export const HeroPanel = (props: Props) => {
 						<div className='overview-tile clickable' onClick={onSelectAncestry}>
 							<HeaderText>Ancestry</HeaderText>
 							<Field label='Ancestry' value={props.hero.ancestry.name} />
+							{ formerLife.length > 0 ? <Field label='Former Life' value={formerLife.map(a => a.name).join(', ')}/> : null }
 						</div>
 						:
 						<div className='overview-tile'>

--- a/src/components/panels/elements/hero-panel/hero-panel.tsx
+++ b/src/components/panels/elements/hero-panel/hero-panel.tsx
@@ -28,6 +28,7 @@ import { SelectablePanel } from '../../../controls/selectable-panel/selectable-p
 import { Skill } from '../../../../models/skill';
 import { SkillList } from '../../../../enums/skill-list';
 import { Sourcebook } from '../../../../models/sourcebook';
+import { SourcebookLogic } from '../../../../logic/sourcebook-logic';
 
 import './hero-panel.scss';
 
@@ -97,7 +98,12 @@ export const HeroPanel = (props: Props) => {
 			incitingIncident = props.hero.career.incitingIncidents.options.find(o => o.id === props.hero.career?.incitingIncidents.selectedID) || null;
 		}
 
-		const formerLife = HeroLogic.getFormerLife(props.hero);
+		const inheritedAncestryFeature = HeroLogic.getInheritedAncestry(props.hero);
+		const inheritedAncestries = inheritedAncestryFeature !== undefined ?
+			SourcebookLogic.getAncestriesById(
+				props.sourcebooks,
+				inheritedAncestryFeature.data.selected
+			) : [];
 
 		return (
 			<div className='hero-left-column'>
@@ -106,7 +112,10 @@ export const HeroPanel = (props: Props) => {
 						<div className='overview-tile clickable' onClick={onSelectAncestry}>
 							<HeaderText>Ancestry</HeaderText>
 							<Field label='Ancestry' value={props.hero.ancestry.name} />
-							{ formerLife.length > 0 ? <Field label='Former Life' value={formerLife.map(a => a.name).join(', ')}/> : null }
+							{ inheritedAncestryFeature !== undefined && inheritedAncestryFeature.data.selected.length > 0 ?
+								<Field label={inheritedAncestryFeature.name} value={inheritedAncestries.map(a => a.name).join(', ')}/> :
+								null
+							}
 						</div>
 						:
 						<div className='overview-tile'>

--- a/src/data/ancestries/devil.ts
+++ b/src/data/ancestries/devil.ts
@@ -22,7 +22,7 @@ export const devil: Ancestry = {
 				})
 			]
 		}),
-		FactoryLogic.feature.createChoice({
+		FactoryLogic.feature.createAncestryTraits({
 			id: 'devil-feature-2',
 			name: 'Devil Traits',
 			options: [

--- a/src/data/ancestries/dragon-knight.ts
+++ b/src/data/ancestries/dragon-knight.ts
@@ -10,7 +10,7 @@ export const dragonKnight: Ancestry = {
 	name: 'Dragon Knight',
 	description: 'The Ritual of Dracogenesis that grants the power to create a generation of dragon knights—also known as draconians or wyrmwights—is obscure and supremely difficult for even an experienced sorcerer to master.',
 	features: [
-		FactoryLogic.feature.createAncestryTraits({
+		FactoryLogic.feature.createChoice({
 			id: 'dragon-knight-feature-1',
 			name: 'Wyrmplate',
 			description: 'Your hardened scales grant you immunity equal to yor level to one of the following damage types: acid, cold, corruption, fire, lightning, or poison. You can change your damage immunity type when you finish a respite.',
@@ -113,7 +113,7 @@ export const dragonKnight: Ancestry = {
 				}
 			]
 		}),
-		FactoryLogic.feature.createChoice({
+		FactoryLogic.feature.createAncestryTraits({
 			id: 'dragon-knight-feature-2',
 			name: 'Dragon Knight Traits',
 			options: [

--- a/src/data/ancestries/dragon-knight.ts
+++ b/src/data/ancestries/dragon-knight.ts
@@ -10,7 +10,7 @@ export const dragonKnight: Ancestry = {
 	name: 'Dragon Knight',
 	description: 'The Ritual of Dracogenesis that grants the power to create a generation of dragon knights—also known as draconians or wyrmwights—is obscure and supremely difficult for even an experienced sorcerer to master.',
 	features: [
-		FactoryLogic.feature.createChoice({
+		FactoryLogic.feature.createAncestryTraits({
 			id: 'dragon-knight-feature-1',
 			name: 'Wyrmplate',
 			description: 'Your hardened scales grant you immunity equal to yor level to one of the following damage types: acid, cold, corruption, fire, lightning, or poison. You can change your damage immunity type when you finish a respite.',

--- a/src/data/ancestries/dwarf.ts
+++ b/src/data/ancestries/dwarf.ts
@@ -16,7 +16,7 @@ You can carve a rune onto your skin and the magic within your body activates it.
 • **Light**: Your skin sheds light for 10 squares. You can turn this on and off as a maneuver.
 • **Voice**: As a maneuver, you can communicate telepathically with another willing creature you have met before whose name you know, who can speak and understand a language you know, and is within 1 mile of you. You and the creature can respond to one another as if having a normal conversation. You can change the person you communicate with by changing the rune.`
 		}),
-		FactoryLogic.feature.createChoice({
+		FactoryLogic.feature.createAncestryTraits({
 			id: 'dwarf-feature-2',
 			name: 'Dwarf Traits',
 			options: [

--- a/src/data/ancestries/elf-high.ts
+++ b/src/data/ancestries/elf-high.ts
@@ -12,7 +12,7 @@ export const highElf: Ancestry = {
 			name: 'High Elf Glamor',
 			description: 'A magic glamor makes others perceive you as interesting and engaging, granting you an edge on Presence tests using the Flirt or Persuade skills. This glamor makes you look and sound slightly different to each creature you meet, since what is engaging to one might be different for another. However, you never appear to be anyone other than yourself.'
 		}),
-		FactoryLogic.feature.createChoice({
+		FactoryLogic.feature.createAncestryTraits({
 			id: 'high-elf-feature-2',
 			name: 'High Elf Features',
 			options: [

--- a/src/data/ancestries/elf-wode.ts
+++ b/src/data/ancestries/elf-wode.ts
@@ -12,7 +12,7 @@ export const wodeElf: Ancestry = {
 			name: 'Wode Elf Glamor',
 			description: 'You can magically alter your appearance to better blend in with your surroundings. You gain an edge on Agility tests made to hide and sneak, and tests made to find you while you are hidden take a bane.'
 		}),
-		FactoryLogic.feature.createChoice({
+		FactoryLogic.feature.createAncestryTraits({
 			id: 'wode-elf-feature-2',
 			name: 'Wode Elf Traits',
 			options: [

--- a/src/data/ancestries/hakaan.ts
+++ b/src/data/ancestries/hakaan.ts
@@ -12,7 +12,7 @@ export const hakaan: Ancestry = {
 			sizeValue: 1,
 			sizeMod: 'L'
 		}),
-		FactoryLogic.feature.createChoice({
+		FactoryLogic.feature.createAncestryTraits({
 			id: 'hakaan-feature-2',
 			name: 'Hakaan Traits',
 			options: [

--- a/src/data/ancestries/human.ts
+++ b/src/data/ancestries/human.ts
@@ -18,7 +18,7 @@ export const human: Ancestry = {
 				effect: 'Until the end of your next turn, you know the location of any supernatural object, undead, construct, or creature from another plane of existence within 5 squares of you, even if you don’t have line of effect to them. You know if you’re detecting an item or a creature, and you know if a creature is undead, a construct, or from another plane of existence.'
 			})
 		}),
-		FactoryLogic.feature.createChoice({
+		FactoryLogic.feature.createAncestryTraits({
 			id: 'human-feature-2',
 			name: 'Human Traits',
 			options: [

--- a/src/data/ancestries/memonek.ts
+++ b/src/data/ancestries/memonek.ts
@@ -16,7 +16,7 @@ export const memonek: Ancestry = {
 			name: 'Lightweight',
 			description: 'Your body is light for a creature of your height. Your size is considered 1S when being force moved by another creature.'
 		}),
-		FactoryLogic.feature.createChoice({
+		FactoryLogic.feature.createAncestryTraits({
 			id: 'memonek-feature-3',
 			name: 'Memonek Traits',
 			options: [

--- a/src/data/ancestries/orc.ts
+++ b/src/data/ancestries/orc.ts
@@ -12,7 +12,7 @@ export const orc: Ancestry = {
 			name: 'Relentless',
 			description: 'When a creature deals damage to you that leaves you dying, you can make a free strike against any creature. If the creature is reduced to 0 Stamina by your strike, you can spend a Recovery.'
 		}),
-		FactoryLogic.feature.createChoice({
+		FactoryLogic.feature.createAncestryTraits({
 			id: 'orc-feature-2',
 			name: 'Orc Traits',
 			options: [

--- a/src/data/ancestries/polder.ts
+++ b/src/data/ancestries/polder.ts
@@ -27,7 +27,7 @@ export const polder: Ancestry = {
 			sizeValue: 1,
 			sizeMod: 'S'
 		}),
-		FactoryLogic.feature.createChoice({
+		FactoryLogic.feature.createAncestryTraits({
 			id: 'polder-feature-3',
 			name: 'Polder Traits',
 			options: [

--- a/src/data/ancestries/revenant.ts
+++ b/src/data/ancestries/revenant.ts
@@ -70,7 +70,15 @@ export const revenant: Ancestry = {
 			id: 'revenant-feature-4',
 			name: 'Revenant Traits',
 			options: [
-				// TODO: Previous Life (1pt)
+				{
+					feature: FactoryLogic.feature.create({
+						id: 'revenant-feature-4-1',
+						name: 'Previous Life (1pt)',
+						description: 'You gain a purchasable trait that costs 1 ancestry point from your previous ancestry. You can take this trait multiple times, selecting a new cost 1 trait from your previous ancestry each time you take this trait.',
+						selectable: false
+					}),
+					value: 1,
+				},
 				{
 					feature: FactoryLogic.feature.create({
 						id: 'revenant-feature-4-2',
@@ -87,7 +95,15 @@ export const revenant: Ancestry = {
 					}),
 					value: 2
 				},
-				// TODO: Previous Life (2pts)
+				{
+					feature: FactoryLogic.feature.create({
+						id: 'revenant-feature-4-1',
+						name: 'Previous Life (2pt)',
+						description: 'You gain a purchasable trait that costs 2 ancestry points from your previous ancestry.',
+						selectable: false
+					}),
+					value: 1
+				},
 				{
 					feature: FactoryLogic.feature.createMultiple({
 						id: 'revenant-feature-4-5',

--- a/src/data/ancestries/revenant.ts
+++ b/src/data/ancestries/revenant.ts
@@ -124,7 +124,13 @@ You can have an active number of sigils equal to your level. You can remove a si
 					value: 2
 				}
 			],
-			count: 2 // TODO: Or 3 if small
+			count: 2,
+			overrides: [{
+				overrideTarget: 'count',
+				overrideValue: 3,
+				conditionTarget: FeatureType.Size,
+				conditionValue: '1S'
+			}]
 		})
 	]
 };

--- a/src/data/ancestries/revenant.ts
+++ b/src/data/ancestries/revenant.ts
@@ -9,8 +9,9 @@ export const revenant: Ancestry = {
 	name: 'Revenant',
 	description: 'Unlike the necromantic rituals that produce wights and wraiths and zombies, revenants rise from the grave through a combination of an unjust death and a burning desire for vengeance. Creatures sustained on pure will, they have no need of food or water or air—and, unlike their zombified cousins, they retain all their memories and personality from life.',
 	features: [
-		FactoryLogic.feature.createFormerLifeFeature({
+		FactoryLogic.feature.createInheritedAncestry({
 			id: 'revenant-feature-1',
+			name: 'Former Life',
 			description: 'Choose the ancestry you were before you died.'
 		}),
 		FactoryLogic.feature.createDamageModifier({

--- a/src/data/ancestries/revenant.ts
+++ b/src/data/ancestries/revenant.ts
@@ -64,7 +64,7 @@ export const revenant: Ancestry = {
 			name: 'Tough But Withered',
 			description: 'When your Stamina equals the negative of your winded value, you become inert instead of dying. You can continue to observe your surroundings, but you can’t speak, take actions, maneuvers, or triggered actions, or move and you fall prone. If you take any fire damage while in this state, your body is destroyed and you die. Otherwise, after 12 hours, you regain Stamina equal to your recovery value.'
 		}),
-		FactoryLogic.feature.createChoice({
+		FactoryLogic.feature.createAncestryTraits({
 			id: 'revenant-feature-4',
 			name: 'Revenant Traits',
 			options: [

--- a/src/data/ancestries/revenant.ts
+++ b/src/data/ancestries/revenant.ts
@@ -9,39 +9,9 @@ export const revenant: Ancestry = {
 	name: 'Revenant',
 	description: 'Unlike the necromantic rituals that produce wights and wraiths and zombies, revenants rise from the grave through a combination of an unjust death and a burning desire for vengeance. Creatures sustained on pure will, they have no need of food or water or air—and, unlike their zombified cousins, they retain all their memories and personality from life.',
 	features: [
-		FactoryLogic.feature.createChoice({
+		FactoryLogic.feature.createFormerLifeFeature({
 			id: 'revenant-feature-1',
-			name: 'Former Life',
-			description: 'Choose the ancestry you were before you died.',
-			options: [
-				{
-					feature: FactoryLogic.feature.createSize({
-						id: 'revenant-feature-1-1',
-						description: '1S',
-						sizeValue: 1,
-						sizeMod: 'S'
-					}),
-					value: 1
-				},
-				{
-					feature: FactoryLogic.feature.createSize({
-						id: 'revenant-feature-1-2',
-						description: '1M',
-						sizeValue: 1,
-						sizeMod: 'M'
-					}),
-					value: 1
-				},
-				{
-					feature: FactoryLogic.feature.createSize({
-						id: 'revenant-feature-1-3',
-						description: '1L',
-						sizeValue: 1,
-						sizeMod: 'L'
-					}),
-					value: 1
-				}
-			]
+			description: 'Choose the ancestry you were before you died.'
 		}),
 		FactoryLogic.feature.createDamageModifier({
 			id: 'revenant-feature-2',

--- a/src/data/ancestries/revenant.ts
+++ b/src/data/ancestries/revenant.ts
@@ -3,6 +3,7 @@ import { Ancestry } from '../../models/ancestry';
 import { Characteristic } from '../../enums/characteristic';
 import { DamageModifierType } from '../../enums/damage-modifier-type';
 import { FactoryLogic } from '../../logic/factory-logic';
+import { FeatureType } from '../../enums/feature-type';
 
 export const revenant: Ancestry = {
 	id: 'ancestry-revenant',
@@ -12,7 +13,8 @@ export const revenant: Ancestry = {
 		FactoryLogic.feature.createInheritedAncestry({
 			id: 'revenant-feature-1',
 			name: 'Former Life',
-			description: 'Choose the ancestry you were before you died.'
+			description: 'Choose the ancestry you were before you died.',
+			inheritedFeatures: [FeatureType.AncestryTraits, FeatureType.Size]
 		}),
 		FactoryLogic.feature.createDamageModifier({
 			id: 'revenant-feature-2',

--- a/src/data/ancestries/time-raider.ts
+++ b/src/data/ancestries/time-raider.ts
@@ -14,7 +14,7 @@ export const timeRaider: Ancestry = {
 			name: 'Four Arms',
 			description: 'Your multiple arms let you take on multiple tasks at the same time. Whenever you use the Grab or Knockback maneuver against an adjacent creature, you can target an additional adjacent creature, using the same power roll for both targets. You can grab up to two creatures at a time.'
 		}),
-		FactoryLogic.feature.createChoice({
+		FactoryLogic.feature.createAncestryTraits({
 			id: 'time-raider-feature-2',
 			name: 'Time Raider Traits',
 			options: [

--- a/src/enums/feature-type.ts
+++ b/src/enums/feature-type.ts
@@ -23,3 +23,8 @@ export enum FeatureType {
 	Speed = 'Speed',
 	Title = 'Title'
 }
+
+export type InheritableFeature =
+	| FeatureType.AncestryTraits
+	| FeatureType.Size
+	| FeatureType.Speed;

--- a/src/enums/feature-type.ts
+++ b/src/enums/feature-type.ts
@@ -8,6 +8,7 @@ export enum FeatureType {
 	DamageModifier = 'Damage Modifier',
 	Domain = 'Domain',
 	DomainFeature = 'Domain Feature',
+	FormerLife = 'Former Life',
 	Kit = 'Kit',
 	KitType = 'Kit Type',
 	Language = 'Language',

--- a/src/enums/feature-type.ts
+++ b/src/enums/feature-type.ts
@@ -8,7 +8,7 @@ export enum FeatureType {
 	DamageModifier = 'Damage Modifier',
 	Domain = 'Domain',
 	DomainFeature = 'Domain Feature',
-	FormerLife = 'Former Life',
+	InheritedAncestry = 'Inherited Ancestry',
 	Kit = 'Kit',
 	KitType = 'Kit Type',
 	Language = 'Language',

--- a/src/enums/feature-type.ts
+++ b/src/enums/feature-type.ts
@@ -2,6 +2,7 @@ export enum FeatureType {
 	Text = 'Text',
 	Ability = 'Ability',
 	AbilityCost = 'Ability Cost',
+	AncestryTraits = 'Ancestry Traits',
 	Bonus = 'Bonus',
 	Choice = 'Choice',
 	ClassAbility = 'Class Ability',

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,6 +29,7 @@ Promise.all(promises).then(results => {
 
 	heroes.forEach(hero => {
 		HeroLogic.updateHero(hero);
+		HeroLogic.updateBreakingChanges(hero);
 	});
 
 	let sourcebooks = results[1] as Sourcebook[] | null;

--- a/src/logic/factory-logic.ts
+++ b/src/logic/factory-logic.ts
@@ -1,6 +1,6 @@
 import { Ability, AbilityDistance, AbilityType } from '../models/ability';
 import { Encounter, EncounterGroup, EncounterSlot } from '../models/encounter';
-import { Feature, FeatureAbility, FeatureAbilityCost, FeatureAbilityData, FeatureBonus, FeatureChoice, FeatureClassAbility, FeatureDamageModifier, FeatureDomain, FeatureDomainFeature, FeatureKit, FeatureKitType, FeatureLanguage, FeatureLanguageChoice, FeatureMalice, FeatureMaliceData, FeatureMultiple, FeaturePerk, FeatureSize, FeatureSkill, FeatureSkillChoice, FeatureSpeed, FeatureText, FeatureTitle } from '../models/feature';
+import { Feature, FeatureAbility, FeatureAbilityCost, FeatureAbilityData, FeatureBonus, FeatureChoice, FeatureClassAbility, FeatureDamageModifier, FeatureDomain, FeatureDomainFeature, FeatureInheritedAncestry, FeatureInheritedAncestryData, FeatureKit, FeatureKitType, FeatureLanguage, FeatureLanguageChoice, FeatureMalice, FeatureMaliceData, FeatureMultiple, FeaturePerk, FeatureSize, FeatureSkill, FeatureSkillChoice, FeatureSpeed, FeatureText, FeatureTitle } from '../models/feature';
 import { Kit, KitDamageBonus } from '../models/kit';
 import { Monster, MonsterGroup, MonsterRole } from '../models/monster';
 import { AbilityDistanceType } from '../enums/abiity-distance-type';
@@ -634,6 +634,19 @@ export class FactoryLogic {
 					selected: []
 				}
 			};
+		},
+		createInheritedAncestry: (data: { id: string, name?: string, description?: string, count?: number }) => {
+			const count = data.count || 1;
+			return {
+				id: data.id,
+				name: data.name || `Inherited ${ count > 1 ? 'Ancestries' : 'Ancestry'}`,
+				description: data.description || `Choose your inherited ${count > 1 ? 'ancestries' : 'ancestry'}.`,
+				type: FeatureType.InheritedAncestry,
+				data: {
+					count: count,
+					selected: []
+				} as FeatureInheritedAncestryData
+			} as FeatureInheritedAncestry
 		},
 		createKitChoice: (data: { id: string, name?: string, description?: string, types?: KitType[], count?: number }): FeatureKit => {
 			const count = data.count || 1;

--- a/src/logic/factory-logic.ts
+++ b/src/logic/factory-logic.ts
@@ -754,6 +754,17 @@ export class FactoryLogic {
 				}
 			};
 		},
+		createSizeFromDescription: (description: string, newId?: string ) => {
+			const id = newId || `generic-size-${description}`;
+			const sizeValue = Number.parseInt(description.charAt(0));
+			const sizeMod = description.charAt(1);
+			return this.feature.createSize({
+				id,
+				description,
+				sizeValue,
+				sizeMod
+			});
+		},
 		createSkill: (data: { id: string, name?: string, description?: string, skill: string }): FeatureSkill => {
 			return {
 				id: data.id,

--- a/src/logic/factory-logic.ts
+++ b/src/logic/factory-logic.ts
@@ -1,6 +1,6 @@
 import { Ability, AbilityDistance, AbilityType } from '../models/ability';
 import { Encounter, EncounterGroup, EncounterSlot } from '../models/encounter';
-import { Feature, FeatureAbility, FeatureAbilityCost, FeatureAbilityData, FeatureAncestryTraits, FeatureBonus, FeatureChoice, FeatureClassAbility, FeatureDamageModifier, FeatureDomain, FeatureDomainFeature, FeatureInheritedAncestry, FeatureInheritedAncestryData, FeatureKit, FeatureKitType, FeatureLanguage, FeatureLanguageChoice, FeatureMalice, FeatureMaliceData, FeatureMultiple, FeaturePerk, FeatureSize, FeatureSkill, FeatureSkillChoice, FeatureSpeed, FeatureText, FeatureTitle} from '../models/feature';
+import { Feature, FeatureAbility, FeatureAbilityCost, FeatureAbilityData, FeatureAncestryTraits, FeatureBonus, FeatureChoice, FeatureClassAbility, FeatureDamageModifier, FeatureDomain, FeatureDomainFeature, FeatureInheritedAncestry, FeatureInheritedAncestryData, FeatureKit, FeatureKitType, FeatureLanguage, FeatureLanguageChoice, FeatureMalice, FeatureMaliceData, FeatureMultiple, FeatureOverride, FeaturePerk, FeatureSize, FeatureSkill, FeatureSkillChoice, FeatureSpeed, FeatureText, FeatureTitle} from '../models/feature';
 import { Kit, KitDamageBonus } from '../models/kit';
 import { Monster, MonsterGroup, MonsterRole } from '../models/monster';
 import { AbilityDistanceType } from '../enums/abiity-distance-type';
@@ -553,18 +553,19 @@ export class FactoryLogic {
 				}
 			};
 		},
-		createAncestryTraits: (data: {id: string, name?: string, description?: string, options: { feature: Feature, value: number }[], count?: number }): FeatureAncestryTraits => {
+		createAncestryTraits: (data: {id: string, name?: string, description?: string, options: { feature: Feature, value: number }[], count?: number, overrides?: FeatureOverride<any>[] }): FeatureAncestryTraits => {
 			const count = data.count || 3;
 			return {
 				id: data.id,
 				name: data.name || 'Ancestry Traits',
-				description: data.description || (count > 1 ? `Choose ${count} options.` : 'Choose an option.'),
+				description: data.description || 'Choose your ancestry traits.',
 				type: FeatureType.AncestryTraits,
 				data: {
 					options: data.options,
 					inheritedOptions: [],
 					count: count,
-					selected: []
+					selected: [],
+					overrides: data.overrides || []
 				}
 			};
 		},

--- a/src/logic/factory-logic.ts
+++ b/src/logic/factory-logic.ts
@@ -1,6 +1,6 @@
 import { Ability, AbilityDistance, AbilityType } from '../models/ability';
 import { Encounter, EncounterGroup, EncounterSlot } from '../models/encounter';
-import { Feature, FeatureAbility, FeatureAbilityCost, FeatureAbilityData, FeatureBonus, FeatureChoice, FeatureClassAbility, FeatureDamageModifier, FeatureDomain, FeatureDomainFeature, FeatureInheritedAncestry, FeatureInheritedAncestryData, FeatureKit, FeatureKitType, FeatureLanguage, FeatureLanguageChoice, FeatureMalice, FeatureMaliceData, FeatureMultiple, FeaturePerk, FeatureSize, FeatureSkill, FeatureSkillChoice, FeatureSpeed, FeatureText, FeatureTitle } from '../models/feature';
+import { Feature, FeatureAbility, FeatureAbilityCost, FeatureAbilityData, FeatureAncestryTraits, FeatureBonus, FeatureChoice, FeatureClassAbility, FeatureDamageModifier, FeatureDomain, FeatureDomainFeature, FeatureInheritedAncestry, FeatureInheritedAncestryData, FeatureKit, FeatureKitType, FeatureLanguage, FeatureLanguageChoice, FeatureMalice, FeatureMaliceData, FeatureMultiple, FeaturePerk, FeatureSize, FeatureSkill, FeatureSkillChoice, FeatureSpeed, FeatureText, FeatureTitle } from '../models/feature';
 import { Kit, KitDamageBonus } from '../models/kit';
 import { Monster, MonsterGroup, MonsterRole } from '../models/monster';
 import { AbilityDistanceType } from '../enums/abiity-distance-type';
@@ -550,6 +550,20 @@ export class FactoryLogic {
 				data: {
 					keywords: data.keywords,
 					modifier: data.modifier
+				}
+			};
+		},
+		createAncestryTraits: (data: {id: string, name?: string, description?: string, options: { feature: Feature, value: number }[], count?: number }): FeatureAncestryTraits => {
+			const count = data.count || 3;
+			return {
+				id: data.id,
+				name: data.name || 'Ancestry Traits',
+				description: data.description || (count > 1 ? `Choose ${count} options.` : 'Choose an option.'),
+				type: FeatureType.AncestryTraits,
+				data: {
+					options: data.options,
+					count: count,
+					selected: []
 				}
 			};
 		},

--- a/src/logic/factory-logic.ts
+++ b/src/logic/factory-logic.ts
@@ -521,13 +521,15 @@ export class FactoryLogic {
 	};
 
 	static feature = {
-		create: (data: { id: string, name: string, description: string }): FeatureText => {
+		create: (data: { id: string, name: string, description: string, selectable?: boolean }): FeatureText => {
 			return {
 				id: data.id,
 				name: data.name,
 				description: data.description,
 				type: FeatureType.Text,
-				data: null
+				data: {
+					selectable: (data.selectable === undefined) ? true : data.selectable
+				},
 			};
 		},
 		createAbility: (data: FeatureAbilityData): FeatureAbility => {

--- a/src/logic/factory-logic.ts
+++ b/src/logic/factory-logic.ts
@@ -1,6 +1,6 @@
 import { Ability, AbilityDistance, AbilityType } from '../models/ability';
 import { Encounter, EncounterGroup, EncounterSlot } from '../models/encounter';
-import { Feature, FeatureAbility, FeatureAbilityCost, FeatureAbilityData, FeatureAncestryTraits, FeatureBonus, FeatureChoice, FeatureClassAbility, FeatureDamageModifier, FeatureDomain, FeatureDomainFeature, FeatureInheritedAncestry, FeatureInheritedAncestryData, FeatureKit, FeatureKitType, FeatureLanguage, FeatureLanguageChoice, FeatureMalice, FeatureMaliceData, FeatureMultiple, FeaturePerk, FeatureSize, FeatureSkill, FeatureSkillChoice, FeatureSpeed, FeatureText, FeatureTitle } from '../models/feature';
+import { Feature, FeatureAbility, FeatureAbilityCost, FeatureAbilityData, FeatureAncestryTraits, FeatureBonus, FeatureChoice, FeatureClassAbility, FeatureDamageModifier, FeatureDomain, FeatureDomainFeature, FeatureInheritedAncestry, FeatureInheritedAncestryData, FeatureKit, FeatureKitType, FeatureLanguage, FeatureLanguageChoice, FeatureMalice, FeatureMaliceData, FeatureMultiple, FeaturePerk, FeatureSize, FeatureSkill, FeatureSkillChoice, FeatureSpeed, FeatureText, FeatureTitle} from '../models/feature';
 import { Kit, KitDamageBonus } from '../models/kit';
 import { Monster, MonsterGroup, MonsterRole } from '../models/monster';
 import { AbilityDistanceType } from '../enums/abiity-distance-type';
@@ -15,7 +15,7 @@ import { DamageModifier } from '../models/damage-modifier';
 import { Domain } from '../models/domain';
 import type { Element } from '../models/element';
 import { FeatureField } from '../enums/feature-field';
-import { FeatureType } from '../enums/feature-type';
+import { FeatureType, InheritableFeature } from '../enums/feature-type';
 import { Format } from '../utils/format';
 import { FormatLogic } from './format-logic';
 import { Hero } from '../models/hero';
@@ -562,6 +562,7 @@ export class FactoryLogic {
 				type: FeatureType.AncestryTraits,
 				data: {
 					options: data.options,
+					inheritedOptions: [],
 					count: count,
 					selected: []
 				}
@@ -649,7 +650,7 @@ export class FactoryLogic {
 				}
 			};
 		},
-		createInheritedAncestry: (data: { id: string, name?: string, description?: string, count?: number }) => {
+		createInheritedAncestry: (data: { id: string, name?: string, description?: string, count?: number, inheritedFeatures?: InheritableFeature[] }) => {
 			const count = data.count || 1;
 			return {
 				id: data.id,
@@ -658,7 +659,8 @@ export class FactoryLogic {
 				type: FeatureType.InheritedAncestry,
 				data: {
 					count: count,
-					selected: []
+					selected: [],
+					inheritedFeatures: data.inheritedFeatures || [FeatureType.Size]
 				} as FeatureInheritedAncestryData
 			} as FeatureInheritedAncestry
 		},

--- a/src/logic/feature-logic.ts
+++ b/src/logic/feature-logic.ts
@@ -7,6 +7,7 @@ import type {
 	FeatureKitData,
 	FeatureLanguageChoiceData,
 	FeaturePerkData,
+	FeatureSize,
 	FeatureSkillChoiceData,
 	FeatureTitleData
 } from '../models/feature';
@@ -238,5 +239,9 @@ export class FeatureLogic {
 			case FeatureType.Title:
 				return 'This feature allows you to choose a title.';
 		}
+	};
+
+	static getSizeDescription = (feature: FeatureSize) => {
+		return `${feature.data.size.value.toString()}${feature.data.size.mod}`;
 	};
 }

--- a/src/logic/feature-logic.ts
+++ b/src/logic/feature-logic.ts
@@ -133,7 +133,7 @@ export class FeatureLogic {
 			case FeatureType.ClassAbility:
 			case FeatureType.Domain:
 			case FeatureType.DomainFeature:
-			case FeatureType.FormerLife:
+			case FeatureType.InheritedAncestry:
 			case FeatureType.Kit:
 			case FeatureType.LanguageChoice:
 			case FeatureType.Perk:

--- a/src/logic/feature-logic.ts
+++ b/src/logic/feature-logic.ts
@@ -100,6 +100,9 @@ export class FeatureLogic {
 			list.push(feature);
 
 			switch (feature.type) {
+				case FeatureType.AncestryTraits:
+					feature.data.selected.forEach(addFeature);
+					break;
 				case FeatureType.Choice:
 					feature.data.selected.forEach(addFeature);
 					break;
@@ -130,6 +133,7 @@ export class FeatureLogic {
 
 	static isChoice = (feature: Feature) => {
 		switch (feature.type) {
+			case FeatureType.AncestryTraits:
 			case FeatureType.Choice:
 			case FeatureType.ClassAbility:
 			case FeatureType.Domain:
@@ -200,6 +204,8 @@ export class FeatureLogic {
 				return 'This feature grants you an ability.';
 			case FeatureType.AbilityCost:
 				return 'This feature modifies the cost to use an ability.';
+			case FeatureType.AncestryTraits:
+				return 'This feature allows you to choose from a collection of Ancestry-specific features.'
 			case FeatureType.Bonus:
 				return 'This feature modifies a statistic.';
 			case FeatureType.Choice:
@@ -212,6 +218,8 @@ export class FeatureLogic {
 				return 'This feature allows you to choose a domain.';
 			case FeatureType.DomainFeature:
 				return 'This feature allows you to choose a feature from your domain.';
+			case FeatureType.InheritedAncestry:
+				return 'This feature allows you to choose another ancestry (or ancestries) to inherit features from.'
 			case FeatureType.Kit:
 				return 'This feature allows you to choose a kit.';
 			case FeatureType.KitType:

--- a/src/logic/feature-logic.ts
+++ b/src/logic/feature-logic.ts
@@ -133,6 +133,7 @@ export class FeatureLogic {
 			case FeatureType.ClassAbility:
 			case FeatureType.Domain:
 			case FeatureType.DomainFeature:
+			case FeatureType.FormerLife:
 			case FeatureType.Kit:
 			case FeatureType.LanguageChoice:
 			case FeatureType.Perk:

--- a/src/logic/hero-logic.ts
+++ b/src/logic/hero-logic.ts
@@ -812,66 +812,6 @@ Complex or time-consuming tests might require an action if made in combat—or c
 
 	///////////////////////////////////////////////////////////////////////////
 
-	static updateInheritedSize = (hero: Hero, feature: FeatureInheritedAncestry, sourcebooks: Sourcebook[]) => {
-		const featureId = 'inherited-size';
-		const ancestryFeatures = hero.ancestry?.features || [];
-
-		const currentSizeIdx = ancestryFeatures.findIndex(f => f.id === featureId);
-		if (currentSizeIdx > -1) {
-			ancestryFeatures.splice(currentSizeIdx, 1);
-		}
-
-		const sizes = new Set<string>();
-		if (feature.data.selected.length > 0) {
-			const ancestries = SourcebookLogic.getAncestriesById(sourcebooks, feature.data.selected);
-			ancestries.forEach(a => {
-				const ancestryOptions = [];
-				a.features.forEach(f => {
-					if (f.type === FeatureType.Size) {
-						ancestryOptions.push(FeatureLogic.getSizeDescription(f as FeatureSize));
-					} else if (f.type === FeatureType.Choice) {
-						(f as FeatureChoice).data.options.forEach(o => {
-							if (o.feature.type === FeatureType.Size) {
-								ancestryOptions.push(FeatureLogic.getSizeDescription(o.feature as FeatureSize));
-							}
-						});
-					}
-				});
-				
-				if (ancestryOptions.length === 0) {
-					ancestryOptions.push('1M');
-				}
-
-				ancestryOptions.forEach(o => sizes.add(o));
-			});
-		}
-
-		let newFeature;
-		if (sizes.size > 1) {
-			newFeature = FactoryLogic.feature.createChoice({
-				id: featureId,
-				name: 'Size',
-				description: 'Choose your size.',
-				options: Array.from(
-					sizes.values(),
-					v => {
-						return {
-							feature: FactoryLogic.feature.createSizeFromDescription(v),
-							value: 1
-						};
-					}
-				)
-			});
-		} else if (sizes.size === 1) {
-			newFeature = FactoryLogic.feature.createSizeFromDescription(sizes.values().next().value as string, featureId);
-		}
-
-		if (newFeature !== undefined) {
-			const inheritedAncestryIdx = ancestryFeatures.findIndex(f => f.type === FeatureType.InheritedAncestry);
-			ancestryFeatures.splice(inheritedAncestryIdx, 0, newFeature);
-		}
-	};
-
 	static updateHero = (hero: Hero) => {
 		if (hero.settingIDs === undefined) {
 			hero.settingIDs = [ SourcebookData.core.id, SourcebookData.orden.id ];
@@ -931,5 +871,76 @@ Complex or time-consuming tests might require an action if made in combat—or c
 				}
 			});
 		});
+	};
+
+	static updateBreakingChanges = (hero: Hero) => {
+		if (!this.getFeatures(hero).some(f => f.type === FeatureType.AncestryTraits)) {
+			const traitsFeature = hero.ancestry?.features.find(f => f.name.includes('Traits'));
+			if (traitsFeature) {
+				traitsFeature.type = FeatureType.AncestryTraits;
+			}
+		}
+	};
+
+	///////////////////////////////////////////////////////////////////////////
+
+	static updateInheritedSize = (hero: Hero, feature: FeatureInheritedAncestry, sourcebooks: Sourcebook[]) => {
+		const featureId = 'inherited-size';
+		const ancestryFeatures = hero.ancestry?.features || [];
+
+		const currentSizeIdx = ancestryFeatures.findIndex(f => f.id === featureId);
+		if (currentSizeIdx > -1) {
+			ancestryFeatures.splice(currentSizeIdx, 1);
+		}
+
+		const sizes = new Set<string>();
+		if (feature.data.selected.length > 0) {
+			const ancestries = SourcebookLogic.getAncestriesById(sourcebooks, feature.data.selected);
+			ancestries.forEach(a => {
+				const ancestryOptions = [];
+				a.features.forEach(f => {
+					if (f.type === FeatureType.Size) {
+						ancestryOptions.push(FeatureLogic.getSizeDescription(f as FeatureSize));
+					} else if (f.type === FeatureType.Choice) {
+						(f as FeatureChoice).data.options.forEach(o => {
+							if (o.feature.type === FeatureType.Size) {
+								ancestryOptions.push(FeatureLogic.getSizeDescription(o.feature as FeatureSize));
+							}
+						});
+					}
+				});
+				
+				if (ancestryOptions.length === 0) {
+					ancestryOptions.push('1M');
+				}
+
+				ancestryOptions.forEach(o => sizes.add(o));
+			});
+		}
+
+		let newFeature;
+		if (sizes.size > 1) {
+			newFeature = FactoryLogic.feature.createChoice({
+				id: featureId,
+				name: 'Size',
+				description: 'Choose your size.',
+				options: Array.from(
+					sizes.values(),
+					v => {
+						return {
+							feature: FactoryLogic.feature.createSizeFromDescription(v),
+							value: 1
+						};
+					}
+				)
+			});
+		} else if (sizes.size === 1) {
+			newFeature = FactoryLogic.feature.createSizeFromDescription(sizes.values().next().value as string, featureId);
+		}
+
+		if (newFeature !== undefined) {
+			const inheritedAncestryIdx = ancestryFeatures.findIndex(f => f.type === FeatureType.InheritedAncestry);
+			ancestryFeatures.splice(inheritedAncestryIdx, 0, newFeature);
+		}
 	};
 }

--- a/src/logic/hero-logic.ts
+++ b/src/logic/hero-logic.ts
@@ -880,6 +880,14 @@ Complex or time-consuming tests might require an action if made in combat—or c
 			const traitsFeature = hero.ancestry?.features.find(f => f.name.includes('Traits'));
 			if (traitsFeature) {
 				traitsFeature.type = FeatureType.AncestryTraits;
+
+				if (hero?.ancestry?.id === revenant.id) {
+					const overrides = revenant.features.find(f => f.type === FeatureType.AncestryTraits)?.data.overrides;
+					if (overrides) {
+						const overridesCopy = JSON.parse(JSON.stringify(overrides));
+						(traitsFeature as FeatureAncestryTraits).data.overrides = overridesCopy;
+					}
+				}
 			}
 		}
 

--- a/src/logic/hero-logic.ts
+++ b/src/logic/hero-logic.ts
@@ -19,6 +19,7 @@ import { Skill } from '../models/skill';
 import { Sourcebook } from '../models/sourcebook';
 import { SourcebookData } from '../data/sourcebook-data';
 import { SourcebookLogic } from './sourcebook-logic';
+import { revenant } from '../data/ancestries/revenant';
 
 export class HeroLogic {
 	static getKitTypes = (hero: Hero) => {
@@ -880,6 +881,17 @@ Complex or time-consuming tests might require an action if made in combat—or c
 				traitsFeature.type = FeatureType.AncestryTraits;
 			}
 		}
+
+		if (hero?.ancestry?.id === revenant.id) {
+			const newFormerLife = revenant.features.find(f => f.type === FeatureType.InheritedAncestry);
+			if (newFormerLife) {
+				const formerLifeIndex = hero.ancestry.features.findIndex(f => f.id === newFormerLife.id);
+				if (hero.ancestry.features[formerLifeIndex].type !== FeatureType.InheritedAncestry) {
+					const formerLifeCopy = JSON.parse(JSON.stringify(newFormerLife)) as FeatureInheritedAncestry;
+					hero.ancestry.features.splice(formerLifeIndex, 1, formerLifeCopy);
+				}
+			}
+		}
 	};
 
 	///////////////////////////////////////////////////////////////////////////
@@ -940,7 +952,7 @@ Complex or time-consuming tests might require an action if made in combat—or c
 
 		if (newFeature !== undefined) {
 			const inheritedAncestryIdx = ancestryFeatures.findIndex(f => f.type === FeatureType.InheritedAncestry);
-			ancestryFeatures.splice(inheritedAncestryIdx, 0, newFeature);
+			ancestryFeatures.splice(inheritedAncestryIdx + 1, 0, newFeature);
 		}
 	};
 }

--- a/src/logic/hero-logic.ts
+++ b/src/logic/hero-logic.ts
@@ -1,5 +1,5 @@
 import { Ability, AbilityDistance } from '../models/ability';
-import { Feature, FeatureAbilityData, FeatureAncestryTraits, FeatureBonusData, FeatureChoice, FeatureClassAbilityData, FeatureDamageModifierData, FeatureDomainData, FeatureInheritedAncestry, FeatureKitData, FeatureKitTypeData, FeatureLanguageChoiceData, FeatureLanguageData, FeatureSize, FeatureSizeData, FeatureSkillChoiceData, FeatureSkillData, FeatureSpeed } from '../models/feature';
+import { Feature, FeatureAbilityData, FeatureAncestryTraits, FeatureBonusData, FeatureChoice, FeatureClassAbilityData, FeatureDamageModifierData, FeatureDomainData, FeatureInheritedAncestry, FeatureKitData, FeatureKitTypeData, FeatureLanguageChoiceData, FeatureLanguageData, FeatureOverride, FeatureSize, FeatureSizeData, FeatureSkillChoiceData, FeatureSkillData, FeatureSpeed } from '../models/feature';
 import { AbilityDistanceType } from '../enums/abiity-distance-type';
 import { AbilityKeyword } from '../enums/ability-keyword';
 import { Characteristic } from '../enums/characteristic';
@@ -1013,4 +1013,15 @@ Complex or time-consuming tests might require an action if made in combat—or c
 			}
 		}
 	};
+
+	static shouldDoOverride = (hero: Hero, override: FeatureOverride<any>) => {
+		switch (override.conditionTarget) {
+			case FeatureType.Size:
+				const heroSize = HeroLogic.getSize(hero);
+				const targetSize = [...override.conditionValue];
+				return heroSize.value.toString() === targetSize[0] && heroSize.mod === targetSize[1];
+			default:
+				return false;
+		}
+	}
 }

--- a/src/logic/hero-logic.ts
+++ b/src/logic/hero-logic.ts
@@ -468,6 +468,14 @@ Complex or time-consuming tests might require an action if made in combat—or c
 		return Collections.sort(immunities, i => i.type);
 	};
 
+	static getFormerLife = (hero: Hero) => {
+		const ancestries = hero.ancestry?.features.find(f => f.type === FeatureType.FormerLife)?.data.selected;
+		if (ancestries !== undefined) {
+			return ancestries;
+		}
+		return [];
+	};
+
 	///////////////////////////////////////////////////////////////////////////
 
 	static getStamina = (hero: Hero) => {
@@ -535,7 +543,13 @@ Complex or time-consuming tests might require an action if made in combat—or c
 	};
 
 	static getSize = (hero: Hero) => {
-		const features = this.getFeatures(hero).filter(f => f.type === FeatureType.Size);
+		const featuresToSearch: Feature[] = [];
+		if (this.getFormerLife(hero).length === 1) {
+			featuresToSearch.push(...this.getFormerLife(hero)[0].features);
+		} else {
+			featuresToSearch.push(...this.getFeatures(hero));
+		}
+		const features = featuresToSearch.filter(f => f.type === FeatureType.Size);
 		if (features.length > 0) {
 			const datas = features.map(f => f.data as FeatureSizeData);
 			const value = Collections.max(datas.map(d => d.size.value), v => v);

--- a/src/logic/hero-logic.ts
+++ b/src/logic/hero-logic.ts
@@ -468,12 +468,8 @@ Complex or time-consuming tests might require an action if made in combat—or c
 		return Collections.sort(immunities, i => i.type);
 	};
 
-	static getFormerLife = (hero: Hero) => {
-		const ancestries = hero.ancestry?.features.find(f => f.type === FeatureType.FormerLife)?.data.selected;
-		if (ancestries !== undefined) {
-			return ancestries;
-		}
-		return [];
+	static getInheritedAncestry = (hero: Hero) => {
+		return hero.ancestry?.features.find(f => f.type === FeatureType.InheritedAncestry);
 	};
 
 	///////////////////////////////////////////////////////////////////////////
@@ -543,13 +539,7 @@ Complex or time-consuming tests might require an action if made in combat—or c
 	};
 
 	static getSize = (hero: Hero) => {
-		const featuresToSearch: Feature[] = [];
-		if (this.getFormerLife(hero).length === 1) {
-			featuresToSearch.push(...this.getFormerLife(hero)[0].features);
-		} else {
-			featuresToSearch.push(...this.getFeatures(hero));
-		}
-		const features = featuresToSearch.filter(f => f.type === FeatureType.Size);
+		const features = this.getFeatures(hero).filter(f => f.type === FeatureType.Size);
 		if (features.length > 0) {
 			const datas = features.map(f => f.data as FeatureSizeData);
 			const value = Collections.max(datas.map(d => d.size.value), v => v);

--- a/src/logic/hero-logic.ts
+++ b/src/logic/hero-logic.ts
@@ -1,5 +1,5 @@
 import { Ability, AbilityDistance } from '../models/ability';
-import { Feature, FeatureAbilityData, FeatureAncestryTraits, FeatureBonusData, FeatureChoice, FeatureClassAbilityData, FeatureDamageModifierData, FeatureDomainData, FeatureInheritedAncestry, FeatureKitData, FeatureKitTypeData, FeatureLanguageChoiceData, FeatureLanguageData, FeatureSize, FeatureSizeData, FeatureSkillChoiceData, FeatureSkillData } from '../models/feature';
+import { Feature, FeatureAbilityData, FeatureAncestryTraits, FeatureBonusData, FeatureChoice, FeatureClassAbilityData, FeatureDamageModifierData, FeatureDomainData, FeatureInheritedAncestry, FeatureKitData, FeatureKitTypeData, FeatureLanguageChoiceData, FeatureLanguageData, FeatureSize, FeatureSizeData, FeatureSkillChoiceData, FeatureSkillData, FeatureSpeed } from '../models/feature';
 import { AbilityDistanceType } from '../enums/abiity-distance-type';
 import { AbilityKeyword } from '../enums/ability-keyword';
 import { Characteristic } from '../enums/characteristic';
@@ -935,9 +935,9 @@ Complex or time-consuming tests might require an action if made in combat—or c
 	static updateInheritedSize = (ancestryFeatures: Feature[], ancestries: Ancestry[]) => {
 		const featureId = 'inherited-size';
 
-		const currentSizeIdx = ancestryFeatures.findIndex(f => f.id === featureId);
-		if (currentSizeIdx > -1) {
-			ancestryFeatures.splice(currentSizeIdx, 1);
+		const currentSizeIndex = ancestryFeatures.findIndex(f => f.id === featureId);
+		if (currentSizeIndex > -1) {
+			ancestryFeatures.splice(currentSizeIndex, 1);
 		}
 
 		const sizes = new Set<string>();
@@ -985,12 +985,32 @@ Complex or time-consuming tests might require an action if made in combat—or c
 		}
 
 		if (newFeature !== undefined) {
-			const inheritedAncestryIdx = ancestryFeatures.findIndex(f => f.type === FeatureType.InheritedAncestry);
-			ancestryFeatures.splice(inheritedAncestryIdx + 1, 0, newFeature);
+			const inheritedAncestryIndex = ancestryFeatures.findIndex(f => f.type === FeatureType.InheritedAncestry);
+			ancestryFeatures.splice(inheritedAncestryIndex + 1, 0, newFeature);
 		}
 	};
 
 	static updateInheritedSpeed = (ancestryFeatures: Feature[], ancestries: Ancestry[]) => {
-		// TODO
+		const currentSpeedIndex = ancestryFeatures.findIndex(f => f.type === FeatureType.Speed);
+		if (currentSpeedIndex > -1) {
+			ancestryFeatures.splice(currentSpeedIndex, 1);
+		}
+
+		if (ancestries.length > 0) {
+			const fastest: FeatureSpeed = ancestries.reduce((acc: FeatureSpeed, curr: Ancestry) => {
+				const speedFeature = curr.features.find(f => f.type === FeatureType.Speed);
+				if (speedFeature) {
+					if (acc.id === undefined || acc.data.speed < speedFeature.data.speed) {
+						return speedFeature;
+					}
+				}
+				return acc;
+			}, {} as FeatureSpeed);
+
+			if (fastest.id) {
+				const inheritedAncestryIndex = ancestryFeatures.findIndex(f => f.type === FeatureType.InheritedAncestry);
+				ancestryFeatures.splice(inheritedAncestryIndex + 1, 0, fastest);
+			}
+		}
 	};
 }

--- a/src/logic/sourcebook-logic.ts
+++ b/src/logic/sourcebook-logic.ts
@@ -100,6 +100,19 @@ export class SourcebookLogic {
 		return Collections.sort(list, item => item.name);
 	};
 
+	static getAncestriesById = (sourcebooks: Sourcebook[], ids: string[]) => {
+		const list: Ancestry[] = [];
+
+		sourcebooks.forEach(sourcebook => {
+			const ancestries = sourcebook.ancestries.filter(a => ids.includes(a.id));
+			if (ancestries.length > 0) {
+				list.push(...ancestries);
+			}
+		});
+
+		return Collections.sort(list, item => item.name);
+	};
+
 	static getCultures = (sourcebooks: Sourcebook[]) => {
 		const list: Culture[] = [];
 

--- a/src/models/feature.ts
+++ b/src/models/feature.ts
@@ -40,6 +40,13 @@ export interface FeatureBonusData extends _FeatureData {
 };
 export type FeatureBonus = FeatureOf<FeatureType.Bonus, FeatureBonusData>;
 
+export interface FeatureAncestryTraitsData extends _FeatureData {
+	options: { feature: Feature, value: number }[];
+	count: number;
+	selected: Feature[];
+}
+export type FeatureAncestryTraits = FeatureOf<FeatureType.AncestryTraits, FeatureAncestryTraitsData>;
+
 export interface FeatureChoiceData extends _FeatureData {
 	options: { feature: Feature, value: number }[];
 	count: number;
@@ -156,6 +163,7 @@ export type FeatureTitle = FeatureOf<FeatureType.Title, FeatureTitleData>;
 export type Feature =
 	| FeatureAbility
 	| FeatureAbilityCost
+	| FeatureAncestryTraits
 	| FeatureBonus
 	| FeatureChoice
 	| FeatureClassAbility

--- a/src/models/feature.ts
+++ b/src/models/feature.ts
@@ -6,6 +6,7 @@ import { Domain } from './domain';
 import { Element } from './element';
 import { FeatureField } from '../enums/feature-field';
 import { FeatureType } from '../enums/feature-type';
+import { Hero } from './hero';
 import { Kit } from './kit';
 import { KitType } from '../enums/kit';
 import { Perk } from './perk';
@@ -14,6 +15,13 @@ import { PowerRoll } from './power-roll';
 import { Size } from './size';
 import { SkillList } from '../enums/skill-list';
 import { Title } from './title';
+
+export interface FeatureOverride<Type> {
+	overrideTarget: string;
+	overrideValue: Type;
+	conditionTarget: FeatureType;
+	conditionValue: any;
+}
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 interface _FeatureData { }
@@ -36,6 +44,7 @@ export interface FeatureAncestryTraitsData extends _FeatureData {
 	inheritedOptions: { feature: Feature, value: number }[];
 	count: number;
 	selected: Feature[];
+	overrides: FeatureOverride<any>[];
 }
 export type FeatureAncestryTraits = FeatureOf<FeatureType.AncestryTraits, FeatureAncestryTraitsData>;
 

--- a/src/models/feature.ts
+++ b/src/models/feature.ts
@@ -31,6 +31,14 @@ export interface FeatureAbilityCostData extends _FeatureData {
 };
 export type FeatureAbilityCost = FeatureOf<FeatureType.AbilityCost, FeatureAbilityCostData>
 
+export interface FeatureAncestryTraitsData extends _FeatureData {
+	options: { feature: Feature, value: number }[];
+	inheritedOptions: { feature: Feature, value: number }[];
+	count: number;
+	selected: Feature[];
+}
+export type FeatureAncestryTraits = FeatureOf<FeatureType.AncestryTraits, FeatureAncestryTraitsData>;
+
 export interface FeatureBonusData extends _FeatureData {
 	field: FeatureField;
 	value: number;
@@ -39,13 +47,6 @@ export interface FeatureBonusData extends _FeatureData {
 	valuePerEchelon: number;
 };
 export type FeatureBonus = FeatureOf<FeatureType.Bonus, FeatureBonusData>;
-
-export interface FeatureAncestryTraitsData extends _FeatureData {
-	options: { feature: Feature, value: number }[];
-	count: number;
-	selected: Feature[];
-}
-export type FeatureAncestryTraits = FeatureOf<FeatureType.AncestryTraits, FeatureAncestryTraitsData>;
 
 export interface FeatureChoiceData extends _FeatureData {
 	options: { feature: Feature, value: number }[];
@@ -83,6 +84,7 @@ export type FeatureDomainFeature = FeatureOf<FeatureType.DomainFeature, FeatureD
 export interface FeatureInheritedAncestryData extends _FeatureData {
 	count: number;
 	selected: string[];
+	inheritedFeatures: InheritableFeature[];
 };
 export type FeatureInheritedAncestry = FeatureOf<FeatureType.InheritedAncestry, FeatureInheritedAncestryData>;
 

--- a/src/models/feature.ts
+++ b/src/models/feature.ts
@@ -14,6 +14,7 @@ import { PowerRoll } from './power-roll';
 import { Size } from './size';
 import { SkillList } from '../enums/skill-list';
 import { Title } from './title';
+import { Ancestry } from './ancestry';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 interface _FeatureData { }
@@ -72,6 +73,12 @@ export interface FeatureDomainFeatureData extends _FeatureData {
 	selected: Feature[];
 };
 export type FeatureDomainFeature = FeatureOf<FeatureType.DomainFeature, FeatureDomainFeatureData>;
+
+export interface FeatureFormerLifeData extends _FeatureData {
+	count: number;
+	selected: Ancestry[];
+};
+export type FeatureFormerLife = FeatureOf<FeatureType.FormerLife, FeatureFormerLifeData>;
 
 export interface FeatureKitData extends _FeatureData {
 	types: KitType[];
@@ -156,6 +163,7 @@ export type Feature =
 	| FeatureDamageModifier
 	| FeatureDomain
 	| FeatureDomainFeature
+	| FeatureFormerLife
 	| FeatureKit
 	| FeatureKitType
 	| FeatureLanguage

--- a/src/models/feature.ts
+++ b/src/models/feature.ts
@@ -14,7 +14,6 @@ import { PowerRoll } from './power-roll';
 import { Size } from './size';
 import { SkillList } from '../enums/skill-list';
 import { Title } from './title';
-import { Ancestry } from './ancestry';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 interface _FeatureData { }
@@ -74,11 +73,11 @@ export interface FeatureDomainFeatureData extends _FeatureData {
 };
 export type FeatureDomainFeature = FeatureOf<FeatureType.DomainFeature, FeatureDomainFeatureData>;
 
-export interface FeatureFormerLifeData extends _FeatureData {
+export interface FeatureInheritedAncestryData extends _FeatureData {
 	count: number;
-	selected: Ancestry[];
+	selected: string[];
 };
-export type FeatureFormerLife = FeatureOf<FeatureType.FormerLife, FeatureFormerLifeData>;
+export type FeatureInheritedAncestry = FeatureOf<FeatureType.InheritedAncestry, FeatureInheritedAncestryData>;
 
 export interface FeatureKitData extends _FeatureData {
 	types: KitType[];
@@ -163,7 +162,7 @@ export type Feature =
 	| FeatureDamageModifier
 	| FeatureDomain
 	| FeatureDomainFeature
-	| FeatureFormerLife
+	| FeatureInheritedAncestry
 	| FeatureKit
 	| FeatureKitType
 	| FeatureLanguage

--- a/src/models/feature.ts
+++ b/src/models/feature.ts
@@ -5,8 +5,7 @@ import { DamageModifier } from './damage-modifier';
 import { Domain } from './domain';
 import { Element } from './element';
 import { FeatureField } from '../enums/feature-field';
-import { FeatureType } from '../enums/feature-type';
-import { Hero } from './hero';
+import { FeatureType, InheritableFeature } from '../enums/feature-type';
 import { Kit } from './kit';
 import { KitType } from '../enums/kit';
 import { Perk } from './perk';
@@ -24,7 +23,9 @@ export interface FeatureOverride<Type> {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-interface _FeatureData { }
+interface _FeatureData { 
+	selectable?: boolean;
+}
 
 type FeatureOf<Type extends FeatureType, Data extends _FeatureData | null = null> = Element & { type: Type, data: Data };
 
@@ -163,7 +164,7 @@ export interface FeatureSpeedData extends _FeatureData {
 };
 export type FeatureSpeed = FeatureOf<FeatureType.Speed, FeatureSpeedData>;
 
-export type FeatureText = FeatureOf<FeatureType.Text>;
+export type FeatureText = FeatureOf<FeatureType.Text, _FeatureData>;
 
 export interface FeatureTitleData extends _FeatureData {
 	count: number;


### PR DESCRIPTION
Intended changes:

- [x] Have FormerLife select an Ancestry instead of a Size
- [x] Have the hero update its size based on the selected ancestry.
- [x] Add the selected ancestry's traits to the Revenant Traits selection
- [x] Update the point total based on hero's size