### PR TITLE
Add handling multiple kit bonuses

### DIFF
--- a/src/components/modals/ability/ability-modal.tsx
+++ b/src/components/modals/ability/ability-modal.tsx
@@ -110,13 +110,20 @@ export const AbilityModal = (props: Props) => {
 		}
 	};
 
+	const abilityChangedHero = (hero: Hero) => {
+		setHero(hero);
+		if (props.updateHero) {
+			props.updateHero(hero);
+		}
+	};
+
 	const getContent = () => {
 		switch (page) {
 			case 'Ability Card':
 				return (
 					<div className='ability-section'>
 						<SelectablePanel>
-							<AbilityPanel ability={props.ability} hero={hero} monster={props.monster} mode={PanelMode.Full} />
+							<AbilityPanel ability={props.ability} hero={hero} monster={props.monster} mode={PanelMode.Full} updateHero={abilityChangedHero} />
 						</SelectablePanel>
 						{
 							props.ability.powerRoll ?

--- a/src/components/panels/elements/ability-panel/ability-panel.tsx
+++ b/src/components/panels/elements/ability-panel/ability-panel.tsx
@@ -33,6 +33,7 @@ interface Props {
 	options?: Options;
 	mode?: PanelMode;
 	tags?: string[];
+	updateHero?: (hero: Hero) => void;
 }
 
 export const AbilityPanel = (props: Props) => {
@@ -280,6 +281,7 @@ export const AbilityPanel = (props: Props) => {
 											ability={props.ability}
 											hero={props.hero}
 											autoCalc={autoCalc}
+											updateHero={props.updateHero}
 										/>
 										: null
 								}

--- a/src/components/panels/power-roll/power-roll-panel.tsx
+++ b/src/components/panels/power-roll/power-roll-panel.tsx
@@ -9,6 +9,8 @@ import { FormatLogic } from '../../../logic/format-logic';
 import { Hero } from '../../../models/hero';
 import { HeroLogic } from '../../../logic/hero-logic';
 import type { PowerRoll } from '../../../models/power-roll';
+import { Select } from 'antd';
+import { Utils } from '../../../utils/utils';
 
 import './power-roll-panel.scss';
 
@@ -18,11 +20,16 @@ interface Props {
 	hero?: Hero;
 	test?: boolean;
 	autoCalc?: boolean;
+	updateHero?: (hero: Hero) => void;
 }
 
 export const PowerRollPanel = (props: Props) => {
-	const dmgMelee = props.ability && props.hero ? HeroLogic.getMeleeDamageBonus(props.hero, props.ability) : null;
-	const dmgRanged = props.ability && props.hero ? HeroLogic.getRangedDamageBonus(props.hero, props.ability) : null;
+	const dmgMelee = props.ability && props.hero ? HeroLogic.getAllMeleeDamageBonus(props.hero, props.ability) : null;
+	const dmgRanged = props.ability && props.hero ? HeroLogic.getAllRangedDamageBonus(props.hero, props.ability) : null;
+
+	const activeMeleeBonus = props.ability && props.hero ? HeroLogic.getMeleeDamageBonus(props.hero, props.ability) : null;
+	const activeRangedBonus = props.ability && props.hero ? HeroLogic.getRangedDamageBonus(props.hero, props.ability) : null;
+
 	const usesPotency = AbilityLogic.usesPotency(props.powerRoll);
 
 	const getHeader = () => {
@@ -65,31 +72,115 @@ export const PowerRollPanel = (props: Props) => {
 		if (props.hero) {
 			const sections = [];
 			if (props.autoCalc) {
+
+				const abilityIsMelee = !!props.ability && props.ability.distance.some(d => d.type === AbilityDistanceType.Melee);
+				const abilityIsRanged = !!props.ability && props.ability.distance.some(d => d.type === AbilityDistanceType.Ranged);
+
 				// Show melee and ranged damage only if:
 				// * we have both, and they're different
 				// * we have only one, but the ability has melee and ranged distances
 				let showBonuses = false;
 				if (dmgMelee && dmgRanged) {
-					showBonuses = ((dmgMelee.tier1 !== dmgRanged.tier1) || (dmgMelee.tier2 !== dmgRanged.tier2) || (dmgMelee.tier3 !== dmgRanged.tier3));
+					//one of the two type have ambiguity, so show all bonuses
+					if (dmgMelee.length > 1 || dmgRanged.length > 1) {
+						showBonuses = true;
+					}
+					//we either have only 1 of each or there is no ambiguity between all the kits
+					if (!showBonuses && activeMeleeBonus && activeRangedBonus) {
+						//there is a single melee bonus, show if we have also ranged
+						showBonuses = ((activeMeleeBonus.tier1 !== activeRangedBonus.tier1) || (activeMeleeBonus.tier2 !== activeRangedBonus.tier2) || (activeMeleeBonus.tier3 !== activeRangedBonus.tier3));
+					}
 				}
+
 				if (dmgMelee || dmgRanged) {
-					showBonuses = !!props.ability && props.ability.distance.some(d => d.type === AbilityDistanceType.Melee) && props.ability.distance.some(d => d.type === AbilityDistanceType.Ranged);
+					showBonuses = abilityIsMelee && abilityIsRanged;
 				}
+
 				if (showBonuses) {
 					if (dmgMelee) {
-						sections.push(<Field key='melee' label='Bonus melee damage' value={`+${dmgMelee.tier1} / +${dmgMelee.tier2} / +${dmgMelee.tier3}`} />);
+						if (dmgMelee.length > 1) {
+							dmgMelee.forEach((kitDmg, idx) => { sections.push(<Field key={`melee${idx}`} label={`${kitDmg.kitName} melee bonus`} value={`+${kitDmg.tier1} / +${kitDmg.tier2} / +${kitDmg.tier3}`} />); });
+						} else if (activeMeleeBonus) {
+							sections.push(<Field key='melee' label='Bonus melee damage' value={`+${activeMeleeBonus.tier1} / +${activeMeleeBonus.tier2} / +${activeMeleeBonus.tier3}`} />);
+						}
+
 					}
 					if (dmgRanged) {
-						sections.push(<Field key='ranged' label='Bonus ranged damage' value={`+${dmgRanged.tier1} / +${dmgRanged.tier2} / +${dmgRanged.tier3}`} />);
+						if (dmgRanged.length > 1) {
+							dmgRanged.forEach((kitDmg, idx) => { sections.push(<Field key={`ranged${idx}`} label={`${kitDmg.kitName} ranged bonus`} value={`+${kitDmg.tier1} / +${kitDmg.tier2} / +${kitDmg.tier3}`} />); });
+						} else if (activeRangedBonus) {
+							sections.push(<Field key='ranged' label='Bonus ranged damage' value={`+${activeRangedBonus.tier1} / +${activeRangedBonus.tier2} / +${activeRangedBonus.tier3}`} />);
+						}
+					}
+				} else {
+					//if bonus are not shown *but* we have multiple possible bonuses, we display which is currently used
+					if (abilityIsMelee && dmgMelee && dmgMelee.length > 1 && activeMeleeBonus) {
+						sections.push(
+							<Field label='Kit Melee Bonus used' key='kit-used-field-melee' value={activeMeleeBonus.kitName} />
+						);
+
+						if (props.updateHero) {
+							sections.push(
+								<Field label='Set Melee Kit Bonus' key='kit-select-field-melee' value={
+									<Select
+										key='kit-select-melee'
+										status={''}
+										allowClear={false}
+										placeholder='Select'
+										options={dmgMelee.map(dmgBonus => ({ label: dmgBonus.kitName, value: dmgBonus.kitId, desc: '' }))}
+										optionRender={option => <Field key={option.data.label} label={option.data.label} value={option.data.desc} />}
+										showSearch={false}
+										filterOption={(input, option) => { return (option?.label || '').toLowerCase().includes(input.toLowerCase()); }}
+										value={activeMeleeBonus.kitName}
+										onClick={e => { e.stopPropagation(); }}
+										onChange={setMeleeKitUsed} />
+								}
+								/>
+							);
+						}
+					}
+
+					if (abilityIsRanged && dmgRanged && dmgRanged.length > 1 && activeRangedBonus) {
+						sections.push(
+							<Field label='Kit Ranged Bonus used' key='kit-used-field-ranged' value={activeRangedBonus.kitName} />
+						);
+
+						if (props.updateHero) {
+							sections.push(
+								<Field label='Set Ranged Kit Bonus' key='kit-select-field-ranged' value={
+									<Select
+										key='kit-select-ranged'
+										status={''}
+										allowClear={false}
+										placeholder='Select'
+										options={dmgRanged.map(dmgBonus => ({ label: dmgBonus.kitName, value: dmgBonus.kitId, desc: '' }))}
+										optionRender={option => <Field key={option.data.label} label={option.data.label} value={option.data.desc} />}
+										showSearch={false}
+										filterOption={(input, option) => { return (option?.label || '').toLowerCase().includes(input.toLowerCase()); }}
+										value={activeRangedBonus.kitName}
+										onClick={e => { e.stopPropagation(); }}
+										onChange={setRangedKitUsed} />
+								}
+								/>
+							);
+						}
 					}
 				}
 			} else {
 				if (dmgMelee) {
-					sections.push(<Field key='melee' label='Bonus melee damage' value={`+${dmgMelee.tier1} / +${dmgMelee.tier2} / +${dmgMelee.tier3}`} />);
-				}
+					if (dmgMelee.length > 1) {
+						dmgMelee.forEach((kitDmg, idx) => { sections.push(<Field key={`melee${idx}`} label={`${kitDmg.kitName} melee bonus`} value={`+${kitDmg.tier1} / +${kitDmg.tier2} / +${kitDmg.tier3}`} />); });
+					} else {
+						sections.push(<Field key='melee' label='Bonus melee damage' value={`+${dmgMelee[0].tier1} / +${dmgMelee[0].tier2} / +${dmgMelee[0].tier3}`} />);
+					}
 
+				}
 				if (dmgRanged) {
-					sections.push(<Field key='ranged' label='Bonus ranged damage' value={`+${dmgRanged.tier1} / +${dmgRanged.tier2} / +${dmgRanged.tier3}`} />);
+					if (dmgRanged.length > 1) {
+						dmgRanged.forEach((kitDmg, idx) => { sections.push(<Field key={`ranged${idx}`} label={`${kitDmg.kitName} ranged bonus`} value={`+${kitDmg.tier1} / +${kitDmg.tier2} / +${kitDmg.tier3}`} />); });
+					} else {
+						sections.push(<Field key='ranged' label='Bonus ranged damage' value={`+${dmgRanged[0].tier1} / +${dmgRanged[0].tier2} / +${dmgRanged[0].tier3}`} />);
+					}
 				}
 
 				if (usesPotency) {
@@ -125,6 +216,24 @@ export const PowerRollPanel = (props: Props) => {
 		}
 
 		return value;
+	};
+
+	const setMeleeKitUsed = (kitId: string) => {
+		const copy = Utils.copy(props.hero) as Hero;
+
+		copy.state.activeMeleeKitBonusId = kitId;
+		if (props.updateHero) {
+			props.updateHero(copy);
+		}
+	};
+
+	const setRangedKitUsed = (kitId: string) => {
+		const copy = Utils.copy(props.hero) as Hero;
+
+		copy.state.activeRangedKitBonusId = kitId;
+		if (props.updateHero) {
+			props.updateHero(copy);
+		}
 	};
 
 	try {

--- a/src/data/hero-data.ts
+++ b/src/data/hero-data.ts
@@ -2201,7 +2201,9 @@ export class HeroData {
 			notes: '',
 			encounterState: 'ready',
 			hidden: false,
-			defeated: false
+			defeated: false,
+			activeMeleeKitBonusId: '',
+			activeRangedKitBonusId: ''
 		},
 		abilityCustomizations: []
 	} as Hero;
@@ -4273,7 +4275,9 @@ export class HeroData {
 			notes: '',
 			encounterState: 'ready',
 			hidden: false,
-			defeated: false
+			defeated: false,
+			activeMeleeKitBonusId: '',
+			activeRangedKitBonusId: ''
 		},
 		abilityCustomizations: []
 	} as Hero;
@@ -6546,7 +6550,9 @@ export class HeroData {
 			notes: '',
 			encounterState: 'ready',
 			hidden: false,
-			defeated: false
+			defeated: false,
+			activeMeleeKitBonusId: '',
+			activeRangedKitBonusId: ''
 		},
 		abilityCustomizations: []
 	} as Hero;
@@ -9020,7 +9026,9 @@ export class HeroData {
 			notes: '',
 			encounterState: 'ready',
 			hidden: false,
-			defeated: false
+			defeated: false,
+			activeMeleeKitBonusId: '',
+			activeRangedKitBonusId: ''
 		},
 		abilityCustomizations: []
 	} as Hero;
@@ -11831,7 +11839,9 @@ export class HeroData {
 			notes: '',
 			encounterState: 'ready',
 			hidden: false,
-			defeated: false
+			defeated: false,
+			activeMeleeKitBonusId: '',
+			activeRangedKitBonusId: ''
 		},
 		abilityCustomizations: []
 	} as Hero;
@@ -14079,7 +14089,9 @@ export class HeroData {
 			notes: '',
 			encounterState: 'ready',
 			hidden: false,
-			defeated: false
+			defeated: false,
+			activeMeleeKitBonusId: '',
+			activeRangedKitBonusId: ''
 		},
 		abilityCustomizations: []
 	} as Hero;
@@ -17077,7 +17089,9 @@ export class HeroData {
 			notes: '',
 			encounterState: 'ready',
 			hidden: false,
-			defeated: false
+			defeated: false,
+			activeMeleeKitBonusId: '',
+			activeRangedKitBonusId: ''
 		},
 		abilityCustomizations: []
 	} as Hero;
@@ -19497,7 +19511,9 @@ export class HeroData {
 			notes: '',
 			encounterState: 'ready',
 			hidden: false,
-			defeated: false
+			defeated: false,
+			activeMeleeKitBonusId: '',
+			activeRangedKitBonusId: ''
 		},
 		abilityCustomizations: []
 	} as Hero;
@@ -22213,7 +22229,9 @@ export class HeroData {
 			notes: '',
 			encounterState: 'ready',
 			hidden: false,
-			defeated: false
+			defeated: false,
+			activeMeleeKitBonusId: '',
+			activeRangedKitBonusId: ''
 		},
 		abilityCustomizations: []
 	} as Hero;

--- a/src/logic/factory-logic.ts
+++ b/src/logic/factory-logic.ts
@@ -96,7 +96,9 @@ export class FactoryLogic {
 				notes: '',
 				encounterState: 'ready',
 				hidden: false,
-				defeated: false
+				defeated: false,
+				activeMeleeKitBonusId: '',
+				activeRangedKitBonusId: ''
 			},
 			abilityCustomizations: []
 		};
@@ -856,7 +858,7 @@ export class FactoryLogic {
 				qualifier: data.qualifier ?? ''
 			};
 		},
-		createSelf: (qualifier=''): AbilityDistance => {
+		createSelf: (qualifier = ''): AbilityDistance => {
 			return {
 				type: AbilityDistanceType.Self,
 				value: 0,
@@ -1062,7 +1064,7 @@ export class FactoryLogic {
 				}
 			};
 		},
-		createCompanion: (data: {id: string, name?: string, description?: string, type: 'companion' | 'mount' | 'retainer' }): FeatureCompanion => {
+		createCompanion: (data: { id: string, name?: string, description?: string, type: 'companion' | 'mount' | 'retainer' }): FeatureCompanion => {
 			return {
 				id: data.id,
 				name: data.name || Format.capitalize(data.type),
@@ -1273,12 +1275,12 @@ export class FactoryLogic {
 				}
 			};
 		},
-		createSoloMonster: (data: { id: string, name: string, gender?: 'm' | 'f' | 'n' , endEfect?: number }): FeatureText => {
+		createSoloMonster: (data: { id: string, name: string, gender?: 'm' | 'f' | 'n', endEfect?: number }): FeatureText => {
 			const capitalizedName = data.name.split(' ').map((n, i) => i === 0 ? Format.capitalize(n) : n).join(' ');
 			const genderWithDefault = data.gender ?? 'n';
-			const heSheThey = ({ m: 'he', f: 'she', n: 'they' } as const)[ genderWithDefault ];
-			const hisHerTheir = ({ m: 'his', f: 'her', n: 'their' } as const)[ genderWithDefault ];
-			const himHerThem = ({ m: 'him', f: 'her', n: 'them' } as const)[ genderWithDefault ];
+			const heSheThey = ({ m: 'he', f: 'she', n: 'they' } as const)[genderWithDefault];
+			const hisHerTheir = ({ m: 'his', f: 'her', n: 'their' } as const)[genderWithDefault];
+			const himHerThem = ({ m: 'him', f: 'her', n: 'them' } as const)[genderWithDefault];
 			return {
 				id: data.id,
 				name: 'Solo Monster',

--- a/src/logic/hero-logic.ts
+++ b/src/logic/hero-logic.ts
@@ -109,11 +109,14 @@ export class HeroLogic {
 	};
 
 	static getRangedKitBonusUsed = (hero: Hero) => {
-		return hero.state.activeRangedKitBonusId ?? undefined;
+		return hero.state.activeRangedKitBonusId ?? null;
 	};
 
 	// Will return the best kit damage in the array or -1 if there is any ambiguity (e.g. 2/2/2 and 0/0/4)
 	static findKitHighestBonusIndex = (kitsDamages: KitDamageBonus[]) => {
+		if (kitsDamages.length == 0)
+			return -1;
+
 		if (kitsDamages.length < 2)
 			return 0;
 
@@ -688,6 +691,8 @@ export class HeroLogic {
 		if (ability.keywords.includes(AbilityKeyword.Ranged) && ability.keywords.includes(AbilityKeyword.Weapon)) {
 			// gather a list of all damage bonus in all kits, as some class can have multiple kits
 			const kits = this.getKits(hero);
+
+			//we also append the name and id to each bonus, so we can find back which kit it come from
 			const returnKitsBonus = kits.filter(kit => kit.rangedDamage !== null).map(kit => {
 				//we add the kit name after the bonus, this is used by UI to show where the bonus come from
 				const dmgBonus = {

--- a/src/models/hero.ts
+++ b/src/models/hero.ts
@@ -27,6 +27,8 @@ export interface HeroState {
 	hidden: boolean;
 	encounterState: 'ready' | 'current' | 'finished';
 	defeated: boolean;
+	activeMeleeKitBonusId: string;
+	activeRangedKitBonusId: string;
 }
 
 export interface AbilityCustomization {


### PR DESCRIPTION
This is a proposed change to handle multiple kits (Tactician in core classes) properly. 
[Related open issue](https://github.com/andyaiken/forgesteel/issues/184)

I implemented this as an exercise to learn the codebase, but unsure of contribution guideline, if this is too big, incomplete, or use wrong architecture, let me know!

## Description

![image](https://github.com/user-attachments/assets/78c1a072-eb37-45e8-990f-481e37f760e4)
*Autocalc now use a single user selectable kit bonus if there is ambiguity instead of combining bonuses*

![image](https://github.com/user-attachments/assets/0c1f096b-a39a-4172-9939-7471df5493da)
*If autocalc is disabled, it shows both kit bonuses*

![image](https://github.com/user-attachments/assets/1ed02f32-90b9-4a9a-8410-f7496eba2a78)
*Which kit bonus is used across all abilities is selectable in the modal window of the ability*

The system work as such:
- work as before when :
    - character have a single kit
    - there is no ambiguity (e.g. one kit give +1/+1/+1 and the other +2/+2/+2)
- if there is ambiguity (eg. +1/+1/+1 and +0/+0/+4) :
    - the system display both bonus when auto calc is disabled in the footer of the power roll table
    - the system show which currently active bonus is used to compute

You can change which kit is used in the modal window of the ability (a dropdown will appear at the bottom under which kit is currently used. This settings is shared between all abilities as you can only use 1 bonus and can only change during respite)

The system store 2 active bonus : melee bonus and ranged bonus (as the rule as far as I can see allow to pick which of the bonus you apply for every feature of a kit, so melee and ranged are separate).

## Implementation Details

The currently active melee and ranged bonus kit id are stored in the state in the hero. 

**This is the place where I'm unsure I did it in the right place**. Wasn't really sure where to store this, and as this is something that can be changed on respite, the state felt the right place.

HeroLogic functions that return melee and range bonus also got modified : they now called to new functions getAllMelee/Range damage bonus which return all bonus *if there are ambiguity* (otherwise they return the highest of bonuses). Those function return new object that store the tier but also kit name and kit id so we can match a bonus to its kit.

Those change should be retrocompatible, so the single get melee/range bonus function should work as expect (but now return the used kit instead of an hybrid bonus that is the highest in all tiers)

Finally added a callback in AbilityPanel and PowerRollPanel that get called when the dropdown selecting the kit change, bubbling the event up to the AbilityModal so it can update the hero.
