### PR TITLE
support abilities with repeatable spend

### DIFF
--- a/src/components/controls/heroic-resource-badge/heroic-resource-badge.tsx
+++ b/src/components/controls/heroic-resource-badge/heroic-resource-badge.tsx
@@ -2,9 +2,10 @@ import { Badge } from '../badge/badge';
 
 interface Props {
 	value: number;
+	repeatable?: boolean;
 	units?: string;
 }
 
 export const HeroicResourceBadge = (props: Props) => {
-	return (<Badge>{props.value}{props.units ?? (props.value === 1 ? 'pt' : 'pts')}</Badge>);
+	return (<Badge>{props.repeatable ? `${props.value}+` : props.value}{props.units ?? (props.value === 1 ? 'pt' : 'pts')}</Badge>);
 };

--- a/src/components/panels/edit/ability-edit-panel/ability-edit-panel.tsx
+++ b/src/components/panels/edit/ability-edit-panel/ability-edit-panel.tsx
@@ -282,7 +282,7 @@ export const AbilityEditPanel = (props: Props) => {
 
 	const addSpend = () => {
 		const copy = JSON.parse(JSON.stringify(ability)) as Ability;
-		copy.spend.push({ effect: '', value: 1 });
+		copy.spend.push({ effect: '', value: 1, repeatable: false });
 		setAbility(copy);
 		props.onChange(copy);
 	};

--- a/src/components/panels/elements/ability-panel/ability-panel.tsx
+++ b/src/components/panels/elements/ability-panel/ability-panel.tsx
@@ -122,7 +122,7 @@ export const AbilityPanel = (props: Props) => {
 										label={(
 											<div style={{ display: 'inline-flex',  alignItems: 'center', gap: '5px' }}>
 												<span>Spend</span>
-												{spend.value ? <HeroicResourceBadge value={spend.value} /> : null}
+												{spend.value ? <HeroicResourceBadge value={spend.value} repeatable={spend.repeatable} /> : null}
 											</div>
 										)}
 										value={<Markdown text={spend.effect} useSpan={true} />}

--- a/src/data/classes/conduit.ts
+++ b/src/data/classes/conduit.ts
@@ -103,6 +103,8 @@ Additionally, you can gain more piety by praying to the gods — but beware! Doi
 						effect: 'The target can spend a Recovery.',
 						spend: [
 							{
+								value: 1,
+								repeatable: true,
 								effect: `
 For each piety spent, you can choose one of the following enhancements:
 • You can target one additional ally within distance.

--- a/src/data/classes/elementalist.ts
+++ b/src/data/classes/elementalist.ts
@@ -872,6 +872,8 @@ Additionally, whenever you touch a living plant that is not a Plant Creature, yo
 								effect: 'The target can spend a Recovery.',
 								spend: [
 									{
+										value: 1,
+										repeatable: true,
 										effect: 'The target can spend an additional Recovery for each essence spent.'
 									}
 								]

--- a/src/data/classes/shadow.ts
+++ b/src/data/classes/shadow.ts
@@ -411,6 +411,8 @@ When you use a heroic ability that has a power roll, that ability costs 1 less i
 								effect: 'You teleport up to 5 squares. If you have concealment or cover at your destination, you can use the Hide maneuver even if you are observed. If you hide using this maneuver, you gain a surge.',
 								spend: [
 									{
+										value: 1,
+										repeatable: true,
 										effect: 'You teleport 1 additional square for each insight spent.'
 									}
 								]
@@ -428,6 +430,8 @@ When you use a heroic ability that has a power roll, that ability costs 1 less i
 								effect: 'You halve the damage, then can teleport up to 4 squares after the triggering effect resolves.',
 								spend: [
 									{
+										value: 1,
+										repeatable: true,
 										effect: 'You teleport 1 additional square for each insight spent.'
 									}
 								]
@@ -515,6 +519,8 @@ When you use a heroic ability that has a power roll, that ability costs 1 less i
 								effect: 'You gain two surges. Whenever you use a surge before the end of the encounter, you can choose to have its damage be poison damage.',
 								spend: [
 									{
+										value: 1,
+										repeatable: true,
 										effect: 'For each insight you spend, you gain an additional surge.'
 									}
 								]

--- a/src/data/classes/talent.ts
+++ b/src/data/classes/talent.ts
@@ -689,6 +689,8 @@ Once on each of your turns, you can use a free maneuver to fire an orb at a crea
 								effect: 'You slide the target up to a number of squares equal to your Reason score.',
 								spend: [
 									{
+										value: 2,
+										repeatable: true,
 										effect: 'The size of the creature or object you can target increases by 1 for every 2 clarity you spend.'
 									},
 									{

--- a/src/data/classes/troubadour.ts
+++ b/src/data/classes/troubadour.ts
@@ -195,6 +195,8 @@ The Director can choose to award the heroes with 1 Hero Token to stop you from f
 			effect: 'You can shift up to 3 squares.',
 			spend: [
 				{
+					value: 2,
+					repeatable: true,
 					effect: 'You can target one additional creature or object within distance for every 2 drama you spend.'
 				}
 			]
@@ -293,6 +295,8 @@ The Director can choose to award the heroes with 1 Hero Token to stop you from f
 			}),
 			spend: [
 				{
+					value: 2,
+					repeatable: true,
 					effect: 'The size of the burst is increased by 1 for every 2 drama you spend.'
 				}
 			]

--- a/src/logic/factory-logic.ts
+++ b/src/logic/factory-logic.ts
@@ -346,7 +346,7 @@ export class FactoryLogic {
 		};
 	};
 
-	static createAbility = (data: { id: string, name: string, description?: string, type: AbilityType, keywords?: AbilityKeyword[], distance: AbilityDistance[], target: string, cost?: number | 'signature', preEffect?: string, powerRoll?: PowerRoll, effect?: string, strained?: string, alternateEffects?: string[], spend?: { value?: number, effect: string }[], persistence?: { value?: number, effect: string }[] }): Ability => {
+	static createAbility = (data: { id: string, name: string, description?: string, type: AbilityType, keywords?: AbilityKeyword[], distance: AbilityDistance[], target: string, cost?: number | 'signature', preEffect?: string, powerRoll?: PowerRoll, effect?: string, strained?: string, alternateEffects?: string[], spend?: { value: number, repeatable?: boolean, effect: string }[], persistence?: { value: number, effect: string }[] }): Ability => {
 		return {
 			id: data.id,
 			name: data.name,
@@ -361,8 +361,8 @@ export class FactoryLogic {
 			effect: data.effect || '',
 			strained: data.strained || '',
 			alternateEffects: data.alternateEffects || [],
-			spend: (data.spend ?? []).map(s => ({ ...s, value: s.value ?? 0 })),
-			persistence: (data.persistence ?? []).map(p => ({ ...p, value: p.value ?? 0 }))
+			spend: (data.spend ?? []).map(s => ({ ...s, repeatable: s.repeatable ?? false })),
+			persistence: (data.persistence ?? []).map(p => ({ ...p }))
 		};
 	};
 	static createPowerRoll = (data: { characteristic?: Characteristic | Characteristic[] } & Pick<PowerRoll, 'tier1' | 'tier2' | 'tier3'> & Partial<Pick<PowerRoll, 'bonus'>>): PowerRoll => {

--- a/src/models/ability.ts
+++ b/src/models/ability.ts
@@ -31,6 +31,6 @@ export interface Ability extends Element {
 	effect: string;
 	strained: string;
 	alternateEffects: string[];
-	spend: { value: number, effect: string }[];
+	spend: { value: number, repeatable: boolean, effect: string }[];
 	persistence: { value: number, effect: string }[];
 }


### PR DESCRIPTION
For ability enhancements that can be used numerous times at once, e.g. Goblin Stinker's Toxic Winds