### PR TITLE
Time Raider Ancestry - #227

### DIFF
--- a/src/data/ancestries/time-raider.ts
+++ b/src/data/ancestries/time-raider.ts
@@ -9,7 +9,7 @@ import { FactoryLogic } from '../../logic/factory-logic';
 export const timeRaider: Ancestry = {
 	id: 'ancestry-time-raider',
 	name: 'Time Raider',
-	description: 'The original servitor species of the synliroi—evil psions with near godlike power—the kuran’zoi liberated themselves during the First Psychic War. In the centuries since, they built their own culture and civilization as nomads of the timescape. The exonym “time raiders” was given to them by denizens of the lower worlds who, seeing the advanced technology the kuran’zoi wield, concluded they must be from the future',
+	description: 'The original servitor species of the synliroi — evil psions with near godlike power — the kuran’zoi liberated themselves during the First Psychic War. In the centuries since, they built their own culture and civilization as nomads of the timescape. The exonym “time raiders” was given to them by denizens of the lower worlds who, seeing the advanced technology the kuran’zoi wield, concluded they must be from the future',
 	features: [
 		FactoryLogic.feature.createDamageModifier({
 			id: 'time-raider-feature-1',

--- a/src/data/ancestries/time-raider.ts
+++ b/src/data/ancestries/time-raider.ts
@@ -9,12 +9,13 @@ import { FactoryLogic } from '../../logic/factory-logic';
 export const timeRaider: Ancestry = {
 	id: 'ancestry-time-raider',
 	name: 'Time Raider',
-	description: 'The original servitor species of the synliiroi - evil psions with near god-like power - the kuran’zoi liberated themselves during the First Psychic War. In the centuries since, they built their own culture and civilization as nomads of the timescape. The exonym “time raiders” was given to them by denizens of the lower worlds who, seeing the advanced technology they wield, concluded they must be from the future.',
+	description: 'The original servitor species of the synliroi—evil psions with near godlike power—the kuran’zoi liberated themselves during the First Psychic War. In the centuries since, they built their own culture and civilization as nomads of the timescape. The exonym “time raiders” was given to them by denizens of the lower worlds who, seeing the advanced technology the kuran’zoi wield, concluded they must be from the future',
 	features: [
-		FactoryLogic.feature.create({
+		FactoryLogic.feature.createDamageModifier({
 			id: 'time-raider-feature-1',
-			name: 'Four Arms',
-			description: 'Your multiple arms let you take on multiple tasks at the same time. Whenever you use the Grab or Knockback maneuver against an adjacent creature, you can target an additional adjacent creature, using the same power roll for both targets. You can grab up to two creatures at a time.'
+			name: 'Psychic Scar',
+			description: 'Your mind is a formidable layer of defense. You have psychic immunity equal to your level.',
+			modifiers:  [ FactoryLogic.damageModifier.createPerLevel({ damageType: DamageType.Psychic, modifierType: DamageModifierType.Immunity, value: 1 }) ]
 		}),
 		FactoryLogic.feature.createChoice({
 			id: 'time-raider-feature-2',
@@ -31,7 +32,7 @@ export const timeRaider: Ancestry = {
 							distance: [ FactoryLogic.distance.createSelf() ],
 							target: 'Self',
 							sections: [
-								FactoryLogic.createAbilitySectionText('You can see through mundane obstructions that are 1 square thick or less. While your vision is adjusted this way, you can’t see and don’t have line of effect to any creatures or objects within 1 square of you. You can return your vision to normal as a maneuver.')
+								FactoryLogic.createAbilitySectionText('You can see through mundane obstructions that are 1 square thick or less. While your vision is adjusted this way, you can’t see the area within 1 square of you and you don’t have line of effect to any creature or object in that area. You can restore your usual vision as a maneuver.')
 							]
 						})
 					}),
@@ -46,7 +47,7 @@ export const timeRaider: Ancestry = {
 							FactoryLogic.feature.create({
 								id: 'time-raider-feature-2-2a',
 								name: 'Foresight',
-								description: 'You instinctively know the location of any concealed creatures who aren’t hidden from you, negating the usual bane on strikes against them.'
+								description: 'You automatically know the location of any creature with concealment who isn’t hidden from you within 20, and you negate the usual bane on strikes against such creatures.'
 							}),
 							FactoryLogic.feature.createAbility({
 								ability: FactoryLogic.createAbility({
@@ -67,88 +68,104 @@ export const timeRaider: Ancestry = {
 					value: 1
 				},
 				{
-					feature: FactoryLogic.feature.createDamageModifier({
+					feature: FactoryLogic.feature.create({
 						id: 'time-raider-feature-2-3',
-						name: 'Psychic Scar',
-						modifiers: [
-							FactoryLogic.damageModifier.createPerLevel({ damageType: DamageType.Psychic, modifierType: DamageModifierType.Immunity, value: 1 })
-						]
+						name: 'Four-Armed Athletics',
+						description: 'Your unique physiology enhances your movement. You gain an edge on tests that use the Climb, Gymnastics, or Swim skills when you can use all your arms in the attempt.'
 					}),
 					value: 1
 				},
 				{
-					feature: FactoryLogic.feature.createAbility({
-						ability: FactoryLogic.createAbility({
-							id: 'time-raider-feature-2-4',
-							name: 'Concussive Slam',
-							description: 'You slam an invisible force down upon the target.',
-							type: FactoryLogic.type.createMain(),
-							cost: 'signature',
-							keywords: [ AbilityKeyword.Psionic, AbilityKeyword.Ranged, AbilityKeyword.Strike ],
-							distance: [ FactoryLogic.distance.createRanged(10) ],
-							target: '1 creature or object',
-							sections: [
-								FactoryLogic.createAbilitySectionRoll(
-									FactoryLogic.createPowerRoll({
-										characteristic: [ Characteristic.Reason, Characteristic.Intuition, Characteristic.Presence ],
-										tier1: '2 + R, I, or P damage',
-										tier2: '5 + R, I, or P damage; push 1',
-										tier3: '7 + R, I, or P damage; push 2; M < [strong] prone'
-									})
-								)
-							]
-						})
+					feature: FactoryLogic.feature.create({
+						id: 'time-raider-feature-2-4',
+						name: 'Four-Armed Martial Arts',
+						description: 'Your multiple arms let you take on multiple tasks at the same time. Whenever you use the Grab or Knockback maneuver against an adjacent creature, you can target one additional adjacent creature, using the same power roll for both targets. Additionally, you can have up to two creatures grabbed at a time.'
 					}),
 					value: 2
 				},
 				{
-					feature: FactoryLogic.feature.createAbility({
-						ability: FactoryLogic.createAbility({
-							id: 'time-raider-feature-2-5',
-							name: 'Psionic Bolt',
-							description: 'You shoot forth a beam of psychic purple force that grips your target.',
-							type: FactoryLogic.type.createMain(),
-							keywords: [ AbilityKeyword.Psionic, AbilityKeyword.Ranged, AbilityKeyword.Strike ],
-							distance: [ FactoryLogic.distance.createRanged(10) ],
-							target: '1 creature or object',
-							cost: 'signature',
-							sections: [
-								FactoryLogic.createAbilitySectionRoll(
-									FactoryLogic.createPowerRoll({
-										characteristic: [ Characteristic.Reason, Characteristic.Intuition, Characteristic.Presence ],
-										tier1: '2 + R, I, or P psychic damage; slide 1',
-										tier2: '5 + R, I, or P psychic damage; slide 2',
-										tier3: '7 + R, I, or P psychic damage; slide 3'
+					feature: FactoryLogic.feature.createChoice({
+						id: 'time-raider-feature-2-5',
+						name: 'Psionic Gift',
+						options: [
+							{
+								feature: FactoryLogic.feature.createAbility({
+									ability: FactoryLogic.createAbility({
+										id: 'time-raider-feature-2-5-1',
+										name: 'Concussive Slam',
+										description: 'You slam an invisible force down upon the target.',
+										type: FactoryLogic.type.createMain(),
+										cost: 'signature',
+										keywords: [ AbilityKeyword.Psionic, AbilityKeyword.Ranged, AbilityKeyword.Strike ],
+										distance: [ FactoryLogic.distance.createRanged(10) ],
+										target: '1 creature or object',
+										sections: [
+											FactoryLogic.createAbilitySectionRoll(
+												FactoryLogic.createPowerRoll({
+													characteristic: [ Characteristic.Reason, Characteristic.Intuition, Characteristic.Presence ],
+													tier1: '2 + R, I, or P damage',
+													tier2: '5 + R, I, or P damage; push 1',
+													tier3: '7 + R, I, or P damage; push 2; M < [strong] prone'
+												})
+											)
+										]
 									})
-								)
-							]
-						})
-					}),
-					value: 2
-				},
-				{
-					feature: FactoryLogic.feature.createAbility({
-						ability: FactoryLogic.createAbility({
-							id: 'time-raider-feature-2-6',
-							name: 'Minor Acceleration',
-							description: 'You fill yourself or an ally with a burst of energy.',
-							type: FactoryLogic.type.createManeuver(),
-							keywords: [ AbilityKeyword.Psionic, AbilityKeyword.Melee ],
-							distance: [
-								FactoryLogic.distance.createSelf(),
-								FactoryLogic.distance.createMelee()
-							],
-							target: 'Self or 1 ally',
-							sections: [
-								FactoryLogic.createAbilitySectionText('The target’s speed increases by an amount equal to your Reason, Intuition, or Presence score (your choice) until the start of your next turn.')
-							]
-						})
+								}),
+								value: 0
+							},
+							{
+								feature: FactoryLogic.feature.createAbility({
+									ability: FactoryLogic.createAbility({
+										id: 'time-raider-feature-2-5-2',
+										name: 'Psionic Bolt',
+										description: 'You shoot forth a purple beam of psychic force that grips your target.',
+										type: FactoryLogic.type.createMain(),
+										keywords: [ AbilityKeyword.Psionic, AbilityKeyword.Ranged, AbilityKeyword.Strike ],
+										distance: [ FactoryLogic.distance.createRanged(10) ],
+										target: '1 creature or object',
+										cost: 'signature',
+										sections: [
+											FactoryLogic.createAbilitySectionRoll(
+												FactoryLogic.createPowerRoll({
+													characteristic: [ Characteristic.Reason, Characteristic.Intuition, Characteristic.Presence ],
+													tier1: '2 + R, I, or P psychic damage; slide 1',
+													tier2: '5 + R, I, or P psychic damage; slide 2',
+													tier3: '7 + R, I, or P psychic damage; slide 3'
+												})
+											)
+										]
+									})
+								}),
+								value: 0
+							},
+							{
+								feature: FactoryLogic.feature.createAbility({
+									ability: FactoryLogic.createAbility({
+										id: 'time-raider-feature-2-5-3',
+										name: 'Minor Acceleration',
+										description: 'You fill yourself or an ally with a burst of speed.',
+										type: FactoryLogic.type.createManeuver(),
+										keywords: [ AbilityKeyword.Psionic, AbilityKeyword.Melee ],
+										distance: [
+											FactoryLogic.distance.createSelf(),
+											FactoryLogic.distance.createMelee()
+										],
+										target: 'Self or 1 ally',
+										cost: 'signature',
+										sections: [
+											FactoryLogic.createAbilitySectionText('The target gains a bonus to speed equal to your Reason, Intuition, or Presence score (your choice) until the start of your next turn.')
+										]
+									})
+								}),
+								value: 0
+							}
+						]
 					}),
 					value: 2
 				},
 				{
 					feature: FactoryLogic.feature.createConditionImmunity({
-						id: 'time-raider-feature-2-7',
+						id: 'time-raider-feature-2-6',
 						name: 'Unstoppable Mind',
 						description: 'Your mind allows you to maintain your focus in any situation.',
 						conditions: [ ConditionType.Dazed ]
@@ -156,7 +173,7 @@ export const timeRaider: Ancestry = {
 					value: 2
 				}
 			],
-			count: 2
+			count: 3
 		})
 	]
 };


### PR DESCRIPTION
Updated the Time Raider Ancestry to match the v1 of Draw Steel for Task #227 .

Notable changes:
The previous Signature Trait, Four Armed, is now one of the Trait choices, Four-Armed Martial Arts, and the Psychic Scar choice is now the Signature Trait for the ancestry.
Additional Trait: Four-Armed Athletics
The Psionic abilities were simple options, but they are now children of the Psionic Gift feature, with the explicit requirement of only one being picked - I presume to balance the Planar Voyager Title.
Some ids were changed, I don't think it impacts backwards compatibility of the system, but I can revert the Ids that still match up.
