### PR TITLE
Drawer/Modal with Hash Routing

### DIFF
--- a/src/components/main/main-layout.tsx
+++ b/src/components/main/main-layout.tsx
@@ -1,19 +1,551 @@
 import { AimOutlined, BookOutlined, TeamOutlined } from '@ant-design/icons';
 import { Button, Drawer } from 'antd';
-import { Outlet } from 'react-router';
-import { type ReactNode } from 'react';
+import { Outlet, useLocation, useNavigate } from 'react-router';
+import { ReactNode, useCallback, useMemo } from 'react';
+import type { Sourcebook, SourcebookElementKind } from '../../models/sourcebook';
+import { AbilityModal } from '../modals/ability/ability-modal';
+import { AboutModal } from '../modals/about/about-modal';
+import type { Ancestry } from '../../models/ancestry';
+import { AncestryModal } from '../modals/ancestry/ancestry-modal';
+import type { Career } from '../../models/career';
+import { CareerModal } from '../modals/career/career-modal';
+import type { Characteristic } from '../../enums/characteristic';
+import { CharacteristicModal } from '../modals/characteristic/characteristic-modal';
+import { ClassModal } from '../modals/class/class-modal';
+import type { Complication } from '../../models/complication';
+import { ComplicationModal } from '../modals/complication/complication-modal';
+import type { Culture } from '../../models/culture';
+import { CultureModal } from '../modals/culture/culture-modal';
+import type { Domain } from '../../models/domain';
+import { DomainModal } from '../modals/domain/domain-modal';
+import type { Element } from '../../models/element';
+import { EncounterModal } from '../modals/encounter/encounter-modal';
+import type { Hero } from '../../models/hero';
+import type { HeroClass } from '../../models/class';
+import { HeroLogic } from '../../logic/hero-logic';
+import { HeroStateModal } from '../modals/hero-state/hero-state-modal';
+import type { Item } from '../../models/item';
+import { ItemModal } from '../modals/item/item-modal';
+import type { Kit } from '../../models/kit';
+import { KitModal } from '../modals/kit/kit-modal';
+import type { MonsterGroup } from '../../models/monster';
+import { MonsterGroupModal } from '../modals/monster-group/monster-group-modal';
+import { MonsterModal } from '../modals/monster/monster-modal';
+import type { Perk } from '../../models/perk';
+import { PerkModal } from '../modals/perk/perk-modal';
+import { Playbook } from '../../models/playbook';
+import { RulesModal } from '../modals/rules/rules-modal';
+import { SourcebookLogic } from '../../logic/sourcebook-logic';
+import { SourcebooksModal } from '../modals/sourcebooks/sourcebooks-modal';
+import type { Title } from '../../models/title';
+import { TitleModal } from '../modals/title/title-modal';
+import { Utils } from '../../utils/utils';
+import pbds from '../../assets/powered-by-draw-steel.png';
 import { useNavigation } from '../../hooks/use-navigation';
 
-import pbds from '../../assets/powered-by-draw-steel.png';
-
 interface Props {
-	section: 'hero' | 'library' | 'encounter';
-	drawer: ReactNode;
-	setDrawer: React.Dispatch<React.SetStateAction<ReactNode>>;
+	heroes: Hero[];
+	playbook: Playbook;
+	officialSourcebooks: Sourcebook[];
+	homebrewSourcebooks: Sourcebook[];
+	hiddenSourcebookIDs: string[];
+	persistHomebrewSourcebooks: (sourcebooks: Sourcebook[]) => Promise<void>;
+	deleteSourcebookElement: (kind: SourcebookElementKind, elementId: string) => Promise<void>;
+	persistHiddenSourcebookIDs: (ids: string[]) => Promise<void>;
+	onAncestryCreate: (ancestry: Ancestry, sourcebook: Sourcebook | null) => void;
+	onCareerCreate: (culture: Career, sourcebook: Sourcebook | null) => void;
+	onClassCreate: (heroClass: HeroClass, sourcebook: Sourcebook | null) => void;
+	onComplicationCreate: (complication: Complication, sourcebook: Sourcebook | null) => void;
+	onCultureCreate: (culture: Culture, sourcebook: Sourcebook | null) => void;
+	onDomainCreate: (domain: Domain, sourcebook: Sourcebook | null) => void;
+	onItemCreate: (item: Item, sourcebook: Sourcebook | null) => void;
+	onKitCreate: (kit: Kit, sourcebook: Sourcebook | null) => void;
+	onPerkCreate: (perk: Perk, sourcebook: Sourcebook | null) => void;
+	onTitleCreate: (title: Title, sourcebook: Sourcebook | null) => void;
+	onEncounterDelete: (encounterId: string) => Promise<void> | void;
+	onHeroChange: (hero: Hero) => Promise<void> | void;
+	onMonsterGroupCreate: (monsterGroup: MonsterGroup, sourcebook: Sourcebook | null) => void;
 }
-
-export const MainLayout = (props: Props) => {
+export const MainLayout = ({
+	heroes,
+	playbook,
+	officialSourcebooks,
+	homebrewSourcebooks,
+	hiddenSourcebookIDs,
+	persistHomebrewSourcebooks,
+	deleteSourcebookElement,
+	persistHiddenSourcebookIDs,
+	onAncestryCreate,
+	onCareerCreate,
+	onClassCreate,
+	onComplicationCreate,
+	onCultureCreate,
+	onDomainCreate,
+	onItemCreate,
+	onKitCreate,
+	onPerkCreate,
+	onTitleCreate,
+	onEncounterDelete,
+	onHeroChange,
+	onMonsterGroupCreate
+}: Props) => {
+	const location = useLocation();
+	const navigate = useNavigate();
 	const navigation = useNavigation();
+
+	const sourcebooks = useMemo(() => [ ...officialSourcebooks, ...homebrewSourcebooks ], [ officialSourcebooks, homebrewSourcebooks ]);
+
+	// #region Sourcebook Element Modals
+
+	const getSourcebookElementModal = useCallback(
+		<T extends Element,>(
+			segments: string[],
+			sourcebookElementKind: SourcebookElementKind,
+			{
+				listAccessor,
+				getSourcebook,
+				exportDefaultName,
+				exportExt,
+				getModal
+			}: {
+				listAccessor: (sourcebook: Sourcebook) => T[],
+				getSourcebook: (sourcebooks: Sourcebook[], element: T) => Sourcebook | undefined,
+				exportDefaultName: string,
+				exportExt: string,
+				getModal: (props: {
+					element: T,
+					sourcebook: Sourcebook,
+					homebrewSourcebooks: Sourcebook[],
+					isHomebrew: boolean,
+					export: (format: 'image' | 'pdf' | 'json') => void,
+					edit: () => void,
+					delete: () => void
+				}) => ReactNode
+			}
+		) => {
+			const [ elementId ] = segments;
+			const element = sourcebooks.flatMap(listAccessor).find(e => e.id === elementId);
+			if (!element) {
+				return null;
+			}
+			const sourcebook = getSourcebook(sourcebooks, element)!;
+			const isHomebrew = homebrewSourcebooks.flatMap(listAccessor).some(a => a.id === elementId);
+			return getModal({
+				element,
+				sourcebook,
+				homebrewSourcebooks,
+				isHomebrew,
+				export: format => Utils.export([ elementId ], element.name || exportDefaultName, element, exportExt, format),
+				edit: () => navigation.goToLibraryEdit(sourcebook.id, sourcebookElementKind, elementId),
+				delete: () => { deleteSourcebookElement(sourcebookElementKind, elementId); navigate({ hash: '' }); }
+			});
+		},
+		[ sourcebooks, navigate, navigation, deleteSourcebookElement ]
+	);
+
+	const getAncestryModal = useCallback(
+		(segments: string[]) => {
+			return getSourcebookElementModal<Ancestry>(
+				segments,
+				'ancestry',
+				{
+					listAccessor: s => s.ancestries,
+					getSourcebook: SourcebookLogic.getAncestrySourcebook,
+					exportDefaultName: 'Ancestry',
+					exportExt: 'ancestry',
+					getModal: ({
+						element,
+						...props
+					}) => <AncestryModal
+						{ ...props }
+						ancestry={element}
+						createHomebrew={sourcebook => onAncestryCreate(element, sourcebook)}
+					/>
+				}
+			);
+		},
+		[ getSourcebookElementModal, onAncestryCreate ]
+	);
+
+	const getCareerModal = useCallback(
+		(segments: string[]) => {
+			return getSourcebookElementModal<Career>(
+				segments,
+				'career',
+				{
+					listAccessor: s => s.careers,
+					getSourcebook: SourcebookLogic.getCareerSourcebook,
+					exportDefaultName: 'Career',
+					exportExt: 'career',
+					getModal: ({
+						element,
+						...props
+					}) => <CareerModal
+						{ ...props }
+						career={element}
+						createHomebrew={sourcebook => onCareerCreate(element, sourcebook)}
+					/>
+				}
+			);
+		},
+		[ getSourcebookElementModal, onCareerCreate ]
+	);
+
+	const getClassModal = useCallback(
+		(segments: string[]) => {
+			return getSourcebookElementModal<HeroClass>(
+				segments,
+				'class',
+				{
+					listAccessor: s => s.classes,
+					getSourcebook: SourcebookLogic.getClassSourcebook,
+					exportDefaultName: 'Class',
+					exportExt: 'class',
+					getModal: ({
+						element,
+						...props
+					}) => <ClassModal
+						{ ...props }
+						heroClass={element}
+						createHomebrew={sourcebook => onClassCreate(element, sourcebook)}
+					/>
+				}
+			);
+		},
+		[ getSourcebookElementModal, onClassCreate ]
+	);
+
+	const getComplicationModal = useCallback(
+		(segments: string[]) => {
+			return getSourcebookElementModal<Complication>(
+				segments,
+				'complication',
+				{
+					listAccessor: s => s.complications,
+					getSourcebook: SourcebookLogic.getComplicationSourcebook,
+					exportDefaultName: 'Complication',
+					exportExt: 'complication',
+					getModal: ({
+						element,
+						...props
+					}) => <ComplicationModal
+						{ ...props }
+						complication={element}
+						createHomebrew={sourcebook => onComplicationCreate(element, sourcebook)}
+					/>
+				}
+			);
+		},
+		[ getSourcebookElementModal, onComplicationCreate ]
+	);
+
+	const getCultureModal = useCallback(
+		(segments: string[]) => {
+			return getSourcebookElementModal<Culture>(
+				segments,
+				'culture',
+				{
+					listAccessor: s => s.cultures,
+					getSourcebook: SourcebookLogic.getCultureSourcebook,
+					exportDefaultName: 'Culture',
+					exportExt: 'culture',
+					getModal: ({
+						element,
+						...props
+					}) => <CultureModal
+						{ ...props }
+						culture={element}
+						createHomebrew={sourcebook => onCultureCreate(element, sourcebook)}
+					/>
+				}
+			);
+		},
+		[ getSourcebookElementModal, onCultureCreate ]
+	);
+
+	const getDomainModal = useCallback(
+		(segments: string[]) => {
+			return getSourcebookElementModal<Domain>(
+				segments,
+				'domain',
+				{
+					listAccessor: s => s.domains,
+					getSourcebook: SourcebookLogic.getDomainSourcebook,
+					exportDefaultName: 'Domain',
+					exportExt: 'domain',
+					getModal: ({
+						element,
+						...props
+					}) => <DomainModal
+						{ ...props }
+						domain={element}
+						createHomebrew={sourcebook => onDomainCreate(element, sourcebook)}
+					/>
+				}
+			);
+		},
+		[ getSourcebookElementModal, onDomainCreate ]
+	);
+
+	const getItemModal = useCallback(
+		(segments: string[]) => {
+			return getSourcebookElementModal<Item>(
+				segments,
+				'item',
+				{
+					listAccessor: s => s.items,
+					getSourcebook: SourcebookLogic.getItemSourcebook,
+					exportDefaultName: 'Item',
+					exportExt: 'item',
+					getModal: ({
+						element,
+						...props
+					}) => <ItemModal
+						{ ...props }
+						item={element}
+						createHomebrew={sourcebook => onItemCreate(element, sourcebook)}
+					/>
+				}
+			);
+		},
+		[ getSourcebookElementModal, onItemCreate ]
+	);
+
+	const getKitModal = useCallback(
+		(segments: string[]) => {
+			return getSourcebookElementModal<Kit>(
+				segments,
+				'kit',
+				{
+					listAccessor: s => s.kits,
+					getSourcebook: SourcebookLogic.getKitSourcebook,
+					exportDefaultName: 'Kit',
+					exportExt: 'kit',
+					getModal: ({
+						element,
+						...props
+					}) => <KitModal
+						{ ...props }
+						kit={element}
+						createHomebrew={sourcebook => onKitCreate(element, sourcebook)}
+					/>
+				}
+			);
+		},
+		[ getSourcebookElementModal, onKitCreate ]
+	);
+
+	const getPerkModal = useCallback(
+		(segments: string[]) => {
+			return getSourcebookElementModal<Perk>(
+				segments,
+				'perk',
+				{
+					listAccessor: s => s.perks,
+					getSourcebook: SourcebookLogic.getPerkSourcebook,
+					exportDefaultName: 'Perk',
+					exportExt: 'perk',
+					getModal: ({
+						element,
+						...props
+					}) => <PerkModal
+						{ ...props }
+						perk={element}
+						createHomebrew={sourcebook => onPerkCreate(element, sourcebook)}
+					/>
+				}
+			);
+		},
+		[ getSourcebookElementModal, onPerkCreate ]
+	);
+
+	const getTitleModal = useCallback(
+		(segments: string[]) => {
+			return getSourcebookElementModal<Title>(
+				segments,
+				'title',
+				{
+					listAccessor: s => s.titles,
+					getSourcebook: SourcebookLogic.getTitleSourcebook,
+					exportDefaultName: 'Title',
+					exportExt: 'title',
+					getModal: ({
+						element,
+						...props
+					}) => <TitleModal
+						{ ...props }
+						title={element}
+						createHomebrew={sourcebook => onTitleCreate(element, sourcebook)}
+					/>
+				}
+			);
+		},
+		[ getSourcebookElementModal, onTitleCreate ]
+	);
+
+	// #endregion
+
+	const getEncounterModal = useCallback(
+		(segments: string[]) => {
+			const [ encounterId ] = segments as [ string ];
+			const encounter = playbook.encounters.find(e => e.id === encounterId)!;
+			return <EncounterModal
+				playbook={playbook}
+				sourcebooks={sourcebooks}
+				encounter={encounter}
+				export={format => Utils.export([ encounter.id ], encounter.name || 'Encounter', encounter, 'encounter', format)}
+				edit={() => navigation.goToEncounterEdit(encounterId)}
+				delete={() => onEncounterDelete(encounterId)}
+			/>;
+		},
+		[ playbook, navigation, onEncounterDelete ]
+	);
+
+	const getHeroModal = useCallback(
+		(segments: string[]) => {
+			const [ heroId, heroPage, ...remainingSegments ] = segments as [ string, 'ability' | 'characteristic'| 'hero' | 'stats' | 'conditions' | 'rules', ...string[] ];
+			const hero = heroes.find(h => h.id === heroId)!;
+			switch (heroPage) {
+				case 'ability':
+					return getHeroAbilityModal(hero, remainingSegments);
+				case 'characteristic':
+					return getHeroCharacteristicModal(hero, remainingSegments);
+				case 'hero':
+				case 'stats':
+				case 'conditions':
+					return <HeroStateModal
+						hero={hero}
+						startPage={heroPage}
+						onChange={onHeroChange}
+						onLevelUp={async () => {
+							if (hero && hero.class) {
+								hero.class.level += 1;
+								await onHeroChange(hero);
+								navigation.goToHeroEdit(hero.id, 'Class');
+							}
+						}}
+					/>;
+				case 'rules':
+					return <RulesModal hero={hero} sourcebooks={sourcebooks} />;
+			}
+		},
+		[ heroes, navigation, onHeroChange ]
+	);
+
+	const getMonsterModal = useCallback(
+		(segments: string[]) => {
+			const [ monsterId ] = segments;
+			const monster = SourcebookLogic.getMonster(sourcebooks, monsterId)!;
+			const monsterGroup = SourcebookLogic.getMonsterGroup(sourcebooks, monsterId)!;
+			return <MonsterModal
+				playbook={playbook}
+				monster={monster}
+				monsterGroup={monsterGroup}
+				export={format => Utils.export([ monster.id ], monster.name || 'Monster', monster, 'monster', format)}
+			/>;
+		},
+		[ sourcebooks ]
+	);
+
+	const getMonsterGroupModal = useCallback(
+		(segments: string[]) => {
+			const [ monsterGroupId ] = segments;
+			const sourcebook = sourcebooks
+				.find(cs => cs.monsterGroups.some(mg => mg.id === monsterGroupId));
+			if (!sourcebook) {
+				return null;
+			}
+			const monsterGroup = sourcebook.monsterGroups.find(mg => mg.id === monsterGroupId)!;
+			return <MonsterGroupModal
+				monsterGroup={monsterGroup}
+				homebrewSourcebooks={homebrewSourcebooks}
+				isHomebrew={sourcebook.isHomebrew}
+				playbook={playbook}
+				createHomebrew={sourcebook => onMonsterGroupCreate(monsterGroup, sourcebook)}
+				export={format => Utils.export([ monsterGroup.id ], monsterGroup.name || 'Monster Group', monsterGroup, 'monster-group', format)}
+				edit={() => navigation.goToLibraryEdit(sourcebook.id, 'monster-group', monsterGroup.id)}
+				delete={() => { deleteSourcebookElement('monster-group', monsterGroup.id); navigate({ hash: '' }); }}
+			/>;
+		},
+		[ sourcebooks, navigate, navigation, onMonsterGroupCreate, deleteSourcebookElement ]
+	);
+
+	function getHeroAbilityModal(hero: Hero, segments: string[]) {
+		const [ abilityId ] = segments;
+		const ability = HeroLogic.getAbilities(hero, true, true, true)
+			.find(a => a.id === abilityId)!;
+		return <AbilityModal ability={ability} hero={hero} />;
+	}
+
+	function getHeroCharacteristicModal(hero: Hero, segments: string[]) {
+		const [ characteristic ] = segments as [ Characteristic ];
+		return <CharacteristicModal characteristic={characteristic} hero={hero} />;
+	}
+
+	const drawer = useMemo(
+		() => {
+			// Drop leading # character
+			const hash = location.hash.substring(1);
+			const [ hashRoot, ...hashSegments ] = hash.split('/');
+			switch (hashRoot) {
+				case 'about':
+					return <AboutModal />;
+				case 'ancestry':
+					return getAncestryModal(hashSegments);
+				case 'career':
+					return getCareerModal(hashSegments);
+				case 'class':
+					return getClassModal(hashSegments);
+				case 'complication':
+					return getComplicationModal(hashSegments);
+				case 'culture':
+					return getCultureModal(hashSegments);
+				case 'domain':
+					return getDomainModal(hashSegments);
+				case 'encounter':
+					return getEncounterModal(hashSegments);
+				case 'hero':
+					return getHeroModal(hashSegments);
+				case 'item':
+					return getItemModal(hashSegments);
+				case 'kit':
+					return getKitModal(hashSegments);
+				case 'monster':
+					return getMonsterModal(hashSegments);
+				case 'monster-group':
+					return getMonsterGroupModal(hashSegments);
+				case 'perk':
+					return getPerkModal(hashSegments);
+				case 'sourcebooks':
+					return <SourcebooksModal
+						officialSourcebooks={officialSourcebooks}
+						homebrewSourcebooks={homebrewSourcebooks}
+						hiddenSourcebookIDs={hiddenSourcebookIDs}
+						onHomebrewSourcebookChange={persistHomebrewSourcebooks}
+						onHiddenSourcebookIDsChange={persistHiddenSourcebookIDs}
+					/>;
+				case 'title':
+					return getTitleModal(hashSegments);
+			}
+		},
+		[
+			location,
+			getAncestryModal,
+			getCareerModal,
+			getClassModal,
+			getComplicationModal,
+			getCultureModal,
+			getDomainModal,
+			getEncounterModal,
+			getHeroModal,
+			getItemModal,
+			getKitModal,
+			getMonsterModal,
+			getMonsterGroupModal,
+			getPerkModal,
+			getTitleModal
+		]
+	);
 
 	return (
 		<div className='main'>
@@ -31,8 +563,8 @@ export const MainLayout = (props: Props) => {
 					<Button type='text' title='Encounters' icon={<AimOutlined />} onClick={() => navigation.goToEncounterList()} />
 				</div>
 			</div>
-			<Drawer open={props.drawer !== null} onClose={() => props.setDrawer(null)} closeIcon={null} width='500px'>
-				{props.drawer}
+			<Drawer open={Boolean(drawer)} onClose={() => navigate({ hash: '' })} closeIcon={null} width='500px'>
+				{drawer}
 			</Drawer>
 		</div>
 	);

--- a/src/components/modals/sourcebooks/sourcebooks-modal.tsx
+++ b/src/components/modals/sourcebooks/sourcebooks-modal.tsx
@@ -12,8 +12,8 @@ interface Props {
 	officialSourcebooks: Sourcebook[];
 	homebrewSourcebooks: Sourcebook[];
 	hiddenSourcebookIDs: string[];
-	onHomebrewSourcebookChange: (Sourcebooks: Sourcebook[]) => void;
-	onHiddenSourcebookIDsChange: (ids: string[]) => void;
+	onHomebrewSourcebookChange: (Sourcebooks: Sourcebook[]) => Promise<void>;
+	onHiddenSourcebookIDsChange: (ids: string[]) => Promise<void>;
 }
 
 export const SourcebooksModal = (props: Props) => {

--- a/src/components/pages/encounters/encounter-edit/encounter-edit.tsx
+++ b/src/components/pages/encounters/encounter-edit/encounter-edit.tsx
@@ -27,6 +27,7 @@ import { Playbook } from '../../../../models/playbook';
 import { SelectablePanel } from '../../../controls/selectable-panel/selectable-panel';
 import { Sourcebook } from '../../../../models/sourcebook';
 import { SourcebookLogic } from '../../../../logic/sourcebook-logic';
+import { useModals } from '../../../../hooks/use-modals';
 import { useParams } from 'react-router';
 
 import './encounter-edit.scss';
@@ -34,13 +35,12 @@ import './encounter-edit.scss';
 interface Props {
 	playbook: Playbook;
 	sourcebooks: Sourcebook[];
-	showAbout: () => void;
-	showMonster: (monsterID: string) => void;
 	saveChanges: (encounter: Encounter) => void;
 	cancelChanges: () => void;
 }
 
 export const EncounterEditPage = (props: Props) => {
+	const modals = useModals();
 	const { encounterId } = useParams<{ encounterId: string }>();
 	const originalEncounter = useMemo(() => props.playbook.encounters.find(e => e.id === encounterId)!, [ encounterId, props.playbook ]);
 	const [ encounter, setEncounter ] = useState(JSON.parse(JSON.stringify(originalEncounter)) as Encounter);
@@ -135,7 +135,7 @@ export const EncounterEditPage = (props: Props) => {
 											<div key={slot.id} className='slot-row'>
 												<MonsterPanel monster={monster} monsterGroup={monsterGroup} mode={PanelMode.Compact} />
 												<div className='actions'>
-													<Button block={true} onClick={() => props.showMonster(slot.monsterID)}>Details</Button>
+													<Button block={true} onClick={() => modals.showMonster(slot.monsterID)}>Details</Button>
 													<NumberSpin
 														value={slot.count}
 														format={value => (value * MonsterLogic.getRoleMultiplier(monster.role.organization)).toString()}
@@ -341,7 +341,7 @@ export const EncounterEditPage = (props: Props) => {
 							<div key={m.id} className='monster-row'>
 								<MonsterPanel monster={m} monsterGroup={monsterGroup} mode={PanelMode.Compact} />
 								<div className='actions'>
-									<Button block={true} onClick={() => props.showMonster(m.id)}>Details</Button>
+									<Button block={true} onClick={() => modals.showMonster(m.id)}>Details</Button>
 									{addBtn}
 								</div>
 							</div>
@@ -451,12 +451,7 @@ export const EncounterEditPage = (props: Props) => {
 	try {
 		return (
 			<div className='encounter-edit-page'>
-				<AppHeader
-					breadcrumbs={[
-						{ label: 'Encounters' }
-					]}
-					showAbout={props.showAbout}
-				>
+				<AppHeader breadcrumbs={[ { label: 'Encounters' } ]}>
 					<Button type='primary' disabled={!dirty} onClick={() => props.saveChanges(encounter)}>
 						Save Changes
 					</Button>

--- a/src/components/pages/encounters/encounter-list/encounter-list.tsx
+++ b/src/components/pages/encounters/encounter-list/encounter-list.tsx
@@ -7,6 +7,7 @@ import { Playbook } from '../../../../models/playbook';
 import { SelectablePanel } from '../../../controls/selectable-panel/selectable-panel';
 import { Sourcebook } from '../../../../models/sourcebook';
 import { Utils } from '../../../../utils/utils';
+import { useModals } from '../../../../hooks/use-modals';
 import { useState } from 'react';
 
 import './encounter-list.scss';
@@ -14,13 +15,12 @@ import './encounter-list.scss';
 interface Props {
 	playbook: Playbook;
 	sourcebooks: Sourcebook[];
-	showAbout: () => void;
-	viewEncounter: (encounter: Encounter) => void;
 	onCreateEncounter: () => void;
 	onImportEncounter: (encounter: Encounter) => void;
 }
 
 export const EncounterListPage = (props: Props) => {
+	const modals = useModals();
 	const [ searchTerm, setSearchTerm ] = useState<string>('');
 
 	const getEncounters = () => {
@@ -45,7 +45,7 @@ export const EncounterListPage = (props: Props) => {
 			<div className='encounter-section-row'>
 				{
 					list.map(enc => (
-						<SelectablePanel key={enc.id} onSelect={() => props.viewEncounter(enc)}>
+						<SelectablePanel key={enc.id} onSelect={() => modals.showEncounter(enc.id)}>
 							<EncounterPanel encounter={enc} playbook={props.playbook} sourcebooks={props.sourcebooks} />
 						</SelectablePanel>
 					))
@@ -59,12 +59,7 @@ export const EncounterListPage = (props: Props) => {
 
 		return (
 			<div className='encounter-list-page'>
-				<AppHeader
-					breadcrumbs={[
-						{ label: 'Encounters' }
-					]}
-					showAbout={props.showAbout}
-				>
+				<AppHeader breadcrumbs={[ { label: 'Encounters' } ]}>
 					<Input
 						placeholder='Search'
 						allowClear={true}

--- a/src/components/pages/heroes/hero-edit/hero-edit-page.tsx
+++ b/src/components/pages/heroes/hero-edit/hero-edit-page.tsx
@@ -58,9 +58,7 @@ const matchElement = (element: Element, searchTerm: string) => {
 interface Props {
 	heroes: Hero[];
 	sourcebooks: Sourcebook[];
-	showAbout: () => void;
 	saveChanges: (hero: Hero) => void;
-	cancelChanges: (heroId: string) => void;
 }
 
 export const HeroEditPage = (props: Props) => {
@@ -444,16 +442,11 @@ export const HeroEditPage = (props: Props) => {
 
 		return (
 			<div className='hero-edit-page'>
-				<AppHeader
-					breadcrumbs={[
-						{ label: 'Heroes' }
-					]}
-					showAbout={props.showAbout}
-				>
+				<AppHeader breadcrumbs={[ { label: 'Heroes' } ]}>
 					<Button type='primary' disabled={!dirty} onClick={saveChanges}>
 						Save Changes
 					</Button>
-					<Button onClick={() => props.cancelChanges(heroId!)}>
+					<Button onClick={() => navigation.goToHeroView(heroId!)}>
 						Cancel
 					</Button>
 				</AppHeader>

--- a/src/components/pages/heroes/hero-list/hero-list-page.tsx
+++ b/src/components/pages/heroes/hero-list/hero-list-page.tsx
@@ -5,28 +5,23 @@ import { Hero } from '../../../../models/hero';
 import { HeroPanel } from '../../../panels/elements/hero-panel/hero-panel';
 import { SelectablePanel } from '../../../controls/selectable-panel/selectable-panel';
 import { Sourcebook } from '../../../../models/sourcebook';
+import { useNavigation } from '../../../../hooks/use-navigation';
 
 import './hero-list-page.scss';
 
 interface Props {
 	heroes: Hero[];
 	sourcebooks: Sourcebook[];
-	showAbout: () => void;
 	addHero: () => void;
-	importHero: (hero: Hero) => void;
-	viewHero: (heroID: string) => void;
+	importHero: (hero: Hero) => Promise<void>;
 }
 
 export const HeroListPage = (props: Props) => {
+	const navigation = useNavigation();
 	try {
 		return (
 			<div className='hero-list-page'>
-				<AppHeader
-					breadcrumbs={[
-						{ label: 'Heroes' }
-					]}
-					showAbout={props.showAbout}
-				>
+				<AppHeader breadcrumbs={[ { label: 'Heroes' } ]}>
 					<Button type='primary' icon={<PlusCircleOutlined />} onClick={props.addHero}>
 						Create A New Hero
 					</Button>
@@ -37,9 +32,10 @@ export const HeroListPage = (props: Props) => {
 						beforeUpload={file => {
 							file
 								.text()
-								.then(json => {
+								.then(async json => {
 									const hero = (JSON.parse(json) as Hero);
-									props.importHero(hero);
+									await props.importHero(hero);
+									navigation.goToHeroView(hero.id);
 								});
 							return false;
 						}}
@@ -50,7 +46,7 @@ export const HeroListPage = (props: Props) => {
 				<div className='hero-list-page-content'>
 					{
 						props.heroes.map(hero => (
-							<SelectablePanel key={hero.id} onSelect={() => props.viewHero(hero.id)}>
+							<SelectablePanel key={hero.id} onSelect={() => navigation.goToHeroView(hero.id)}>
 								<HeroPanel hero={hero} sourcebooks={props.sourcebooks} />
 							</SelectablePanel>
 						))

--- a/src/components/pages/heroes/hero-view/hero-view-page.tsx
+++ b/src/components/pages/heroes/hero-view/hero-view-page.tsx
@@ -1,24 +1,17 @@
 import { Button, Divider, Popover } from 'antd';
 import { DownOutlined, EditOutlined } from '@ant-design/icons';
-import { Ability } from '../../../../models/ability';
-import { Ancestry } from '../../../../models/ancestry';
 import { AppHeader } from '../../../panels/app-header/app-header';
-import { Career } from '../../../../models/career';
-import { Characteristic } from '../../../../enums/characteristic';
-import { Complication } from '../../../../models/complication';
-import { Culture } from '../../../../models/culture';
 import { DangerButton } from '../../../controls/danger-button/danger-button';
-import { Domain } from '../../../../models/domain';
 import { DropdownButton } from '../../../controls/dropdown-button/dropdown-button';
 import { Hero } from '../../../../models/hero';
-import { HeroClass } from '../../../../models/class';
 import { HeroPanel } from '../../../panels/elements/hero-panel/hero-panel';
-import { Kit } from '../../../../models/kit';
 import { Options } from '../../../../models/options';
 import { PanelMode } from '../../../../enums/panel-mode';
 import { Sourcebook } from '../../../../models/sourcebook';
 import { Toggle } from '../../../controls/toggle/toggle';
 import { useMemo } from 'react';
+import { useModals } from '../../../../hooks/use-modals';
+import { useNavigation } from '../../../../hooks/use-navigation';
 import { useParams } from 'react-router';
 
 import './hero-view-page.scss';
@@ -28,27 +21,15 @@ interface Props {
 	sourcebooks: Sourcebook[];
 	options: Options;
 	setOptions: (options: Options) => void;
-	showAbout: () => void;
-	closeHero: () => void;
-	editHero: (heroId: string) => void;
 	exportHero: (heroId: string, format: 'image' | 'pdf' | 'json') => void;
-	deleteHero: (heroId: string) => void;
-	onSelectAncestry: (ancestry: Ancestry) => void;
-	onSelectCulture: (culture: Culture) => void;
-	onSelectCareer: (career: Career) => void;
-	onSelectClass: (heroClass: HeroClass) => void;
-	onSelectComplication: (complication: Complication) => void;
-	onSelectDomain: (domain: Domain) => void;
-	onSelectKit: (kit: Kit) => void;
-	onSelectCharacteristic: (characteristic: Characteristic, hero: Hero) => void;
-	onSelectAbility: (ability: Ability, hero: Hero) => void;
-	onShowHeroState: (hero: Hero, page: 'hero' | 'stats' | 'conditions') => void;
-	onShowRules: (hero: Hero) => void;
+	deleteHero: (heroId: string) => Promise<void>;
 }
 
 const getHero = (heroId: string, heroes: Hero[]) => heroes.find(h => h.id === heroId)!;
 
 export const HeroPage = (props: Props) => {
+	const modals = useModals();
+	const navigation = useNavigation();
 	const { heroId } = useParams<{ heroId: string }>();
 	const hero = useMemo(() => getHero(heroId!, props.heroes), [ heroId, props.heroes ]);
 
@@ -79,19 +60,14 @@ export const HeroPage = (props: Props) => {
 
 		return (
 			<div className='hero-view-page'>
-				<AppHeader
-					breadcrumbs={[
-						{ label: 'Heroes' }
-					]}
-					showAbout={props.showAbout}
-				>
-					<Button onClick={props.closeHero}>
+				<AppHeader breadcrumbs={[ { label: 'Heroes' } ]}>
+					<Button onClick={navigation.goToHeroList}>
 						Close
 					</Button>
-					<Button onClick={() => props.onShowHeroState(hero, 'hero')}>
+					<Button onClick={() => modals.showHeroState(heroId!, 'hero')}>
 						State
 					</Button>
-					<Button onClick={() => props.onShowRules(hero)}>
+					<Button onClick={() => modals.showHeroRules(heroId!)}>
 						Rules
 					</Button>
 					<Popover
@@ -122,8 +98,8 @@ export const HeroPage = (props: Props) => {
 									]}
 									onClick={key => props.exportHero(heroId!, key as 'image' | 'pdf' | 'json')}
 								/>
-								<Button icon={<EditOutlined />} onClick={() => (props).editHero(heroId!)}>Edit</Button>
-								<DangerButton onConfirm={() => props.deleteHero(heroId!)} />
+								<Button icon={<EditOutlined />} onClick={() => navigation.goToHeroEdit(heroId!)}>Edit</Button>
+								<DangerButton onConfirm={async () => { await props.deleteHero(heroId!); navigation.goToHeroList(); }} />
 							</div>
 						)}
 					>
@@ -139,16 +115,6 @@ export const HeroPage = (props: Props) => {
 						sourcebooks={props.sourcebooks}
 						options={props.options}
 						mode={PanelMode.Full}
-						onSelectAncestry={props.onSelectAncestry}
-						onSelectCulture={props.onSelectCulture}
-						onSelectCareer={props.onSelectCareer}
-						onSelectClass={props.onSelectClass}
-						onSelectComplication={props.onSelectComplication}
-						onSelectDomain={props.onSelectDomain}
-						onSelectKit={props.onSelectKit}
-						onSelectCharacteristic={characteristic => props.onSelectCharacteristic(characteristic, hero)}
-						onSelectAbility={ability => props.onSelectAbility(ability, hero)}
-						onShowState={page => props.onShowHeroState(hero, page)}
 					/>
 				</div>
 			</div>

--- a/src/components/pages/library/library-edit/library-edit.tsx
+++ b/src/components/pages/library/library-edit/library-edit.tsx
@@ -56,19 +56,20 @@ import { TitlePanel } from '../../../panels/elements/title-panel/title-panel';
 import { Toggle } from '../../../controls/toggle/toggle';
 import { Utils } from '../../../../utils/utils';
 import { getSourcebookKey } from '../../../../utils/get-sourcebook-key';
+import { useModals } from '../../../../hooks/use-modals';
+import { useNavigation } from '../../../../hooks/use-navigation';
 import { useParams } from 'react-router';
 
 import './library-edit.scss';
 
 interface Props {
 	sourcebooks: Sourcebook[];
-	showAbout: () => void;
-	showMonster: (monsterID: string) => void;
 	saveChanges: (sourcebookId: string, kind: SourcebookElementKind, element: Element) => void;
-	cancelChanges: (kind: SourcebookElementKind) => void;
 }
 
 export const LibraryEditPage = (props: Props) => {
+	const modals = useModals();
+	const navigation = useNavigation();
 	const { sourcebookId, kind, elementId } = useParams<{ sourcebookId: string, kind: SourcebookElementKind, elementId: string }>();
 	const [ subElementId, setSubElementId ] = useState<string>('');
 	const sourcebook = useMemo(() => props.sourcebooks.find(s => s.id === sourcebookId)!, [ sourcebookId, props.sourcebooks ]);
@@ -1315,7 +1316,7 @@ export const LibraryEditPage = (props: Props) => {
 						}
 
 						return (
-							<SelectablePanel key={m.id} onSelect={() => props.showMonster(monster.id)}>
+							<SelectablePanel key={m.id} onSelect={() => modals.showMonster(monster.id)}>
 								<MonsterPanel
 									monster={m}
 									monsterGroup={monsterGroup}
@@ -1710,16 +1711,11 @@ export const LibraryEditPage = (props: Props) => {
 	try {
 		return (
 			<div className='library-edit-page'>
-				<AppHeader
-					breadcrumbs={[
-						{ label: 'Library' }
-					]}
-					showAbout={props.showAbout}
-				>
+				<AppHeader breadcrumbs={[ { label: 'Library' } ]}>
 					<Button type='primary' disabled={!dirty} onClick={() => props.saveChanges(sourcebookId!, kind!, element)}>
 						Save Changes
 					</Button>
-					<Button onClick={() => props.cancelChanges(kind!)}>
+					<Button onClick={() => navigation.goToLibraryList(kind!)}>
 						Cancel
 					</Button>
 				</AppHeader>

--- a/src/components/pages/library/library-list/library-list.tsx
+++ b/src/components/pages/library/library-list/library-list.tsx
@@ -29,6 +29,7 @@ import { SourcebookLogic } from '../../../../logic/sourcebook-logic';
 import { Title } from '../../../../models/title';
 // import { TitlePanel } from '../../../panels/elements/title-panel/title-panel';
 import { Utils } from '../../../../utils/utils';
+import { useModals } from '../../../../hooks/use-modals';
 import { useNavigation } from '../../../../hooks/use-navigation';
 import { useParams } from 'react-router';
 import { useState } from 'react';
@@ -38,19 +39,6 @@ import './library-list.scss';
 interface Props {
 	sourcebooks: Sourcebook[];
 	hiddenSourcebookIDs: string[];
-	showAbout: () => void;
-	showSourcebooks: () => void;
-	viewAncestry: (ancestry: Ancestry) => void;
-	viewCulture: (cultiure: Culture) => void;
-	viewCareer: (career: Career) => void;
-	viewClass: (heroClass: HeroClass) => void;
-	viewComplication: (complication: Complication) => void;
-	viewDomain: (domain: Domain) => void;
-	viewKit: (kit: Kit) => void;
-	viewPerk: (perk: Perk) => void;
-	viewTitle: (title: Title) => void;
-	viewItem: (item: Item) => void;
-	viewMonsterGroup: (monsterGroup: MonsterGroup) => void;
 	onCreateHomebrew: (type: SourcebookElementKind, sourcebookID: string | null) => void;
 	onImportHomebrew: (type: SourcebookElementKind, sourcebookID: string | null, element: Element) => void;
 }
@@ -65,9 +53,10 @@ const useTabKey = (): [SourcebookElementKind, (tabKey: SourcebookElementKind) =>
 };
 
 export const LibraryListPage = (props: Props) => {
+	const modals = useModals();
 	const [ tabKey, setTabKey ] = useTabKey();
 	const [ previousTab, setPreviousTab ] = useState(tabKey);
-	const [ element, setElement ] = useState<SourcebookElementKind>('ancestry');
+	const [ element, setElement ] = useState<SourcebookElementKind>(tabKey);
 	const [ searchTerm, setSearchTerm ] = useState<string>('');
 	const [ sourcebookID, setSourcebookID ] = useState<string | null>(props.sourcebooks.filter(cs => cs.isHomebrew).length > 0 ? props.sourcebooks.filter(cs => cs.isHomebrew)[0].id : null);
 
@@ -201,7 +190,7 @@ export const LibraryListPage = (props: Props) => {
 				{
 					list.map(a => {
 						const item = (
-							<SelectablePanel key={a.id} onSelect={() => props.viewAncestry(a)}>
+							<SelectablePanel key={a.id} onSelect={() => modals.showAncestry(a.id)}>
 								<AncestryPanel ancestry={a} />
 							</SelectablePanel>
 						);
@@ -238,7 +227,7 @@ export const LibraryListPage = (props: Props) => {
 				{
 					list.map(c => {
 						const item = (
-							<SelectablePanel key={c.id} onSelect={() => props.viewCulture(c)}>
+							<SelectablePanel key={c.id} onSelect={() => modals.showCulture(c.id)}>
 								<CulturePanel culture={c} />
 							</SelectablePanel>
 						);
@@ -275,7 +264,7 @@ export const LibraryListPage = (props: Props) => {
 				{
 					list.map(c => {
 						const item = (
-							<SelectablePanel key={c.id} onSelect={() => props.viewCareer(c)}>
+							<SelectablePanel key={c.id} onSelect={() => modals.showCareer(c.id)}>
 								<CareerPanel career={c} />
 							</SelectablePanel>
 						);
@@ -313,7 +302,7 @@ export const LibraryListPage = (props: Props) => {
 					list.map(c => {
 
 						const item = (
-							<SelectablePanel key={c.id} onSelect={() => props.viewClass(c)}>
+							<SelectablePanel key={c.id} onSelect={() => modals.showClass(c.id)}>
 								<ClassPanel heroClass={c} />
 							</SelectablePanel>
 						);
@@ -350,7 +339,7 @@ export const LibraryListPage = (props: Props) => {
 				{
 					list.map(c => {
 						const item = (
-							<SelectablePanel key={c.id} onSelect={() => props.viewComplication(c)}>
+							<SelectablePanel key={c.id} onSelect={() => modals.showComplication(c.id)}>
 								<ComplicationPanel complication={c} />
 							</SelectablePanel>
 						);
@@ -387,7 +376,7 @@ export const LibraryListPage = (props: Props) => {
 				{
 					list.map(d => {
 						const item = (
-							<SelectablePanel key={d.id} onSelect={() => props.viewDomain(d)}>
+							<SelectablePanel key={d.id} onSelect={() => modals.showDomain(d.id)}>
 								<DomainPanel domain={d} />
 							</SelectablePanel>
 						);
@@ -424,7 +413,7 @@ export const LibraryListPage = (props: Props) => {
 				{
 					list.map(k => {
 						const item = (
-							<SelectablePanel key={k.id} onSelect={() => props.viewKit(k)}>
+							<SelectablePanel key={k.id} onSelect={() => modals.showKit(k.id)}>
 								<KitPanel kit={k} />
 							</SelectablePanel>
 						);
@@ -461,7 +450,7 @@ export const LibraryListPage = (props: Props) => {
 				{
 					list.map(p => {
 						const item = (
-							<SelectablePanel key={p.id} onSelect={() => props.viewPerk(p)}>
+							<SelectablePanel key={p.id} onSelect={() => modals.showPerk(p.id)}>
 								<PerkPanel perk={p} />
 							</SelectablePanel>
 						);
@@ -499,7 +488,7 @@ export const LibraryListPage = (props: Props) => {
 				{
 					list.map(t => {
 						const item = (
-							<SelectablePanel key={t.id} onSelect={() => props.viewTitle(t)}>
+							<SelectablePanel key={t.id} onSelect={() => modals.showTitle(t.id)}>
 								<TitlePanel title={t} />
 							</SelectablePanel>
 						);
@@ -536,7 +525,7 @@ export const LibraryListPage = (props: Props) => {
 				{
 					list.map(i => {
 						const item = (
-							<SelectablePanel key={i.id} onSelect={() => props.viewItem(i)}>
+							<SelectablePanel key={i.id} onSelect={() => modals.showItem(i.id)}>
 								<ItemPanel item={i} />
 							</SelectablePanel>
 						);
@@ -574,7 +563,7 @@ export const LibraryListPage = (props: Props) => {
 				{
 					list.map(mg => {
 						const item = (
-							<SelectablePanel key={mg.id} onSelect={() => props.viewMonsterGroup(mg)}>
+							<SelectablePanel key={mg.id} onSelect={() => modals.showMonsterGroup(mg.id)}>
 								<MonsterGroupPanel monsterGroup={mg} sourcebooks={props.sourcebooks} />
 							</SelectablePanel>
 						);
@@ -617,12 +606,7 @@ export const LibraryListPage = (props: Props) => {
 
 		return (
 			<div className='library-list-page'>
-				<AppHeader
-					breadcrumbs={[
-						{ label: 'Library' }
-					]}
-					showAbout={props.showAbout}
-				>
+				<AppHeader breadcrumbs={[ { label: 'Library' } ]}>
 					<Input
 						placeholder='Search'
 						allowClear={true}
@@ -690,7 +674,7 @@ export const LibraryListPage = (props: Props) => {
 							<DownOutlined />
 						</Button>
 					</Popover>
-					<Button onClick={props.showSourcebooks}>
+					<Button onClick={modals.showSourcebooks}>
 						Sourcebooks
 					</Button>
 				</AppHeader>

--- a/src/components/pages/welcome/welcome-page.tsx
+++ b/src/components/pages/welcome/welcome-page.tsx
@@ -7,7 +7,6 @@ import { SelectablePanel } from '../../controls/selectable-panel/selectable-pane
 import './welcome-page.scss';
 
 interface Props {
-	showAbout: () => void;
 	showHeroes: () => void;
 	showLibrary: () => void;
 	showEncounters: () => void;
@@ -17,7 +16,7 @@ export const WelcomePage = (props: Props) => {
 	try {
 		return (
 			<div className='welcome-page'>
-				<AppHeader breadcrumbs={[]} showAbout={props.showAbout}/>
+				<AppHeader breadcrumbs={[]}/>
 				<div className='welcome-page-content'>
 					<div className='welcome-column'>
 						<SelectablePanel>

--- a/src/components/panels/app-header/app-header.tsx
+++ b/src/components/panels/app-header/app-header.tsx
@@ -1,18 +1,18 @@
 import { Button } from 'antd';
 import { ReactNode } from 'react';
-import { useNavigation } from '../../../hooks/use-navigation';
-
 import shield from './../../../assets/shield.png';
+import { useModals } from '../../../hooks/use-modals';
+import { useNavigation } from '../../../hooks/use-navigation';
 
 import './app-header.scss';
 
 interface Props {
 	breadcrumbs: { label: string }[];
 	children?: ReactNode;
-	showAbout: () => void;
 }
 
 export const AppHeader = (props: Props) => {
+	const modals = useModals();
 	const navigation = useNavigation();
 
 	return (
@@ -27,7 +27,7 @@ export const AppHeader = (props: Props) => {
 			<div className='action-buttons'>
 				{props.children}
 				{props.children ? <div className='divider' /> : null}
-				<Button onClick={props.showAbout}>About</Button>
+				<Button onClick={modals.showAbout}>About</Button>
 			</div>
 		</div>
 	);

--- a/src/components/panels/elements/hero-panel/hero-panel.tsx
+++ b/src/components/panels/elements/hero-panel/hero-panel.tsx
@@ -3,13 +3,9 @@ import { Ability } from '../../../../models/ability';
 import { AbilityLogic } from '../../../../logic/ability-logic';
 import { AbilityPanel } from '../ability-panel/ability-panel';
 import { AbilityUsage } from '../../../../enums/ability-usage';
-import { Ancestry } from '../../../../models/ancestry';
-import { Career } from '../../../../models/career';
 import { Characteristic } from '../../../../enums/characteristic';
-import { Complication } from '../../../../models/complication';
 import { ConditionEndType } from '../../../../enums/condition-type';
 import { ConditionLogic } from '../../../../logic/condition-logic';
-import { Culture } from '../../../../models/culture';
 import { CultureData } from '../../../../data/culture-data';
 import { DamageModifierType } from '../../../../enums/damage-modifier-type';
 import { Domain } from '../../../../models/domain';
@@ -20,7 +16,6 @@ import { Field } from '../../../controls/field/field';
 import { FormatLogic } from '../../../../logic/format-logic';
 import { HeaderText } from '../../../controls/header-text/header-text';
 import { Hero } from '../../../../models/hero';
-import { HeroClass } from '../../../../models/class';
 import { HeroLogic } from '../../../../logic/hero-logic';
 import { Kit } from '../../../../models/kit';
 import { Options } from '../../../../models/options';
@@ -29,6 +24,7 @@ import { SelectablePanel } from '../../../controls/selectable-panel/selectable-p
 import { Skill } from '../../../../models/skill';
 import { SkillList } from '../../../../enums/skill-list';
 import { Sourcebook } from '../../../../models/sourcebook';
+import { useModals } from '../../../../hooks/use-modals';
 
 import './hero-panel.scss';
 
@@ -37,60 +33,48 @@ interface Props {
 	sourcebooks: Sourcebook[];
 	options?: Options;
 	mode?: PanelMode;
-	onSelectAncestry?: (ancestry: Ancestry) => void;
-	onSelectCulture?: (culture: Culture) => void;
-	onSelectCareer?: (career: Career) => void;
-	onSelectClass?: (heroClass: HeroClass) => void;
-	onSelectComplication?: (complication: Complication) => void;
-	onSelectDomain?: (domain: Domain) => void;
-	onSelectKit?: (kit: Kit) => void;
-	onSelectCharacteristic?: (characteristic: Characteristic) => void;
-	onSelectAbility?: (ability: Ability) => void;
-	onShowState?: (page: 'hero' | 'stats' | 'conditions') => void;
 }
 
 export const HeroPanel = (props: Props) => {
+	const modals = useModals();
+
 	const getLeftColumn = () => {
 		const onSelectAncestry = () => {
-			if (props.hero.ancestry && props.onSelectAncestry) {
-				props.onSelectAncestry(props.hero.ancestry);
+			if (props.hero.ancestry) {
+				modals.showAncestry(props.hero.ancestry.id);
 			}
 		};
 
 		const onSelectCulture = () => {
-			if (props.hero.culture && props.onSelectCulture) {
-				props.onSelectCulture(props.hero.culture);
+			if (props.hero.culture) {
+				modals.showCulture(props.hero.culture.id);
 			}
 		};
 
 		const onSelectCareer = () => {
-			if (props.hero.career && props.onSelectCareer) {
-				props.onSelectCareer(props.hero.career);
+			if (props.hero.career) {
+				modals.showCareer(props.hero.career.id);
 			}
 		};
 
 		const onSelectClass = () => {
-			if (props.hero.class && props.onSelectClass) {
-				props.onSelectClass(props.hero.class);
+			if (props.hero.class) {
+				modals.showClass(props.hero.class.id);
 			}
 		};
 
 		const onSelectComplication = () => {
-			if (props.hero.complication && props.onSelectComplication) {
-				props.onSelectComplication(props.hero.complication);
+			if (props.hero.complication) {
+				modals.showComplication(props.hero.complication.id);
 			}
 		};
 
 		const onSelectDomain = (domain: Domain) => {
-			if (props.onSelectDomain) {
-				props.onSelectDomain(domain);
-			}
+			modals.showDomain(domain.id);
 		};
 
 		const onSelectKit = (kit: Kit) => {
-			if (props.onSelectKit) {
-				props.onSelectKit(kit);
-			}
+			modals.showKit(kit.id);
 		};
 
 		let incitingIncident: Element | null = null;
@@ -267,24 +251,6 @@ export const HeroPanel = (props: Props) => {
 			xxl: 8
 		};
 
-		const onSelectCharacteristic = (characteristic: Characteristic) => {
-			if (props.onSelectCharacteristic) {
-				props.onSelectCharacteristic(characteristic);
-			}
-		};
-
-		const onShowHero = () => {
-			if (props.onShowState) {
-				props.onShowState('hero');
-			}
-		};
-
-		const onShowStats = () => {
-			if (props.onShowState) {
-				props.onShowState('stats');
-			}
-		};
-
 		const maxStamina = HeroLogic.getStamina(props.hero);
 		const stamina = props.hero.state.staminaDamage === 0 ? maxStamina : maxStamina - props.hero.state.staminaDamage;
 		const staminaSuffix = props.hero.state.staminaDamage === 0 ? null : `/ ${maxStamina}`;
@@ -297,19 +263,19 @@ export const HeroPanel = (props: Props) => {
 			<Row gutter={[ 16, 16 ]}>
 				<Col span={24}>
 					<div className='characteristics-box'>
-						<div className='characteristic clickable' onClick={() => onSelectCharacteristic(Characteristic.Might)}>
+						<div className='characteristic clickable' onClick={() => modals.showHeroCharacteristic(props.hero.id, Characteristic.Might)}>
 							<Statistic title='Might' value={HeroLogic.getCharacteristic(props.hero, Characteristic.Might)} />
 						</div>
-						<div className='characteristic clickable' onClick={() => onSelectCharacteristic(Characteristic.Agility)}>
+						<div className='characteristic clickable' onClick={() => modals.showHeroCharacteristic(props.hero.id, Characteristic.Agility)}>
 							<Statistic title='Agility' value={HeroLogic.getCharacteristic(props.hero, Characteristic.Agility)} />
 						</div>
-						<div className='characteristic clickable' onClick={() => onSelectCharacteristic(Characteristic.Reason)}>
+						<div className='characteristic clickable' onClick={() => modals.showHeroCharacteristic(props.hero.id, Characteristic.Reason)}>
 							<Statistic title='Reason' value={HeroLogic.getCharacteristic(props.hero, Characteristic.Reason)} />
 						</div>
-						<div className='characteristic clickable' onClick={() => onSelectCharacteristic(Characteristic.Intuition)}>
+						<div className='characteristic clickable' onClick={() => modals.showHeroCharacteristic(props.hero.id, Characteristic.Intuition)}>
 							<Statistic title='Intuition' value={HeroLogic.getCharacteristic(props.hero, Characteristic.Intuition)} />
 						</div>
-						<div className='characteristic clickable' onClick={() => onSelectCharacteristic(Characteristic.Presence)}>
+						<div className='characteristic clickable' onClick={() => modals.showHeroCharacteristic(props.hero.id, Characteristic.Presence)}>
 							<Statistic title='Presence' value={HeroLogic.getCharacteristic(props.hero, Characteristic.Presence)} />
 						</div>
 					</div>
@@ -331,7 +297,7 @@ export const HeroPanel = (props: Props) => {
 					</div>
 				</Col>
 				<Col xs={sizeSmall.xs} sm={sizeSmall.sm} md={sizeSmall.md} lg={sizeSmall.lg} xl={sizeSmall.xl} xxl={sizeSmall.xxl}>
-					<div className='characteristics-box clickable' onClick={onShowStats}>
+					<div className='characteristics-box clickable' onClick={() => modals.showHeroState(props.hero.id, 'stats')}>
 						<div className='characteristic'>
 							<Statistic title='Hero Tokens' value={props.hero.state.heroTokens} />
 						</div>
@@ -344,7 +310,7 @@ export const HeroPanel = (props: Props) => {
 					</div>
 				</Col>
 				<Col xs={sizeLarge.xs} sm={sizeLarge.sm} md={sizeLarge.md} lg={sizeLarge.lg} xl={sizeLarge.xl} xxl={sizeLarge.xxl}>
-					<div className='characteristics-box clickable' onClick={onShowHero}>
+					<div className='characteristics-box clickable' onClick={() => modals.showHeroState(props.hero.id, 'hero')}>
 						<div className='characteristic'>
 							<Statistic title={props.hero.class ? props.hero.class.heroicResource : 'Resource'} value={props.hero.state.heroicResource} />
 						</div>
@@ -360,7 +326,7 @@ export const HeroPanel = (props: Props) => {
 					</div>
 				</Col>
 				<Col xs={sizeSmall.xs} sm={sizeSmall.sm} md={sizeSmall.md} lg={sizeSmall.lg} xl={sizeSmall.xl} xxl={sizeSmall.xxl}>
-					<div className='characteristics-box clickable' onClick={onShowHero}>
+					<div className='characteristics-box clickable' onClick={() => modals.showHeroState(props.hero.id, 'hero')}>
 						<div className='characteristic'>
 							<Statistic title='Stamina' value={stamina} suffix={staminaSuffix} />
 						</div>
@@ -381,19 +347,13 @@ export const HeroPanel = (props: Props) => {
 			return null;
 		}
 
-		const openConditions = () => {
-			if (props.onShowState) {
-				props.onShowState('conditions');
-			}
-		};
-
 		return (
 			<div className='conditions-section'>
 				<HeaderText level={1}>Conditions</HeaderText>
 				<div className='conditions-grid'>
 					{
 						props.hero.state.conditions.map(c => (
-							<div key={c.id} className='condition-tile' onClick={openConditions}>
+							<div key={c.id} className='condition-tile' onClick={() => modals.showHeroState(props.hero.id, 'conditions')}>
 								<HeaderText>
 									{
 										(c.ends === ConditionEndType.ResistanceEnds) ?
@@ -443,12 +403,6 @@ export const HeroPanel = (props: Props) => {
 			return null;
 		}
 
-		const onSelectAbility = (ability: Ability) => {
-			if (props.onSelectAbility) {
-				props.onSelectAbility(ability);
-			}
-		};
-
 		return (
 			<div className='abilities-section'>
 				<HeaderText level={1}>{type}s</HeaderText>
@@ -456,7 +410,7 @@ export const HeroPanel = (props: Props) => {
 					{
 						abilities.map(ability => (
 							<SelectablePanel key={ability.id} style={{ gridColumn: `span ${AbilityLogic.panelWidth(ability)}` }}>
-								<AbilityPanel ability={ability} hero={props.hero} options={props.options} mode={PanelMode.Full} onRoll={() => onSelectAbility(ability)} />
+								<AbilityPanel ability={ability} hero={props.hero} options={props.options} mode={PanelMode.Full} onRoll={() => modals.showHeroAbility(props.hero.id, ability.id)} />
 							</SelectablePanel>
 						))
 					}

--- a/src/hooks/use-modals.ts
+++ b/src/hooks/use-modals.ts
@@ -1,0 +1,65 @@
+import type { Characteristic } from '../enums/characteristic';
+import { useNavigate } from 'react-router';
+
+export const useModals = () => {
+	const navigate = useNavigate();
+	return {
+		showAbout() {
+			return navigate({ hash: 'about' });
+		},
+		showAncestry(ancestryId: string) {
+			return navigate({ hash: `ancestry/${ancestryId}` });
+		},
+		showCareer(careerId: string) {
+			return navigate({ hash: `career/${careerId}` });
+		},
+		showClass(classId: string) {
+			return navigate({ hash: `class/${classId}` });
+		},
+		showComplication(complicationId: string) {
+			return navigate({ hash: `complication/${complicationId}` });
+		},
+		showCulture(cultureId: string) {
+			return navigate({ hash: `culture/${cultureId}` });
+		},
+		showDomain(domainId: string) {
+			return navigate({ hash: `domain/${domainId}` });
+		},
+		showEncounter(encounterId: string) {
+			return navigate({ hash: `encounter/${encounterId}` });
+		},
+		showHeroAbility(heroId: string, abilityId: string) {
+			return navigate({ hash: `hero/${heroId}/ability/${abilityId}` });
+		},
+		showHeroCharacteristic(heroId: string, characteristic: Characteristic) {
+			return navigate({ hash: `hero/${heroId}/characteristic/${characteristic}` });
+		},
+		showHeroRules(heroId: string) {
+			return navigate({ hash: `hero/${heroId}/rules` });
+		},
+		showHeroState(heroId: string, page: 'hero' | 'stats' | 'conditions') {
+			return navigate({ hash: `hero/${heroId}/${page}` });
+		},
+		showItem(itemId: string) {
+			return navigate({ hash: `item/${itemId}` });
+		},
+		showKit(kitId: string) {
+			return navigate({ hash: `kit/${kitId}` });
+		},
+		showMonster(monsterId: string) {
+			return navigate({ hash: `monster/${monsterId}` });
+		},
+		showMonsterGroup(monsterGroupId: string) {
+			return navigate({ hash: `monster-group/${monsterGroupId}` });
+		},
+		showPerk(perkId: string) {
+			return navigate({ hash: `perk/${perkId}` });
+		},
+		showSourcebooks() {
+			return navigate({ hash: 'sourcebooks' });
+		},
+		showTitle(titleId: string) {
+			return navigate({ hash: `title/${titleId}` });
+		}
+	};
+};


### PR DESCRIPTION
Redo of #35 with just the drawer hash routing, and without the persisted data hooks.

Drawer opens based on hash route of the url.

Hash route is set or cleared with functions from `useModals` hook.