### PR TITLE
Update Ability Panel Distance Display

### DIFF
--- a/src/logic/ability-logic.ts
+++ b/src/logic/ability-logic.ts
@@ -123,7 +123,11 @@ export class AbilityLogic {
 				sections.push(`${distance.type} ${distance.value + bonus}`);
 				break;
 			case AbilityDistanceType.Line:
-				sections.push(`Line ${Math.max(distance.value, distance.value2)}x${Math.min(distance.value, distance.value2)}`);
+				sections.push(`${Math.max(distance.value, distance.value2)} x ${Math.min(distance.value, distance.value2)} line`);
+				break;
+			case AbilityDistanceType.Burst:
+			case AbilityDistanceType.Cube:
+				sections.push(`${distance.value} ${distance.type}`);
 				break;
 			default:
 				sections.push(`${distance.type} ${distance.value}`);

--- a/src/logic/ability-logic.ts
+++ b/src/logic/ability-logic.ts
@@ -123,7 +123,7 @@ export class AbilityLogic {
 				sections.push(`${distance.type} ${distance.value + bonus}`);
 				break;
 			case AbilityDistanceType.Line:
-				sections.push(`${Math.max(distance.value, distance.value2)} x ${Math.min(distance.value, distance.value2)} line`);
+				sections.push(`${Math.max(distance.value, distance.value2)} x ${Math.min(distance.value, distance.value2)} ${distance.type}`);
 				break;
 			case AbilityDistanceType.Burst:
 			case AbilityDistanceType.Cube:


### PR DESCRIPTION
updated the distance display of abilities to better match the book. 

Examples of Old vs New and the Book Text:

## Burst
### Old:
<img width="403" height="90" alt="old_burst" src="https://github.com/user-attachments/assets/42022aa8-e503-41af-8dfc-332babf4eb98" />

### New:
<img width="406" height="88" alt="new_burst" src="https://github.com/user-attachments/assets/ff399d0f-a76c-4c9c-86ae-edd9b36881c1" />

### Book:
<img width="68" height="22" alt="burst_text" src="https://github.com/user-attachments/assets/c31aa7fb-80c8-40c8-8f09-166955164839" />

## Cube
### Old:
<img width="407" height="88" alt="old_cube" src="https://github.com/user-attachments/assets/938ee960-cb53-4fe8-a8f0-b436f556072f" />

### New:
<img width="404" height="91" alt="new_cube" src="https://github.com/user-attachments/assets/1d0177a2-81a8-40b9-a853-0596740737af" />

### Book:
<img width="214" height="24" alt="cube_text" src="https://github.com/user-attachments/assets/808b97d3-4ea2-43f8-9b58-e3259b23f58d" />

## Line
### Old:
<img width="414" height="85" alt="old_line" src="https://github.com/user-attachments/assets/2dedc2a5-e2f7-41ca-9da6-f1e298f489e6" />

### New:
<img width="410" height="87" alt="new_line" src="https://github.com/user-attachments/assets/410702d3-d283-4e23-89eb-8734ca4f4e00" />

### Book:
<img width="131" height="27" alt="line_text" src="https://github.com/user-attachments/assets/59c1196f-e936-4452-99ca-0201d9048e58" />


