### PR TITLE
Revitalize the Vitals panel

### DIFF
--- a/src/components/modals/hero-state/hero-state-modal.tsx
+++ b/src/components/modals/hero-state/hero-state-modal.tsx
@@ -269,6 +269,7 @@ export const HeroStateModal = (props: Props) => {
 					<NumberSpin
 						label='Damage/Restore Stamina'
 						value={damageOrRestoreValue}
+						max={hero.state.staminaDamage}
 						onChange={setDamageOrRestoreValue}
 					/>
 					<Button

--- a/src/components/modals/hero-state/hero-state-modal.tsx
+++ b/src/components/modals/hero-state/hero-state-modal.tsx
@@ -49,7 +49,7 @@ export const HeroStateModal = (props: Props) => {
 	const [ shopVisible, setShopVisible ] = useState<boolean>(false);
 	const [ conditionsVisible, setConditionsVisible ] = useState<boolean>(false);
 	const [ projectsVisible, setProjectsVisible ] = useState<boolean>(false);
-	const [ damageOrRestoreValue, setDamageOrRestoreValue ] = useState<number>(0);
+	const [ damageOrRegainValue, setDamageOrRegainValue ] = useState<number>(0);
 	const [ temporaryStaminaToGain, setTemporaryStaminaToGain ] = useState<number>(0);
 
 	const getHeroSection = () => {
@@ -187,10 +187,10 @@ export const HeroStateModal = (props: Props) => {
 	};
 
 	const getVitalsSection = () => {
-		const applyDamageOrRestore = () => {
+		const applyDamageOrRegain = () => {
 			const copy = Utils.copy(hero);
 
-			let value = damageOrRestoreValue;
+			let value = damageOrRegainValue;
 			// Negative value means damage
 			if (value < 0) {
 				value = -value;
@@ -204,7 +204,7 @@ export const HeroStateModal = (props: Props) => {
 				copy.state.staminaDamage = Math.max(copy.state.staminaDamage - value, 0);
 			}
 
-			setDamageOrRestoreValue(0);
+			setDamageOrRegainValue(0);
 			setHero(copy);
 			props.onChange(copy);
 		};
@@ -280,28 +280,28 @@ export const HeroStateModal = (props: Props) => {
 				<Row gutter={[ 16, 16 ]}>
 					<Col span={16}>
 						<NumberSpin
-							label='Damage/Restore Stamina'
-							value={damageOrRestoreValue}
+							label='Damage/Regain Stamina'
+							value={damageOrRegainValue}
 							max={hero.state.staminaDamage}
-							onChange={setDamageOrRestoreValue}
+							onChange={setDamageOrRegainValue}
 						/>
 					</Col>
 					<Col span={8}>
 						<Button
-							key='apply-damage-restore'
+							key='apply-damage-regain'
 							className='tall-button'
 							type='primary'
-							disabled={damageOrRestoreValue === 0}
-							onClick={applyDamageOrRestore}
+							disabled={damageOrRegainValue === 0}
+							onClick={applyDamageOrRegain}
 						>
 							<div>
 								<div>Apply</div>
 								{
-									damageOrRestoreValue !== 0 ?
+									damageOrRegainValue !== 0 ?
 										<div className='subtext'>
-											{damageOrRestoreValue < 0 ?
-												`Deal ${-damageOrRestoreValue} damage` :
-												`Restore ${damageOrRestoreValue} stamina`}
+											{damageOrRegainValue < 0 ?
+												`Deal ${-damageOrRegainValue} damage` :
+												`Regain ${damageOrRegainValue} stamina`}
 										</div>
 										: null
 								}

--- a/src/components/modals/hero-state/hero-state-modal.tsx
+++ b/src/components/modals/hero-state/hero-state-modal.tsx
@@ -50,7 +50,7 @@ export const HeroStateModal = (props: Props) => {
 	const [ conditionsVisible, setConditionsVisible ] = useState<boolean>(false);
 	const [ projectsVisible, setProjectsVisible ] = useState<boolean>(false);
 	const [ damageOrRestoreValue, setDamageOrRestoreValue ] = useState<number>(0);
-	const [ temporaryStaminaDiff, setTemporaryStaminaDiff ] = useState<number>(0);
+	const [ temporaryStaminaToGain, setTemporaryStaminaToGain ] = useState<number>(0);
 
 	const getHeroSection = () => {
 		const setHeroicResource = (value: number) => {
@@ -209,10 +209,10 @@ export const HeroStateModal = (props: Props) => {
 			props.onChange(copy);
 		};
 
-		const applyTemporaryStaminaDiff = () => {
+		const gainTemporaryStamina = () => {
 			const copy = Utils.copy(hero);
-			copy.state.staminaTemp += temporaryStaminaDiff;
-			setTemporaryStaminaDiff(0);
+			copy.state.staminaTemp = Math.max(copy.state.staminaTemp, temporaryStaminaToGain);
+			setTemporaryStaminaToGain(0);
 			setHero(copy);
 			props.onChange(copy);
 		};
@@ -312,6 +312,37 @@ export const HeroStateModal = (props: Props) => {
 				<Row gutter={[ 16, 16 ]}>
 					<Col span={16}>
 						<NumberSpin
+							label='Gain Temporary Stamina'
+							value={temporaryStaminaToGain}
+							min={0}
+							onChange={setTemporaryStaminaToGain}
+						/>
+					</Col>
+					<Col span={8}>
+						<Button
+							key='apply-temporary-stamina'
+							className='tall-button'
+							type='primary'
+							disabled={temporaryStaminaToGain <= hero.state.staminaTemp}
+							onClick={gainTemporaryStamina}
+						>
+							<div>
+								<div>Apply</div>
+								{
+									temporaryStaminaToGain > 0 && temporaryStaminaToGain <= hero.state.staminaTemp ?
+										<div className='subtext'>
+											Already at {hero.state.staminaTemp} temporary stamina
+										</div>
+										: null
+								}
+							</div>
+						</Button>
+					</Col>
+				</Row>
+				<Divider />
+				<Row gutter={[ 16, 16 ]}>
+					<Col span={16}>
+						<NumberSpin
 							label='Recoveries Used'
 							value={hero.state.recoveriesUsed}
 							suffix={hero.state.recoveriesUsed > 0 ? `/ ${HeroLogic.getRecoveries(hero)}` : undefined}
@@ -333,36 +364,6 @@ export const HeroStateModal = (props: Props) => {
 								<div className='subtext'>
 									Regain {HeroLogic.getRecoveryValue(hero)} Stamina
 								</div>
-							</div>
-						</Button>
-					</Col>
-				</Row>
-				<Row gutter={[ 16, 16 ]}>
-					<Col span={16}>
-						<NumberSpin
-							label='Temporary Stamina'
-							value={temporaryStaminaDiff}
-							min={-hero.state.staminaTemp}
-							onChange={setTemporaryStaminaDiff}
-						/>
-					</Col>
-					<Col span={8}>
-						<Button
-							key='apply-temporary-stamina'
-							className='tall-button'
-							type='primary'
-							disabled={temporaryStaminaDiff === 0}
-							onClick={applyTemporaryStaminaDiff}
-						>
-							<div>
-								<div>Apply</div>
-								{
-									temporaryStaminaDiff !== 0 ?
-										<div className='subtext'>
-											Set temporary stamina to {hero.state.staminaTemp + temporaryStaminaDiff}
-										</div>
-										: null
-								}
 							</div>
 						</Button>
 					</Col>

--- a/src/components/modals/hero-state/hero-state-modal.tsx
+++ b/src/components/modals/hero-state/hero-state-modal.tsx
@@ -280,7 +280,7 @@ export const HeroStateModal = (props: Props) => {
 				<Row gutter={[ 16, 16 ]}>
 					<Col span={16}>
 						<NumberSpin
-							label='Damage/Regain Stamina'
+							label='Stamina'
 							value={damageOrRegainValue}
 							max={hero.state.staminaDamage}
 							onChange={setDamageOrRegainValue}

--- a/src/components/modals/hero-state/hero-state-modal.tsx
+++ b/src/components/modals/hero-state/hero-state-modal.tsx
@@ -217,9 +217,9 @@ export const HeroStateModal = (props: Props) => {
 			props.onChange(copy);
 		};
 
-		const setRecoveriesUsed = (value: number) => {
+		const setRecoveries = (value: number) => {
 			const copy = Utils.copy(hero);
-			copy.state.recoveriesUsed = HeroLogic.getRecoveries(hero) - value;
+			copy.state.recoveriesUsed = Math.max(0, HeroLogic.getRecoveries(hero) - Math.max(0, value));
 			setHero(copy);
 			props.onChange(copy);
 		};
@@ -348,7 +348,7 @@ export const HeroStateModal = (props: Props) => {
 							suffix={`/ ${HeroLogic.getRecoveries(hero)}`}
 							min={0}
 							max={HeroLogic.getRecoveries(hero)}
-							onChange={setRecoveriesUsed}
+							onChange={setRecoveries}
 						/>
 					</Col>
 					<Col span={8}>

--- a/src/components/modals/hero-state/hero-state-modal.tsx
+++ b/src/components/modals/hero-state/hero-state-modal.tsx
@@ -50,6 +50,7 @@ export const HeroStateModal = (props: Props) => {
 	const [ conditionsVisible, setConditionsVisible ] = useState<boolean>(false);
 	const [ projectsVisible, setProjectsVisible ] = useState<boolean>(false);
 	const [ damageOrRestoreValue, setDamageOrRestoreValue ] = useState<number>(0);
+	const [ temporaryStaminaDiff, setTemporaryStaminaDiff ] = useState<number>(0);
 
 	const getHeroSection = () => {
 		const setHeroicResource = (value: number) => {
@@ -208,9 +209,10 @@ export const HeroStateModal = (props: Props) => {
 			props.onChange(copy);
 		};
 
-		const setStaminaTemp = (value: number) => {
+		const applyTemporaryStaminaDiff = () => {
 			const copy = Utils.copy(hero);
-			copy.state.staminaTemp = value;
+			copy.state.staminaTemp += temporaryStaminaDiff;
+			setTemporaryStaminaDiff(0);
 			setHero(copy);
 			props.onChange(copy);
 		};
@@ -225,6 +227,7 @@ export const HeroStateModal = (props: Props) => {
 		const endRespite = () => {
 			const copy = Utils.copy(hero);
 			copy.state.staminaDamage = 0;
+			copy.state.staminaTemp = 0;
 			copy.state.recoveriesUsed = 0;
 			copy.state.xp += copy.state.victories;
 			copy.state.victories = 0;
@@ -293,31 +296,15 @@ export const HeroStateModal = (props: Props) => {
 						</div>
 					</Button>
 				</Flex>
-				<NumberSpin
-					label='Recoveries Used'
-					value={hero.state.recoveriesUsed}
-					suffix={hero.state.recoveriesUsed > 0 ? `/ ${HeroLogic.getRecoveries(hero)}` : undefined}
-					min={0}
-					max={HeroLogic.getRecoveries(hero)}
-					onChange={setRecoveriesUsed}
-				/>
-				{
-					HeroLogic.isWinded(hero) ?
-						<Alert
-							type='warning'
-							showIcon={true}
-							message='You are winded.'
-						/>
-						: null
-				}
-				<NumberSpin
-					label='Temporary Stamina'
-					value={hero.state.staminaTemp}
-					min={0}
-					onChange={setStaminaTemp}
-				/>
-				<Divider />
 				<Flex align='center' justify='space-evenly'>
+					<NumberSpin
+						label='Recoveries Used'
+						value={hero.state.recoveriesUsed}
+						suffix={hero.state.recoveriesUsed > 0 ? `/ ${HeroLogic.getRecoveries(hero)}` : undefined}
+						min={0}
+						max={HeroLogic.getRecoveries(hero)}
+						onChange={setRecoveriesUsed}
+					/>
 					<Button
 						key='spend-recovery'
 						className='tall-button'
@@ -332,6 +319,45 @@ export const HeroStateModal = (props: Props) => {
 							</div>
 						</div>
 					</Button>
+				</Flex>
+				{
+					HeroLogic.isWinded(hero) ?
+						<Alert
+							type='warning'
+							showIcon={true}
+							message='You are winded.'
+						/>
+						: null
+				}
+				<Flex align='center' justify='space-evenly'>
+					<NumberSpin
+						label='Temporary Stamina'
+						value={temporaryStaminaDiff}
+						min={-hero.state.staminaTemp}
+						onChange={setTemporaryStaminaDiff}
+					/>
+					<Button
+						key='apply-temporary-stamina'
+						className='tall-button'
+						type='primary'
+						disabled={temporaryStaminaDiff === 0}
+						onClick={applyTemporaryStaminaDiff}
+					>
+						<div>
+							<div>Apply</div>
+							{
+								temporaryStaminaDiff !== 0 ?
+									<div className='subtext'>
+										Set temporary stamina to {hero.state.staminaTemp + temporaryStaminaDiff}
+									</div>
+									: null
+							}
+						</div>
+					</Button>
+
+				</Flex>
+				<Divider />
+				<Flex align='center' justify='space-evenly'>
 					<Button
 						key='take-respite'
 						className='tall-button'

--- a/src/components/modals/hero-state/hero-state-modal.tsx
+++ b/src/components/modals/hero-state/hero-state-modal.tsx
@@ -219,7 +219,7 @@ export const HeroStateModal = (props: Props) => {
 
 		const setRecoveriesUsed = (value: number) => {
 			const copy = Utils.copy(hero);
-			copy.state.recoveriesUsed = value;
+			copy.state.recoveriesUsed = HeroLogic.getRecoveries(hero) - value;
 			setHero(copy);
 			props.onChange(copy);
 		};
@@ -343,9 +343,9 @@ export const HeroStateModal = (props: Props) => {
 				<Row gutter={[ 16, 16 ]}>
 					<Col span={16}>
 						<NumberSpin
-							label='Recoveries Used'
-							value={hero.state.recoveriesUsed}
-							suffix={hero.state.recoveriesUsed > 0 ? `/ ${HeroLogic.getRecoveries(hero)}` : undefined}
+							label='Recoveries'
+							value={HeroLogic.getRecoveries(hero) - hero.state.recoveriesUsed}
+							suffix={`/ ${HeroLogic.getRecoveries(hero)}`}
 							min={0}
 							max={HeroLogic.getRecoveries(hero)}
 							onChange={setRecoveriesUsed}

--- a/src/components/modals/hero-state/hero-state-modal.tsx
+++ b/src/components/modals/hero-state/hero-state-modal.tsx
@@ -1,4 +1,4 @@
-import { Alert, Button, Divider, Drawer, Flex, Segmented, Space } from 'antd';
+import { Alert, Button, Col, Divider, Drawer, Flex, Row, Segmented, Space } from 'antd';
 import { ArrowUpOutlined, CaretDownOutlined, CaretUpOutlined } from '@ant-design/icons';
 import { ConditionEndType, ConditionType } from '../../../enums/condition-type';
 import { Collections } from '../../../utils/collections';
@@ -268,58 +268,6 @@ export const HeroStateModal = (props: Props) => {
 			<Space direction='vertical' style={{ width: '100%' }}>
 				<HealthPanel hero={hero} />
 				<Divider />
-				<Flex align='center' justify='space-evenly'>
-					<NumberSpin
-						label='Damage/Restore Stamina'
-						value={damageOrRestoreValue}
-						max={hero.state.staminaDamage}
-						onChange={setDamageOrRestoreValue}
-					/>
-					<Button
-						key='apply-damage-restore'
-						className='tall-button'
-						type='primary'
-						disabled={damageOrRestoreValue === 0}
-						onClick={applyDamageOrRestore}
-					>
-						<div>
-							<div>Apply</div>
-							{
-								damageOrRestoreValue !== 0 ?
-									<div className='subtext'>
-										{damageOrRestoreValue < 0 ?
-											`Deal ${-damageOrRestoreValue} damage` :
-											`Restore ${damageOrRestoreValue} stamina`}
-									</div>
-									: null
-							}
-						</div>
-					</Button>
-				</Flex>
-				<Flex align='center' justify='space-evenly'>
-					<NumberSpin
-						label='Recoveries Used'
-						value={hero.state.recoveriesUsed}
-						suffix={hero.state.recoveriesUsed > 0 ? `/ ${HeroLogic.getRecoveries(hero)}` : undefined}
-						min={0}
-						max={HeroLogic.getRecoveries(hero)}
-						onChange={setRecoveriesUsed}
-					/>
-					<Button
-						key='spend-recovery'
-						className='tall-button'
-						type='primary'
-						disabled={(hero.state.staminaDamage === 0) || (hero.state.recoveriesUsed >= HeroLogic.getRecoveries(hero))}
-						onClick={spendRecovery}
-					>
-						<div>
-							<div>Spend a Recovery</div>
-							<div className='subtext'>
-								Regain {HeroLogic.getRecoveryValue(hero)} Stamina
-							</div>
-						</div>
-					</Button>
-				</Flex>
 				{
 					HeroLogic.isWinded(hero) ?
 						<Alert
@@ -329,33 +277,96 @@ export const HeroStateModal = (props: Props) => {
 						/>
 						: null
 				}
-				<Flex align='center' justify='space-evenly'>
-					<NumberSpin
-						label='Temporary Stamina'
-						value={temporaryStaminaDiff}
-						min={-hero.state.staminaTemp}
-						onChange={setTemporaryStaminaDiff}
-					/>
-					<Button
-						key='apply-temporary-stamina'
-						className='tall-button'
-						type='primary'
-						disabled={temporaryStaminaDiff === 0}
-						onClick={applyTemporaryStaminaDiff}
-					>
-						<div>
-							<div>Apply</div>
-							{
-								temporaryStaminaDiff !== 0 ?
-									<div className='subtext'>
-										Set temporary stamina to {hero.state.staminaTemp + temporaryStaminaDiff}
-									</div>
-									: null
-							}
-						</div>
-					</Button>
-
-				</Flex>
+				<Row gutter={[ 16, 16 ]}>
+					<Col span={16}>
+						<NumberSpin
+							label='Damage/Restore Stamina'
+							value={damageOrRestoreValue}
+							max={hero.state.staminaDamage}
+							onChange={setDamageOrRestoreValue}
+						/>
+					</Col>
+					<Col span={8}>
+						<Button
+							key='apply-damage-restore'
+							className='tall-button'
+							type='primary'
+							disabled={damageOrRestoreValue === 0}
+							onClick={applyDamageOrRestore}
+						>
+							<div>
+								<div>Apply</div>
+								{
+									damageOrRestoreValue !== 0 ?
+										<div className='subtext'>
+											{damageOrRestoreValue < 0 ?
+												`Deal ${-damageOrRestoreValue} damage` :
+												`Restore ${damageOrRestoreValue} stamina`}
+										</div>
+										: null
+								}
+							</div>
+						</Button>
+					</Col>
+				</Row>
+				<Row gutter={[ 16, 16 ]}>
+					<Col span={16}>
+						<NumberSpin
+							label='Recoveries Used'
+							value={hero.state.recoveriesUsed}
+							suffix={hero.state.recoveriesUsed > 0 ? `/ ${HeroLogic.getRecoveries(hero)}` : undefined}
+							min={0}
+							max={HeroLogic.getRecoveries(hero)}
+							onChange={setRecoveriesUsed}
+						/>
+					</Col>
+					<Col span={8}>
+						<Button
+							key='spend-recovery'
+							className='tall-button'
+							type='primary'
+							disabled={(hero.state.staminaDamage === 0) || (hero.state.recoveriesUsed >= HeroLogic.getRecoveries(hero))}
+							onClick={spendRecovery}
+						>
+							<div>
+								<div>Spend a Recovery</div>
+								<div className='subtext'>
+									Regain {HeroLogic.getRecoveryValue(hero)} Stamina
+								</div>
+							</div>
+						</Button>
+					</Col>
+				</Row>
+				<Row gutter={[ 16, 16 ]}>
+					<Col span={16}>
+						<NumberSpin
+							label='Temporary Stamina'
+							value={temporaryStaminaDiff}
+							min={-hero.state.staminaTemp}
+							onChange={setTemporaryStaminaDiff}
+						/>
+					</Col>
+					<Col span={8}>
+						<Button
+							key='apply-temporary-stamina'
+							className='tall-button'
+							type='primary'
+							disabled={temporaryStaminaDiff === 0}
+							onClick={applyTemporaryStaminaDiff}
+						>
+							<div>
+								<div>Apply</div>
+								{
+									temporaryStaminaDiff !== 0 ?
+										<div className='subtext'>
+											Set temporary stamina to {hero.state.staminaTemp + temporaryStaminaDiff}
+										</div>
+										: null
+								}
+							</div>
+						</Button>
+					</Col>
+				</Row>
 				<Divider />
 				<Flex align='center' justify='space-evenly'>
 					<Button


### PR DESCRIPTION
Issue #162 

Rework Vitals panel to allow first entering damage number before applying it.

Full list of changes:
1. Added Stamina selector with Apply button next to it. Negative numbers mean damage. Positive - regaining of stamina.
2. Added logic for applying damage to first subtract from temporary stamina.
3. Added Gain Temporary Stamina selector with Apply button next to it. When applied, sets temporary stamina to the entered number. If the hero already have this or more temporary stamina, button won't be active. 

Demo screen recording:
https://github.com/user-attachments/assets/e9696b7f-5f03-4d76-8c2d-e0e1900e461a

