### PR TITLE
Ability model with optional properties

### DIFF
--- a/src/components/controls/markdown/markdown.tsx
+++ b/src/components/controls/markdown/markdown.tsx
@@ -1,7 +1,7 @@
 import { Utils } from '../../../utils/utils';
 
 interface Props {
-	text: string;
+	text: string | undefined;
 	useSpan?: boolean;
 }
 

--- a/src/components/controls/multi-line/multi-line.tsx
+++ b/src/components/controls/multi-line/multi-line.tsx
@@ -5,7 +5,7 @@ import './multi-line.scss';
 
 interface Props {
 	label: string;
-	value: string;
+	value?: string;
 	onChange: (value: string) => void;
 }
 

--- a/src/components/pages/heroes/hero-edit/hero-edit-page.tsx
+++ b/src/components/pages/heroes/hero-edit/hero-edit-page.tsx
@@ -49,11 +49,11 @@ type HeroTab = 'ancestry' | 'culture' | 'career' | 'class' | 'complication' | 'd
 
 const matchElement = (element: Element, searchTerm: string) => {
 	const name = element.name.toLowerCase();
-	const desc = element.description.toLowerCase();
+	const desc = element.description?.toLowerCase();
 	return searchTerm
 		.toLowerCase()
 		.split(' ')
-		.some(token => name.includes(token) || desc.includes(token));
+		.some(token => name.includes(token) || desc?.includes(token));
 };
 
 interface Props {

--- a/src/components/panels/edit/ability-edit-panel/ability-edit-panel.tsx
+++ b/src/components/panels/edit/ability-edit-panel/ability-edit-panel.tsx
@@ -35,7 +35,12 @@ export const AbilityEditPanel = (props: Props) => {
 
 	const setDescription = (value: string) => {
 		const copy = JSON.parse(JSON.stringify(ability)) as Ability;
-		copy.description = value;
+		if (value) {
+			copy.description = value;
+		}
+		else {
+			delete copy.description;
+		}
 		setAbility(copy);
 		props.onChange(copy);
 	};
@@ -190,21 +195,36 @@ export const AbilityEditPanel = (props: Props) => {
 
 	const setCost = (value: number | 'signature') => {
 		const copy = JSON.parse(JSON.stringify(ability)) as Ability;
-		copy.cost = value;
+		if (value) {
+			copy.cost = value;
+		}
+		else {
+			delete copy.cost;
+		}
 		setAbility(copy);
 		props.onChange(copy);
 	};
 
 	const setPreEffect = (value: string) => {
 		const copy = JSON.parse(JSON.stringify(ability)) as Ability;
-		copy.preEffect = value;
+		if (value) {
+			copy.preEffect = value;
+		}
+		else {
+			delete copy.preEffect;
+		}
 		setAbility(copy);
 		props.onChange(copy);
 	};
 
 	const setPowerRoll = (value: boolean) => {
 		const copy = JSON.parse(JSON.stringify(ability)) as Ability;
-		copy.powerRoll = value ? FactoryLogic.createPowerRoll({ characteristic: [], tier1: '', tier2: '', tier3: '' }) : null;
+		if (value) {
+			copy.powerRoll = FactoryLogic.createPowerRoll({ characteristic: [], tier1: '', tier2: '', tier3: '' })
+		}
+		else {
+			delete copy.powerRoll;
+		}
 		setAbility(copy);
 		props.onChange(copy);
 	};
@@ -247,13 +267,19 @@ export const AbilityEditPanel = (props: Props) => {
 
 	const setEffect = (value: string) => {
 		const copy = JSON.parse(JSON.stringify(ability)) as Ability;
-		copy.effect = value;
+		if (value) {
+			copy.effect = value;
+		}
+		else {
+			delete copy.effect;
+		}
 		setAbility(copy);
 		props.onChange(copy);
 	};
 
 	const addAlternateEffect = () => {
 		const copy = JSON.parse(JSON.stringify(ability)) as Ability;
+		copy.alternateEffects = copy.alternateEffects ?? [];
 		copy.alternateEffects.push('');
 		setAbility(copy);
 		props.onChange(copy);
@@ -261,27 +287,33 @@ export const AbilityEditPanel = (props: Props) => {
 
 	const setAlternateEffect = (index: number, value: string) => {
 		const copy = JSON.parse(JSON.stringify(ability)) as Ability;
-		copy.alternateEffects[index] = value;
+		copy.alternateEffects![index] = value;
 		setAbility(copy);
 		props.onChange(copy);
 	};
 
 	const moveAlternateEffect = (index: number, direction: 'up' | 'down') => {
 		const copy = JSON.parse(JSON.stringify(ability)) as Ability;
-		copy.alternateEffects = Collections.move(copy.alternateEffects, index, direction);
+		copy.alternateEffects = Collections.move(copy.alternateEffects!, index, direction);
 		setAbility(copy);
 		props.onChange(copy);
 	};
 
 	const deleteAlternateEffect = (index: number) => {
 		const copy = JSON.parse(JSON.stringify(ability)) as Ability;
-		copy.alternateEffects.splice(index, 1);
+		if (copy.alternateEffects?.length && copy.alternateEffects.length >= 1) {
+			copy.alternateEffects!.splice(index, 1);
+		}
+		else {
+			delete copy.alternateEffects;
+		}
 		setAbility(copy);
 		props.onChange(copy);
 	};
 
 	const addSpend = () => {
 		const copy = JSON.parse(JSON.stringify(ability)) as Ability;
+		copy.spend = copy.spend ?? [];
 		copy.spend.push({ name: '', effect: '', value: 1, repeatable: false });
 		setAbility(copy);
 		props.onChange(copy);
@@ -289,34 +321,40 @@ export const AbilityEditPanel = (props: Props) => {
 
 	const setSpendValue = (index: number, value: number) => {
 		const copy = JSON.parse(JSON.stringify(ability)) as Ability;
-		copy.spend[index].value = value;
+		copy.spend![index].value = value;
 		setAbility(copy);
 		props.onChange(copy);
 	};
 
 	const setSpendEffect = (index: number, value: string) => {
 		const copy = JSON.parse(JSON.stringify(ability)) as Ability;
-		copy.spend[index].effect = value;
+		copy.spend![index].effect = value;
 		setAbility(copy);
 		props.onChange(copy);
 	};
 
 	const moveSpend = (index: number, direction: 'up' | 'down') => {
 		const copy = JSON.parse(JSON.stringify(ability)) as Ability;
-		copy.spend = Collections.move(copy.spend, index, direction);
+		copy.spend = Collections.move(copy.spend!, index, direction);
 		setAbility(copy);
 		props.onChange(copy);
 	};
 
 	const deleteSpend = (index: number) => {
 		const copy = JSON.parse(JSON.stringify(ability)) as Ability;
-		copy.spend.splice(index, 1);
+		if (copy.spend?.length && copy.spend.length >= 1) {
+			copy.spend!.splice(index, 1);
+		}
+		else {
+			delete copy.spend;
+		}
 		setAbility(copy);
 		props.onChange(copy);
 	};
 
 	const addPersistence = () => {
 		const copy = JSON.parse(JSON.stringify(ability)) as Ability;
+		copy.persistence = copy.persistence ?? [];
 		copy.persistence.push({ effect: '', value: 1 });
 		setAbility(copy);
 		props.onChange(copy);
@@ -324,35 +362,45 @@ export const AbilityEditPanel = (props: Props) => {
 
 	const setPersistenceValue = (index: number, value: number) => {
 		const copy = JSON.parse(JSON.stringify(ability)) as Ability;
-		copy.persistence[index].value = value;
+		copy.persistence![index].value = value;
 		setAbility(copy);
 		props.onChange(copy);
 	};
 
 	const setPersistenceEffect = (index: number, value: string) => {
 		const copy = JSON.parse(JSON.stringify(ability)) as Ability;
-		copy.persistence[index].effect = value;
+		copy.persistence![index].effect = value;
 		setAbility(copy);
 		props.onChange(copy);
 	};
 
 	const movePersistence = (index: number, direction: 'up' | 'down') => {
 		const copy = JSON.parse(JSON.stringify(ability)) as Ability;
-		copy.persistence = Collections.move(copy.persistence, index, direction);
+		copy.persistence = Collections.move(copy.persistence!, index, direction);
 		setAbility(copy);
 		props.onChange(copy);
 	};
 
 	const deletePersistence = (index: number) => {
 		const copy = JSON.parse(JSON.stringify(ability)) as Ability;
-		copy.persistence.splice(index, 1);
+		if (copy.persistence?.length && copy.persistence.length >= 1) {
+			copy.persistence!.splice(index, 1);
+		}
+		else {
+			delete copy.persistence;
+		}
 		setAbility(copy);
 		props.onChange(copy);
 	};
 
 	const setStrained = (value: string) => {
 		const copy = JSON.parse(JSON.stringify(ability)) as Ability;
-		copy.strained = value;
+		if (value) {
+			copy.strained = value;
+		}
+		else {
+			delete copy.strained;
+		}
 		setAbility(copy);
 		props.onChange(copy);
 	};
@@ -548,7 +596,7 @@ export const AbilityEditPanel = (props: Props) => {
 										ability.cost !== 'signature' ?
 											<>
 												<HeaderText>Cost</HeaderText>
-												<NumberSpin min={0} value={ability.cost} onChange={setCost} />
+												<NumberSpin min={0} value={ability.cost ?? 0} onChange={setCost} />
 											</>
 											: null
 									}
@@ -626,108 +674,99 @@ export const AbilityEditPanel = (props: Props) => {
 									<HeaderText>Alternate Effects</HeaderText>
 									<Space direction='vertical' style={{ width: '100%' }}>
 										{
-											ability.alternateEffects.map((effect, n) => (
-												<Expander
-													key={n}
-													title='Alternate Effect'
-													extra={[
-														<Button key='up' type='text' icon={<CaretUpOutlined />} onClick={() => moveAlternateEffect(n, 'up')} />,
-														<Button key='down' type='text' icon={<CaretDownOutlined />} onClick={() => moveAlternateEffect(n, 'down')} />,
-														<DangerButton key='delete' mode='icon' onConfirm={() => deleteAlternateEffect(n)} />
-													]}
-												>
-													<Input
-														className={effect === '' ? 'input-empty' : ''}
-														placeholder='Alternate Effect'
-														allowClear={true}
-														value={effect}
-														onChange={e => setAlternateEffect(n, e.target.value)}
-													/>
-												</Expander>
-											))
-										}
-										{
-											ability.alternateEffects.length === 0 ?
-												<Alert
+											ability.alternateEffects?.length
+												? ability.alternateEffects.map((effect, n) => (
+													<Expander
+														key={n}
+														title='Alternate Effect'
+														extra={[
+															<Button key='up' type='text' icon={<CaretUpOutlined />} onClick={() => moveAlternateEffect(n, 'up')} />,
+															<Button key='down' type='text' icon={<CaretDownOutlined />} onClick={() => moveAlternateEffect(n, 'down')} />,
+															<DangerButton key='delete' mode='icon' onConfirm={() => deleteAlternateEffect(n)} />
+														]}
+													>
+														<Input
+															className={effect === '' ? 'input-empty' : ''}
+															placeholder='Alternate Effect'
+															allowClear={true}
+															value={effect}
+															onChange={e => setAlternateEffect(n, e.target.value)}
+														/>
+													</Expander>
+												))
+												: <Alert
 													type='warning'
 													showIcon={true}
 													message='No alternate effects'
 												/>
-												: null
 										}
 										<Button block={true} onClick={addAlternateEffect}>Add an alternate effect</Button>
 									</Space>
 									<HeaderText>Spend</HeaderText>
 									<Space direction='vertical' style={{ width: '100%' }}>
 										{
-											ability.spend.map((spend, n) => (
-												<Expander
-													key={n}
-													title='Spend Effect'
-													extra={[
-														<Button key='up' type='text' icon={<CaretUpOutlined />} onClick={() => moveSpend(n, 'up')} />,
-														<Button key='down' type='text' icon={<CaretDownOutlined />} onClick={() => moveSpend(n, 'down')} />,
-														<DangerButton key='delete' mode='icon' onConfirm={() => deleteSpend(n)} />
-													]}
-												>
-													<Space direction='vertical' style={{ width: '100%' }}>
-														<Input
-															className={spend.effect === '' ? 'input-empty' : ''}
-															placeholder='Spend effect'
-															allowClear={true}
-															value={spend.effect}
-															onChange={e => setSpendEffect(n, e.target.value)}
-														/>
-														<NumberSpin min={0} value={spend.value} onChange={value => setSpendValue(n, value)} />
-													</Space>
-												</Expander>
-											))
-										}
-										{
-											ability.spend.length === 0 ?
-												<Alert
+											ability.spend?.length
+												? ability.spend.map((spend, n) => (
+													<Expander
+														key={n}
+														title='Spend Effect'
+														extra={[
+															<Button key='up' type='text' icon={<CaretUpOutlined />} onClick={() => moveSpend(n, 'up')} />,
+															<Button key='down' type='text' icon={<CaretDownOutlined />} onClick={() => moveSpend(n, 'down')} />,
+															<DangerButton key='delete' mode='icon' onConfirm={() => deleteSpend(n)} />
+														]}
+													>
+														<Space direction='vertical' style={{ width: '100%' }}>
+															<Input
+																className={spend.effect === '' ? 'input-empty' : ''}
+																placeholder='Spend effect'
+																allowClear={true}
+																value={spend.effect}
+																onChange={e => setSpendEffect(n, e.target.value)}
+															/>
+															<NumberSpin min={0} value={spend.value} onChange={value => setSpendValue(n, value)} />
+														</Space>
+													</Expander>
+												))
+												: <Alert
 													type='warning'
 													showIcon={true}
 													message='No spend effects'
 												/>
-												: null
 										}
 										<Button block={true} onClick={addSpend}>Add a spend effect</Button>
 									</Space>
 									<HeaderText>Persistence</HeaderText>
 									<Space direction='vertical' style={{ width: '100%' }}>
 										{
-											ability.persistence.map((persist, n) => (
-												<Expander
-													key={n}
-													title='Persistence Effect'
-													extra={[
-														<Button key='up' type='text' icon={<CaretUpOutlined />} onClick={() => movePersistence(n, 'up')} />,
-														<Button key='down' type='text' icon={<CaretDownOutlined />} onClick={() => movePersistence(n, 'down')} />,
-														<DangerButton key='delete' mode='icon' onConfirm={() => deletePersistence(n)} />
-													]}
-												>
-													<Space direction='vertical' style={{ width: '100%' }}>
-														<Input
-															className={persist.effect === '' ? 'input-empty' : ''}
-															placeholder='Persistence Effect'
-															allowClear={true}
-															value={persist.effect}
-															onChange={e => setPersistenceEffect(n, e.target.value)}
-														/>
-														<NumberSpin min={0} value={persist.value} onChange={value => setPersistenceValue(n, value)} />
-													</Space>
-												</Expander>
-											))
-										}
-										{
-											ability.persistence.length === 0 ?
-												<Alert
+											ability.persistence?.length
+												? ability.persistence.map((persist, n) => (
+													<Expander
+														key={n}
+														title='Persistence Effect'
+														extra={[
+															<Button key='up' type='text' icon={<CaretUpOutlined />} onClick={() => movePersistence(n, 'up')} />,
+															<Button key='down' type='text' icon={<CaretDownOutlined />} onClick={() => movePersistence(n, 'down')} />,
+															<DangerButton key='delete' mode='icon' onConfirm={() => deletePersistence(n)} />
+														]}
+													>
+														<Space direction='vertical' style={{ width: '100%' }}>
+															<Input
+																className={persist.effect === '' ? 'input-empty' : ''}
+																placeholder='Persistence Effect'
+																allowClear={true}
+																value={persist.effect}
+																onChange={e => setPersistenceEffect(n, e.target.value)}
+															/>
+															<NumberSpin min={0} value={persist.value} onChange={value => setPersistenceValue(n, value)} />
+														</Space>
+													</Expander>
+												))
+												: <Alert
 													type='warning'
 													showIcon={true}
 													message='No persistence effects'
 												/>
-												: null
 										}
 										<Button block={true} onClick={addPersistence}>Add a persistence effect</Button>
 										<HeaderText>Strained</HeaderText>

--- a/src/components/panels/edit/feature-edit-panel/feature-edit-panel.tsx
+++ b/src/components/panels/edit/feature-edit-panel/feature-edit-panel.tsx
@@ -58,15 +58,13 @@ export const FeatureEditPanel = (props: Props) => {
 		switch (value) {
 			case FeatureType.Ability:
 				data = {
-					ability: FactoryLogic.createAbility({
+					ability: {
 						id: Utils.guid(),
 						name: '',
-						description: '',
 						type: FactoryLogic.type.createAction(),
-						keywords: [],
 						distance: [ FactoryLogic.distance.createMelee() ],
 						target: ''
-					})
+					}
 				};
 				break;
 			case FeatureType.AbilityCost:

--- a/src/components/panels/elements/ability-panel/ability-panel.tsx
+++ b/src/components/panels/elements/ability-panel/ability-panel.tsx
@@ -29,15 +29,16 @@ interface Props {
 }
 
 export const AbilityPanel = (props: Props) => {
+	// const abilityWithDefaults = useMemo(() => )
 	const cost = useMemo(
 		() => {
 			const cost = props.cost ?? props.ability.cost;
-			if (cost === 'signature' || cost <= 0 || !props.hero) {
+			if (cost === 'signature' || !cost || !props.hero) {
 				return cost;
 			}
 			const modifierSum = HeroLogic.getFeatures(props.hero)
 				.filter(f => f.type === FeatureType.AbilityCost)
-				.filter(f => f.data.keywords.every(k => props.ability.keywords.includes(k)))
+				.filter(f => f.data.keywords.every(k => props.ability.keywords?.includes(k)))
 				.map(f => f.data.modifier)
 				.reduce((sum, m) => sum + m, 0);
 
@@ -48,13 +49,14 @@ export const AbilityPanel = (props: Props) => {
 	const headerRibbon = useMemo(
 		() => cost === 'signature'
 			? (<Badge>Signature</Badge>)
-			: cost > 0 ? (<HeroicResourceBadge value={cost} />) : null,
+			: cost ? (<HeroicResourceBadge value={cost} />) : null,
 		[ cost ]
 	);
 	const disabled = useMemo(
 		() => (props.options?.dimUnavailableAbilities ?? false)
 			&& props.hero
 			&& cost !== 'signature'
+			&& cost
 			&& cost > props.hero.state.heroicResource,
 		[ props.hero, props.options, cost ]
 	);
@@ -74,7 +76,7 @@ export const AbilityPanel = (props: Props) => {
 					props.mode === PanelMode.Full ?
 						<div>
 							{
-								props.ability.keywords.length > 0 ?
+								props.ability.keywords?.length ?
 									<Field label='Keywords' value={props.ability.keywords.map((k, n) => <Tag key={n}>{k}</Tag>)} />
 									: null
 							}
@@ -112,7 +114,7 @@ export const AbilityPanel = (props: Props) => {
 									: null
 							}
 							{
-								props.ability.alternateEffects.map((effect, n) => (
+								props.ability.alternateEffects?.map((effect, n) => (
 									<Field
 										key={n}
 										label='Alternate Effect'
@@ -121,7 +123,7 @@ export const AbilityPanel = (props: Props) => {
 								))
 							}
 							{
-								props.ability.spend.map((spend, n) => (
+								props.ability.spend?.map((spend, n) => (
 									<Field
 										key={n}
 										disabled={props.hero && (props.options?.dimUnavailableAbilities || false) && (spend.value > props.hero.state.heroicResource)}
@@ -136,7 +138,7 @@ export const AbilityPanel = (props: Props) => {
 								))
 							}
 							{
-								props.ability.persistence.map((persist, n) => (
+								props.ability.persistence?.map((persist, n) => (
 									<Field
 										key={n}
 										label={(

--- a/src/components/panels/elements/ability-panel/ability-panel.tsx
+++ b/src/components/panels/elements/ability-panel/ability-panel.tsx
@@ -29,7 +29,6 @@ interface Props {
 }
 
 export const AbilityPanel = (props: Props) => {
-	// const abilityWithDefaults = useMemo(() => )
 	const cost = useMemo(
 		() => {
 			const cost = props.cost ?? props.ability.cost;

--- a/src/components/panels/elements/feature-panel/feature-panel.tsx
+++ b/src/components/panels/elements/feature-panel/feature-panel.tsx
@@ -123,7 +123,7 @@ export const FeaturePanel = (props: Props) => {
 	};
 
 	const getEditableClassAbility = (data: FeatureClassAbilityData) => {
-		const abilities = props.hero?.class?.abilities.filter(a => a.cost === data.cost).filter(a => a.minLevel <= data.minLevel) || [];
+		const abilities = props.hero?.class?.abilities.filter(a => a.cost === data.cost).filter(a => !a.minLevel || a.minLevel <= data.minLevel) || [];
 
 		const distinctAbilities = Collections.distinct(abilities, a => a.name);
 		const sortedAbilities = Collections.sort(distinctAbilities, a => a.name);

--- a/src/data/monsters/radenwight.ts
+++ b/src/data/monsters/radenwight.ts
@@ -41,7 +41,7 @@ In truth, The Great Maclette finds beauty in the thrill of the heist. Robbery is
 	],
 	malice: [
 		FactoryLogic.feature.createAbility({
-			ability: FactoryLogic.createAbility({
+			ability: {
 				id: 'radenwight-malice-1',
 				name: 'Trouser Cut',
 				type: FactoryLogic.type.createAction({ qualifiers: [ 'Non-minion' ] }),
@@ -56,7 +56,7 @@ In truth, The Great Maclette finds beauty in the thrill of the heist. Robbery is
 					tier3: '13 damage; push 5; taunted (EoT)'
 				}),
 				effect: 'If a target is wearing clothing covering the lower half of their body, they must use a maneuver to pull that clothing up before they can move.'
-			})
+			}
 		}),
 		FactoryLogic.feature.createMalice({
 			id: 'radenwight-malice-2',
@@ -95,7 +95,7 @@ In truth, The Great Maclette finds beauty in the thrill of the heist. Robbery is
 			withCaptain: 'Strike damage +1',
 			features: [
 				FactoryLogic.feature.createAbility({
-					ability: FactoryLogic.createAbility({
+					ability: {
 						id: 'radenwight-1-feature-1',
 						name: 'Dagger Dance',
 						type: FactoryLogic.type.createAction(),
@@ -113,10 +113,10 @@ In truth, The Great Maclette finds beauty in the thrill of the heist. Robbery is
 							tier3: '5 damage'
 						}),
 						effect: 'If the mischiever is hidden when they use this ability, they can target two creatures.'
-					})
+					}
 				}),
 				FactoryLogic.feature.createAbility({
-					ability: FactoryLogic.createAbility({
+					ability: {
 						id: 'radenwight-1-feature-2',
 						name: 'Ready Rodent',
 						type: FactoryLogic.type.createTrigger('An ally deals damage to the target.'),
@@ -124,7 +124,7 @@ In truth, The Great Maclette finds beauty in the thrill of the heist. Robbery is
 						distance: [ FactoryLogic.distance.createMelee() ],
 						target: 'One creature',
 						effect: 'The mischiever makes a free strike against the target.'
-					})
+					}
 				})
 			]
 		}),
@@ -144,7 +144,7 @@ In truth, The Great Maclette finds beauty in the thrill of the heist. Robbery is
 			withCaptain: 'Melee distance +2',
 			features: [
 				FactoryLogic.feature.createAbility({
-					ability: FactoryLogic.createAbility({
+					ability: {
 						id: 'radenwight-2-feature-1',
 						name: 'Buckler Bash',
 						type: FactoryLogic.type.createAction(),
@@ -158,10 +158,10 @@ In truth, The Great Maclette finds beauty in the thrill of the heist. Robbery is
 							tier2: '2 damage; taunted (EoT)',
 							tier3: '3 damage; taunted (EoT)'
 						})
-					})
+					}
 				}),
 				FactoryLogic.feature.createAbility({
-					ability: FactoryLogic.createAbility({
+					ability: {
 						id: 'radenwight-2-feature-2',
 						name: 'Ready Rodent',
 						type: FactoryLogic.type.createTrigger('An ally deals damage to the target.'),
@@ -169,7 +169,7 @@ In truth, The Great Maclette finds beauty in the thrill of the heist. Robbery is
 						distance: [ FactoryLogic.distance.createMelee() ],
 						target: 'One creature',
 						effect: 'The scrapper makes a free strike against the target.'
-					})
+					}
 				})
 			]
 		}),
@@ -188,7 +188,7 @@ In truth, The Great Maclette finds beauty in the thrill of the heist. Robbery is
 			withCaptain: 'Edge on strikes',
 			features: [
 				FactoryLogic.feature.createAbility({
-					ability: FactoryLogic.createAbility({
+					ability: {
 						id: 'radenwight-3-feature-1',
 						name: 'Rapier Flunge',
 						type: FactoryLogic.type.createAction(),
@@ -202,10 +202,10 @@ In truth, The Great Maclette finds beauty in the thrill of the heist. Robbery is
 							tier2: '2 damage; slide 2; shift 2',
 							tier3: '3 damage; slide 3; shift 3'
 						})
-					})
+					}
 				}),
 				FactoryLogic.feature.createAbility({
-					ability: FactoryLogic.createAbility({
+					ability: {
 						id: 'radenwight-3-feature-2',
 						name: 'Ready Rodent',
 						type: FactoryLogic.type.createTrigger('An ally deals damage to the target.'),
@@ -213,7 +213,7 @@ In truth, The Great Maclette finds beauty in the thrill of the heist. Robbery is
 						distance: [ FactoryLogic.distance.createMelee() ],
 						target: 'One creature',
 						effect: 'The swiftpaw makes a free strike against the target.'
-					})
+					}
 				})
 			]
 		}),
@@ -232,7 +232,7 @@ In truth, The Great Maclette finds beauty in the thrill of the heist. Robbery is
 			withCaptain: 'Edge on strikes',
 			features: [
 				FactoryLogic.feature.createAbility({
-					ability: FactoryLogic.createAbility({
+					ability: {
 						id: 'radenwight-4-feature-1',
 						name: 'Eyes-On-Me Shot',
 						type: FactoryLogic.type.createAction(),
@@ -247,10 +247,10 @@ In truth, The Great Maclette finds beauty in the thrill of the heist. Robbery is
 							tier3: '5 damage'
 						}),
 						effect: 'An ally of the redeye within 2 squares of the target can shift up to 2 squares.'
-					})
+					}
 				}),
 				FactoryLogic.feature.createAbility({
-					ability: FactoryLogic.createAbility({
+					ability: {
 						id: 'radenwight-4-feature-2',
 						name: 'Ready Rodent',
 						type: FactoryLogic.type.createTrigger('An ally deals damage to the target.'),
@@ -258,7 +258,7 @@ In truth, The Great Maclette finds beauty in the thrill of the heist. Robbery is
 						distance: [ FactoryLogic.distance.createMelee() ],
 						target: 'One creature',
 						effect: 'The redeye makes a free strike against the target.'
-					})
+					}
 				})
 			]
 		}),
@@ -277,7 +277,7 @@ In truth, The Great Maclette finds beauty in the thrill of the heist. Robbery is
 			characteristics: MonsterLogic.createCharacteristics(2, 1, -1, 0, 0),
 			features: [
 				FactoryLogic.feature.createAbility({
-					ability: FactoryLogic.createAbility({
+					ability: {
 						id: 'radenwight-5-feature-1',
 						name: 'Lockjaw',
 						type: FactoryLogic.type.createAction(),
@@ -292,10 +292,10 @@ In truth, The Great Maclette finds beauty in the thrill of the heist. Robbery is
 							tier3: '12 damage; grabbed'
 						}),
 						effect: 'While the target is grabbed, they take 2 damage at the start of each of the bruxer’s turns.'
-					})
+					}
 				}),
 				FactoryLogic.feature.createAbility({
-					ability: FactoryLogic.createAbility({
+					ability: {
 						id: 'radenwight-5-feature-2',
 						name: 'Flurry of Bites',
 						type: FactoryLogic.type.createAction(),
@@ -309,10 +309,10 @@ In truth, The Great Maclette finds beauty in the thrill of the heist. Robbery is
 							tier2: '5 damage; A<1 bleeding (save ends)',
 							tier3: '8 damage; A<2 bleeding (save ends)'
 						})
-					})
+					}
 				}),
 				FactoryLogic.feature.createAbility({
-					ability: FactoryLogic.createAbility({
+					ability: {
 						id: 'radenwight-5-feature-3',
 						name: 'Ready Rodent',
 						type: FactoryLogic.type.createTrigger('An ally deals damage to the target.'),
@@ -320,7 +320,7 @@ In truth, The Great Maclette finds beauty in the thrill of the heist. Robbery is
 						distance: [ FactoryLogic.distance.createMelee() ],
 						target: 'One creature',
 						effect: 'The bruxer makes a free strike against the target.'
-					})
+					}
 				}),
 				FactoryLogic.feature.create({
 					id: 'radenwight-5-feature-4',
@@ -343,7 +343,7 @@ In truth, The Great Maclette finds beauty in the thrill of the heist. Robbery is
 			characteristics: MonsterLogic.createCharacteristics(0, 0, 0, 2, 1),
 			features: [
 				FactoryLogic.feature.createAbility({
-					ability: FactoryLogic.createAbility({
+					ability: {
 						id: 'radenwight-6-feature-1',
 						name: 'Piercing Trill',
 						type: FactoryLogic.type.createAction(),
@@ -361,10 +361,10 @@ In truth, The Great Maclette finds beauty in the thrill of the heist. Robbery is
 							tier3: '9 sonic damage; push 4'
 						}),
 						effect: 'The piper or an ally within distance regains Stamina equal to half the damage dealt.'
-					})
+					}
 				}),
 				FactoryLogic.feature.createAbility({
-					ability: FactoryLogic.createAbility({
+					ability: {
 						id: 'radenwight-6-feature-2',
 						name: 'Vivace Vivace!',
 						type: FactoryLogic.type.createManeuver(),
@@ -374,10 +374,10 @@ In truth, The Great Maclette finds beauty in the thrill of the heist. Robbery is
 						cost: 3,
 						effect: 'Each target who has used their Ready Rodent ability since their last turn regains the use of their triggered action.',
 						spend: [ { value: 2, effect: 'The area increases to 6 burst.' } ]
-					})
+					}
 				}),
 				FactoryLogic.feature.createAbility({
-					ability: FactoryLogic.createAbility({
+					ability: {
 						id: 'radenwight-6-feature-3',
 						name: 'Ready Rodent',
 						type: FactoryLogic.type.createTrigger('An ally deals damage to the target.'),
@@ -385,7 +385,7 @@ In truth, The Great Maclette finds beauty in the thrill of the heist. Robbery is
 						distance: [ FactoryLogic.distance.createMelee() ],
 						target: 'One creature',
 						effect: 'The piper makes a free strike against the target.'
-					})
+					}
 				}),
 				FactoryLogic.feature.create({
 					id: 'radenwight-6-feature-4',
@@ -408,7 +408,7 @@ In truth, The Great Maclette finds beauty in the thrill of the heist. Robbery is
 			characteristics: MonsterLogic.createCharacteristics(-1, 2, 0, 0, 1),
 			features: [
 				FactoryLogic.feature.createAbility({
-					ability: FactoryLogic.createAbility({
+					ability: {
 						id: 'radenwight-7-feature-2',
 						name: 'En Garde!',
 						type: FactoryLogic.type.createAction(),
@@ -423,10 +423,10 @@ In truth, The Great Maclette finds beauty in the thrill of the heist. Robbery is
 							tier3: '8 damage'
 						}),
 						effect: 'The ratcrobat can shift up to 2 squares after striking the first target, then can shift 1 square after striking the second target.'
-					})
+					}
 				}),
 				FactoryLogic.feature.createAbility({
-					ability: FactoryLogic.createAbility({
+					ability: {
 						id: 'radenwight-7-feature-3',
 						name: 'Over Here, Thanks',
 						type: FactoryLogic.type.createManeuver(),
@@ -434,10 +434,10 @@ In truth, The Great Maclette finds beauty in the thrill of the heist. Robbery is
 						distance: [ FactoryLogic.distance.createMelee() ],
 						target: 'One enemy',
 						effect: 'Slide 3; the ratcrobat can then shift into the any of the squares the target left.'
-					})
+					}
 				}),
 				FactoryLogic.feature.createAbility({
-					ability: FactoryLogic.createAbility({
+					ability: {
 						id: 'radenwight-7-feature-4',
 						name: 'Ready Rodent',
 						type: FactoryLogic.type.createTrigger('An ally deals damage to the target.'),
@@ -445,7 +445,7 @@ In truth, The Great Maclette finds beauty in the thrill of the heist. Robbery is
 						distance: [ FactoryLogic.distance.createMelee() ],
 						target: 'One creature',
 						effect: 'The ratcrobat makes a free strike against the target.'
-					})
+					}
 				}),
 				FactoryLogic.feature.create({
 					id: 'radenwight-7-feature-1',
@@ -470,7 +470,7 @@ In truth, The Great Maclette finds beauty in the thrill of the heist. Robbery is
 			characteristics: MonsterLogic.createCharacteristics(-2, 2, 0, 0, 3),
 			features: [
 				FactoryLogic.feature.createAbility({
-					ability: FactoryLogic.createAbility({
+					ability: {
 						id: 'radenwight-8-feature-1',
 						name: 'Cacophony',
 						type: FactoryLogic.type.createAction(),
@@ -485,10 +485,10 @@ In truth, The Great Maclette finds beauty in the thrill of the heist. Robbery is
 							tier3: '8 sonic damage; slide 5; shift 5'
 						}),
 						effect: 'Each all within distance can use Ready Roden as a free triggered action once before the end of the round.'
-					})
+					}
 				}),
 				FactoryLogic.feature.createAbility({
-					ability: FactoryLogic.createAbility({
+					ability: {
 						id: 'radenwight-8-feature-2',
 						name: 'Tempo Change',
 						type: FactoryLogic.type.createManeuver(),
@@ -507,10 +507,10 @@ In truth, The Great Maclette finds beauty in the thrill of the heist. Robbery is
 								effect: 'Each ally within 3 of a target has their speed increased by 2 until the end of their next turn.'
 							}
 						]
-					})
+					}
 				}),
 				FactoryLogic.feature.createAbility({
-					ability: FactoryLogic.createAbility({
+					ability: {
 						id: 'radenwight-8-feature-3',
 						name: 'Ever Ready Rodent',
 						type: FactoryLogic.type.createTrigger('The target deals damage to an ally or takes damage from an ally.', true),
@@ -519,7 +519,7 @@ In truth, The Great Maclette finds beauty in the thrill of the heist. Robbery is
 						distance: [ FactoryLogic.distance.createRanged(5) ],
 						target: 'One creature',
 						effect: 'The maestro makes a free strike against the target.'
-					})
+					}
 				}),
 				FactoryLogic.feature.create({
 					id: 'radenwight-8-feature-4',
@@ -527,7 +527,7 @@ In truth, The Great Maclette finds beauty in the thrill of the heist. Robbery is
 					description: 'At the end of their turn, the maestro can take 5 damage to end one save ends effect affecting them. This damage can’t be reduced in any way.'
 				}),
 				FactoryLogic.feature.createAbility({
-					ability: FactoryLogic.createAbility({
+					ability: {
 						id: 'radenwight-8-feature-5',
 						name: 'Overture',
 						type: FactoryLogic.type.createVillainAction(),
@@ -535,10 +535,10 @@ In truth, The Great Maclette finds beauty in the thrill of the heist. Robbery is
 						distance: [ FactoryLogic.distance.create({ type: AbilityDistanceType.Burst, value: 10 }) ],
 						target: 'All allies in the burst',
 						effect: 'Each target shifts up to their speed or takes the Defend action.'
-					})
+					}
 				}),
 				FactoryLogic.feature.createAbility({
-					ability: FactoryLogic.createAbility({
+					ability: {
 						id: 'radenwight-8-feature-6',
 						name: 'Solo Act',
 						type: FactoryLogic.type.createVillainAction(),
@@ -546,10 +546,10 @@ In truth, The Great Maclette finds beauty in the thrill of the heist. Robbery is
 						distance: [ FactoryLogic.distance.createRanged(15) ],
 						target: 'One creature',
 						effect: 'Until the end of their next turn, the target halves incoming damage, deals an additional 4 damage on strikes, and their speed is doubled.'
-					})
+					}
 				}),
 				FactoryLogic.feature.createAbility({
-					ability: FactoryLogic.createAbility({
+					ability: {
 						id: 'radenwight-8-feature-7',
 						name: 'Rondo of Rat',
 						type: FactoryLogic.type.createVillainAction(),
@@ -557,7 +557,7 @@ In truth, The Great Maclette finds beauty in the thrill of the heist. Robbery is
 						distance: [ FactoryLogic.distance.create({ type: AbilityDistanceType.Burst, value: 10 }) ],
 						target: 'All dead allies in the burst',
 						effect: 'Each target stands, makes a free strike, then collapses again. Allies of the targets can use Ready Rodent as a free triggered action once in conjunction with these free strikes.'
-					})
+					}
 				})
 			]
 		})

--- a/src/logic/ability-logic.ts
+++ b/src/logic/ability-logic.ts
@@ -31,13 +31,13 @@ export class AbilityLogic {
 	};
 
 	static panelWidth = (ability: Ability) => {
-		const descLength = Math.round(ability.description.split(' ').length / 10);
-		const preEffectLength = Math.round(ability.preEffect.split(' ').length / 10);
+		const descLength = ability.description ? Math.round(ability.description.split(' ').length / 10) : 0;
+		const preEffectLength = ability.preEffect ? Math.round(ability.preEffect.split(' ').length / 10) : 0;
 		const powerRollLength = ability.powerRoll ? 6 : 0;
-		const effectLength = Math.round(ability.effect.split(' ').length / 10);
-		const alternateLength = Collections.sum(ability.alternateEffects, e => Math.round(e.split(' ').length / 10));
-		const spendLength = Collections.sum(ability.spend, e => Math.round(e.effect.split(' ').length / 10));
-		const persistLength = Collections.sum(ability.persistence, e => Math.round(e.effect.split(' ').length / 10));
+		const effectLength = ability.effect ? Math.round(ability.effect.split(' ').length / 10) : 0;
+		const alternateLength = ability.alternateEffects ? Collections.sum(ability.alternateEffects, e => Math.round(e.split(' ').length / 10)) : 0;
+		const spendLength = ability.spend ? Collections.sum(ability.spend, e => Math.round(e.effect.split(' ').length / 10)) : 0;
+		const persistLength = ability.persistence ? Collections.sum(ability.persistence, e => Math.round(e.effect.split(' ').length / 10)) : 0;
 
 		const length = descLength + preEffectLength + powerRollLength + effectLength + alternateLength + spendLength + persistLength;
 		return Math.max(1, Math.round(length / 20));

--- a/src/logic/factory-logic.ts
+++ b/src/logic/factory-logic.ts
@@ -342,44 +342,9 @@ export class FactoryLogic {
 		};
 	};
 
-	static createAbility = (data: {
-		id: string,
-		name: string,
-		description?: string,
-		type: AbilityType,
-		keywords?: AbilityKeyword[],
-		distance: AbilityDistance[],
-		target: string,
-		cost?: number | 'signature',
-		minLevel?: number,
-		preEffect?: string,
-		powerRoll?: PowerRoll,
-		test?: PowerRoll,
-		effect?: string,
-		strained?: string,
-		alternateEffects?: string[],
-		spend?: { name?: string, value: number, repeatable?: boolean, effect: string }[],
-		persistence?: { value: number, effect: string }[]
-	}): Ability => {
-		return {
-			id: data.id,
-			name: data.name,
-			description: data.description || '',
-			type: data.type,
-			keywords: data.keywords || [],
-			distance: data.distance || [],
-			target: data.target || '',
-			cost: data.cost || 0,
-			minLevel: data.minLevel || 1,
-			preEffect: data.preEffect || '',
-			powerRoll: data.powerRoll || null,
-			test: data.test ?? null,
-			effect: data.effect || '',
-			strained: data.strained || '',
-			alternateEffects: data.alternateEffects || [],
-			spend: (data.spend ?? []).map(s => ({ ...s, name: s.name ?? '', repeatable: s.repeatable ?? false })),
-			persistence: (data.persistence ?? []).map(p => ({ ...p }))
-		};
+	/** @deprecated Use direct Ability object instead */
+	static createAbility = (data: Ability): Ability => {
+		return data;
 	};
 
 	static createPowerRoll = (data: {

--- a/src/logic/hero-logic.ts
+++ b/src/logic/hero-logic.ts
@@ -164,7 +164,7 @@ export class HeroLogic {
 					if (b === 'signature') {
 						return 1;
 					}
-					return a - b;
+					return (a ?? 0) - (b ?? 0);
 				})
 				.forEach(cost => abilities.push(...Collections.sort(choices.filter(a => a.cost === cost), a => a.name)));
 		}
@@ -627,7 +627,7 @@ Complex or time-consuming tests might require an action if made in combat—or c
 		let value2 = 0;
 		let value3 = 0;
 
-		if (ability.keywords.includes(AbilityKeyword.Melee) && ability.keywords.includes(AbilityKeyword.Weapon)) {
+		if (ability.keywords?.includes(AbilityKeyword.Melee) && ability.keywords.includes(AbilityKeyword.Weapon)) {
 			// Add maximum from kits
 			const kits = this.getKits(hero);
 			value1 += Collections.max(kits.map(kit => kit.meleeDamage?.tier1 || 0), value => value) || 0;
@@ -651,7 +651,7 @@ Complex or time-consuming tests might require an action if made in combat—or c
 		let value2 = 0;
 		let value3 = 0;
 
-		if (ability.keywords.includes(AbilityKeyword.Ranged) && ability.keywords.includes(AbilityKeyword.Weapon)) {
+		if (ability.keywords?.includes(AbilityKeyword.Ranged) && ability.keywords.includes(AbilityKeyword.Weapon)) {
 			// Add maximum from kits
 			const kits = this.getKits(hero);
 			value1 += Collections.max(kits.map(kit => kit.rangedDamage?.tier1 || 0), value => value) || 0;
@@ -673,12 +673,12 @@ Complex or time-consuming tests might require an action if made in combat—or c
 	static getDistanceBonus = (hero: Hero, ability: Ability, distance: AbilityDistance) => {
 		const kits = this.getKits(hero);
 
-		if (ability.keywords.includes(AbilityKeyword.Melee) && ability.keywords.includes(AbilityKeyword.Weapon) && (distance.type === AbilityDistanceType.Melee)) {
+		if (ability.keywords?.includes(AbilityKeyword.Melee) && ability.keywords.includes(AbilityKeyword.Weapon) && (distance.type === AbilityDistanceType.Melee)) {
 			// Add maximum melee distance bonus from kits
 			return Collections.max(kits.map(kit => kit.meleeDistance), value => value) || 0;
 		}
 
-		if (ability.keywords.includes(AbilityKeyword.Ranged) && ability.keywords.includes(AbilityKeyword.Weapon) && (distance.type === AbilityDistanceType.Ranged)) {
+		if (ability.keywords?.includes(AbilityKeyword.Ranged) && ability.keywords.includes(AbilityKeyword.Weapon) && (distance.type === AbilityDistanceType.Ranged)) {
 			// Add maximum ranged distance bonus from kits
 			return Collections.max(kits.map(kit => kit.rangedDistance), value => value) || 0;
 		}

--- a/src/models/ability.ts
+++ b/src/models/ability.ts
@@ -23,17 +23,17 @@ export interface AbilityDistance {
 
 export interface Ability extends Element {
 	type: AbilityType;
-	keywords: AbilityKeyword[];
+	keywords?: AbilityKeyword[];
 	distance: AbilityDistance[];
 	target: string; // Creature, Object, Enemy, Ally, Self, All
-	cost: number | 'signature';
-	minLevel: number;
-	preEffect: string;
-	powerRoll: PowerRoll | null,
-	test: PowerRoll | null,
-	effect: string;
-	strained: string;
-	alternateEffects: string[];
-	spend: { name: string, value: number, repeatable: boolean, effect: string }[];
-	persistence: { value: number, effect: string }[];
+	cost?: number | 'signature';
+	minLevel?: number;
+	preEffect?: string;
+	powerRoll?: PowerRoll,
+	test?: PowerRoll,
+	effect?: string;
+	strained?: string;
+	alternateEffects?: string[];
+	spend?: { name?: string, value: number, repeatable?: boolean, effect: string }[];
+	persistence?: { value: number, effect: string }[];
 }

--- a/src/models/element.ts
+++ b/src/models/element.ts
@@ -1,5 +1,5 @@
 export interface Element {
 	id: string;
 	name: string;
-	description: string;
+	description?: string;
 }


### PR DESCRIPTION
Should be able to expand this approach to most (all?) of the models.

* Eliminates need for factory function
  * Define Ability properties only once (in interface) rather than twice (in interface and in factory function)
* Concise data models - only have the actually relevant properties
* These properties are broadly regarded as optional already, this just codifies it