### PR TITLE
Formatting fixes

### DIFF
--- a/src/logic/ability-logic.ts
+++ b/src/logic/ability-logic.ts
@@ -298,8 +298,8 @@ export class AbilityLogic {
 
 		// Equal to [N times] your [Characteristic(s)] score
 		if (hero) {
-			const charRegex = /equal to[^,.;:]*your[^,.;:]*score/gi;
-			[ ...text.matchAll(charRegex) ].map(r => r[0]).forEach(str => {
+			const charRegex = /(equal to (?:or (?:greater|less) than)?)[^,.;:]* your ([^,.;:]*) score/gi;
+			[ ...text.matchAll(charRegex) ].forEach(match => {
 				const options: number[] = [];
 				[
 					Characteristic.Might,
@@ -308,15 +308,16 @@ export class AbilityLogic {
 					Characteristic.Intuition,
 					Characteristic.Presence
 				].forEach(ch => {
-					if (str.toLowerCase().includes('highest characteristic') || str.toLowerCase().includes(ch.toLowerCase())) {
+					if (match[2].toLowerCase() == 'highest characteristic' || match[2].toLowerCase() == ch.toLowerCase()) {
 						options.push(HeroLogic.getCharacteristic(hero, ch));
 					}
 				});
 				const value = Math.max(...options);
 
-				const constant = FormatLogic.getConstant(str);
-				const multiplier = FormatLogic.getMultiplier(str);
-				text = text.replace(str, `equal to ${constant + (value * multiplier)}`);
+				const constant = FormatLogic.getConstant(match[0]);
+				const multiplier = FormatLogic.getMultiplier(match[0]);
+				
+				text = text.replace(match[0], `${match[1]} ${constant + (value * multiplier)}`);
 			});
 		}
 

--- a/src/logic/format-logic.ts
+++ b/src/logic/format-logic.ts
@@ -112,7 +112,8 @@ export class FormatLogic {
 					'2x',
 					'2 x',
 					'2×',
-					'2 ×'
+					'2 ×',
+					'2 times'
 				]
 			},
 			{
@@ -143,7 +144,8 @@ export class FormatLogic {
 					'5x',
 					'5 x',
 					'5×',
-					'5 ×'
+					'5 ×',
+					'5 times'
 				]
 			},
 			{


### PR DESCRIPTION
Improve formatting for abilities with 'equal to or greater than' and 'equal to or lesser than' to preserve the greater/lesser specification. Add support for '5 times' and '2 times' as detected multiples

This fixes the description of the Elementalist's Persistent feature (both fixes are relevant here):
    Before: "If you take damage equal to 2 in one turn, you stop maintaining any persistent abilities."
    After: "If you take damage equal to or greater than 10 in one turn, you stop maintaining any persistent abilities."

This also fixes the description of grab (somewhat):
    Before: "You can usually target only creatures of your size or smaller. If your Might score is 2 or higher, you can target any creature with a size equal to 1."
    After: "You can usually target only creatures of your size or smaller. If your Might score is 2 or higher, you can target any creature with a size equal to or less than 1."