### PR TITLE
Add temporary stamina to health-panel

### DIFF
--- a/src/components/panels/health/health-panel.scss
+++ b/src/components/panels/health/health-panel.scss
@@ -7,6 +7,11 @@
 	align-items: center;
 	justify-content: center;
 
+	.stamina-temp-progress {
+		position: absolute;
+		transform: scale(1.6);
+	}
+
 	.stamina-progress {
 		position: absolute;
 		transform: scale(1.3);

--- a/src/components/panels/health/health-panel.tsx
+++ b/src/components/panels/health/health-panel.tsx
@@ -15,6 +15,17 @@ export const HealthPanel = (props: Props) => {
 	return (
 		<ErrorBoundary>
 			<div className='health-panel'>
+				{
+					props.hero.state.staminaTemp > 0 ?
+						<Progress
+							className='stamina-temp-progress'
+							type='dashboard'
+							percent={100 * props.hero.state.staminaTemp / HeroLogic.getStamina(props.hero)}
+							showInfo={false}
+							status='active'
+						/>
+						: null
+				}
 				<Progress
 					className='stamina-progress'
 					type='dashboard'
@@ -30,6 +41,14 @@ export const HealthPanel = (props: Props) => {
 					status='active'
 				/>
 				<div className='gauge-info'>
+					{
+						props.hero.state.staminaTemp > 0 ?
+							<div>
+								Tmp <b>{props.hero.state.staminaTemp}</b>
+								<Divider style={{ margin: '5px 0' }} />
+							</div>
+							: null
+					}
 					<div>
 						Sta <b>{props.hero.state.staminaDamage ? `${HeroLogic.getStamina(props.hero) - props.hero.state.staminaDamage} / ${HeroLogic.getStamina(props.hero)}` : `${HeroLogic.getStamina(props.hero)}`}</b>
 					</div>


### PR DESCRIPTION
In Heroes view, if temporary stamina is present, add it to "health panel" on top of Vitals tab.

For the scale of Progress, I used the base Stamina of the hero. Makes sense to have the same scale for temp and regular stamina.

In an unlikely case when Temporary Stamina is greater than Max Stamina, the Progress will appear full. 

Here some example screenshots:

<img width="470" alt="Screenshot 2025-04-06 at 21 21 58" src="https://github.com/user-attachments/assets/720a953f-4e38-467d-bc74-ab6b36591539" />
<img width="470" alt="Screenshot 2025-04-06 at 21 22 07" src="https://github.com/user-attachments/assets/e5afe9d6-614d-4837-99ea-6345cea86dbe" />
<img width="470" alt="Screenshot 2025-04-06 at 21 23 15" src="https://github.com/user-attachments/assets/326de28b-457b-4b39-9885-1bedd645c3d2" />
