### PR TITLE
Feature/add damage immunities weaknesses

### DIFF
--- a/src/components/pages/heroes/hero-sheet/hero-sheet-page.scss
+++ b/src/components/pages/heroes/hero-sheet/hero-sheet-page.scss
@@ -148,8 +148,11 @@
         grid-template-columns: 2fr 1fr;
     }
 
-    .turn-reference.card {
+    .reference-damages {
         grid-row-end: span 2;
+
+        display: grid;
+        grid-template-rows: 1fr min-content;
     }
 
     .page-2 {

--- a/src/components/pages/heroes/hero-sheet/hero-sheet-page.tsx
+++ b/src/components/pages/heroes/hero-sheet/hero-sheet-page.tsx
@@ -24,7 +24,7 @@ import { SkillsCard } from '../../../panels/hero-sheet/skills-card/skills-card';
 import { Sourcebook } from '../../../../models/sourcebook';
 import { StatsResourcesCard } from '../../../panels/hero-sheet/stats-resources-card/stats-resources-card';
 import { TitlesCard } from '../../../panels/hero-sheet/titles-card/titles-card';
-import { TurnReferenceCard } from '../../../panels/hero-sheet/reference/turn-reference-card';
+import { PrimaryReferenceCard } from '../../../panels/hero-sheet/reference/turn-reference-card';
 
 import './hero-sheet-page.scss';
 
@@ -178,7 +178,7 @@ export const HeroSheetPage = (props: Props) => {
 									character={character}
 									options={props.options}
 								/>
-								<TurnReferenceCard
+								<PrimaryReferenceCard
 									character={character}
 								/>
 							</div>

--- a/src/components/pages/heroes/hero-sheet/hero-sheet-page.tsx
+++ b/src/components/pages/heroes/hero-sheet/hero-sheet-page.tsx
@@ -1,6 +1,7 @@
 import { AbilitySheet, CharacterSheet } from '../../../../models/character-sheet';
 import { EdgesBanesReferenceCard, MainActionsReferenceCard, ManeuversReferenceCard, MoveActionsReferenceCard, TurnOptionsReferenceCard } from '../../../panels/hero-sheet/reference/reference-cards';
 import { Fragment, JSX, useMemo } from 'react';
+
 import { AbilityCard } from '../../../panels/hero-sheet/ability-card/ability-card';
 import { AncestryTraitsCard } from '../../../panels/hero-sheet/ancestry-traits-card/ancestry-traits-card';
 import { CareerCard } from '../../../panels/hero-sheet/career-card/career-card';
@@ -14,17 +15,18 @@ import { ErrorBoundary } from '../../../controls/error-boundary/error-boundary';
 import { FeatureReferenceCard } from '../../../panels/hero-sheet/reference/feature-reference-card';
 import { Hero } from '../../../../models/hero';
 import { HeroHeaderCard } from '../../../panels/hero-sheet/hero-header-card/hero-header-card';
+import { ImmunitiesWeaknessesCard } from '../../../panels/hero-sheet/immunities-weaknesses-card/immunities-weaknesses-card';
 import { InventoryCard } from '../../../panels/hero-sheet/inventory-card/inventory-card';
 import { ModifiersCard } from '../../../panels/hero-sheet/modifiers-card/modifiers-card';
 import { Options } from '../../../../models/options';
 import { PerksCard } from '../../../panels/hero-sheet/perks-card/perks-card';
 import { PotenciesCard } from '../../../panels/hero-sheet/potencies-card/potencies-card';
+import { PrimaryReferenceCard } from '../../../panels/hero-sheet/reference/turn-reference-card';
 import { ProjectsCard } from '../../../panels/hero-sheet/projects-card/projects-card';
 import { SkillsCard } from '../../../panels/hero-sheet/skills-card/skills-card';
 import { Sourcebook } from '../../../../models/sourcebook';
 import { StatsResourcesCard } from '../../../panels/hero-sheet/stats-resources-card/stats-resources-card';
 import { TitlesCard } from '../../../panels/hero-sheet/titles-card/titles-card';
-import { PrimaryReferenceCard } from '../../../panels/hero-sheet/reference/turn-reference-card';
 
 import './hero-sheet-page.scss';
 
@@ -41,6 +43,10 @@ export const HeroSheetPage = (props: Props) => {
 		() => CharacterSheetBuilder.buildSheetForHero(hero, props.sourcebooks),
 		[ hero, props.sourcebooks ]
 	);
+
+	const hasImmunitiesOrWeaknesses = () => {
+		return character.immunities?.length || character.weaknesses?.length;
+	};
 
 	try {
 		let pageNum = 0;
@@ -154,10 +160,6 @@ export const HeroSheetPage = (props: Props) => {
 			<ErrorBoundary>
 				<main id='hero-sheet-page'>
 					<div className='hero-sheet' id={hero.id}>
-						{/* <div className='page' id={addPageId(hero)}>
-                            <FontTester />
-                        </div>
-                        <hr className='dashed' /> */}
 						<div className='page page-1' id={addPageId(hero)}>
 							<HeroHeaderCard
 								character={character}
@@ -178,9 +180,16 @@ export const HeroSheetPage = (props: Props) => {
 									character={character}
 									options={props.options}
 								/>
-								<PrimaryReferenceCard
-									character={character}
-								/>
+								<div className='reference-damages'>
+									<PrimaryReferenceCard
+										character={character}
+									/>
+									{hasImmunitiesOrWeaknesses() ?
+										<ImmunitiesWeaknessesCard
+											character={character}
+										/>
+										: undefined}
+								</div>
 							</div>
 							<div className='class-ancestry-features'>
 								<ClassFeaturesCard

--- a/src/components/panels/hero-sheet/ability-card/ability-card.scss
+++ b/src/components/panels/hero-sheet/ability-card/ability-card.scss
@@ -150,5 +150,9 @@
     }
     .ability-effect {
         font-size: 1.1rem;
+
+        ul {
+            margin-left: 10px;
+        }
     }
 }

--- a/src/components/panels/hero-sheet/ancestry-traits-card/ancestry-traits-card.tsx
+++ b/src/components/panels/hero-sheet/ancestry-traits-card/ancestry-traits-card.tsx
@@ -1,4 +1,5 @@
 import { CharacterSheet } from '../../../../models/character-sheet';
+import { CharacterSheetFormatter } from '../../../../utils/character-sheet-formatter';
 import { FeatureComponent } from '../components/feature-component';
 import './ancestry-traits-card.scss';
 
@@ -8,18 +9,38 @@ interface Props {
 
 export const AncestryTraitsCard = (props: Props) => {
 	const character = props.character;
+
+	const getTraits = () => {
+		let traits = character.ancestryTraits || [];
+		const numLines = traits.reduce((n, f) => {
+			const lines = CharacterSheetFormatter.countLines(f.description, 40);
+			return n + 1 + lines;
+		}, 0);
+
+		if (numLines > 26) {
+			traits = traits.map(f => {
+				if (f.description.includes('…')) {
+					f.description = '*See Reference for details…*';
+				}
+				return f;
+			});
+		}
+
+		return traits.map(f =>
+			<li key={f.id}>
+				<FeatureComponent
+					feature={f}
+					hero={character.hero}
+				/>
+			</li>
+		);
+	};
+
 	return (
 		<div className='ancestry-traits card'>
 			<h2>Ancestry Traits</h2>
 			<ul className='features-container'>
-				{character.ancestryTraits?.map(f =>
-					<li key={f.id}>
-						<FeatureComponent
-							feature={f}
-							hero={character.hero}
-						/>
-					</li>
-				)}
+				{getTraits()}
 			</ul>
 		</div>
 	);

--- a/src/components/panels/hero-sheet/components/feature-component.scss
+++ b/src/components/panels/hero-sheet/components/feature-component.scss
@@ -29,8 +29,7 @@
         }
     }
 
-    .feature-line,
-    .feature-iteration {
+    .feature-line {
         line-height: 1.2rem;
         font-size: 1.1rem;
     }
@@ -93,8 +92,11 @@
         border: 1px solid common.$color-light;
         background: common.$color-extra-light;
         border-radius: 3px;
-        padding: 1px 3px;
+        padding: 0 3px 1px;
         opacity: 0.8;
+        
+        line-height: 1.2rem;
+        font-size: 1.0rem;
     }
 }
 
@@ -104,4 +106,11 @@ li .feature ul.feature-description {
 
 .feature-reference .feature .feature-description table td:first-child {
     text-wrap: nowrap;
+    vertical-align: text-top;
+
+    img {
+        width: 50px;
+        height: 18px;
+        margin: 1px 0;
+    }
 }

--- a/src/components/panels/hero-sheet/components/feature-component.tsx
+++ b/src/components/panels/hero-sheet/components/feature-component.tsx
@@ -56,7 +56,7 @@ const AncestryChoiceFeatureComponent = (feature: FeatureAncestryChoice) => {
 	return (
 		<>
 			<div className='feature-line'>
-				<strong>{`• ${feature.type}: `}</strong>{feature.data.selected?.name}
+				<strong>{`• ${feature.name}: `}</strong>{feature.data.selected?.name}
 			</div>
 		</>
 	);

--- a/src/components/panels/hero-sheet/components/feature-component.tsx
+++ b/src/components/panels/hero-sheet/components/feature-component.tsx
@@ -180,7 +180,7 @@ const DamageModifierComponent = (feature: FeatureDamageModifier, hero: Hero) => 
 const DomainFeatureComponent = (feature: FeatureDomain | FeatureDomainFeature) => {
 	return (
 		<>
-			<div className='feature-title'>• {feature.type}: {feature.name}</div>
+			<div className='feature-line'><strong>• {feature.type}:</strong> {feature.name}</div>
 		</>
 	);
 };

--- a/src/components/panels/hero-sheet/immunities-weaknesses-card/immunities-weaknesses-card.scss
+++ b/src/components/panels/hero-sheet/immunities-weaknesses-card/immunities-weaknesses-card.scss
@@ -1,0 +1,27 @@
+@use '../../../pages/heroes/hero-sheet/common.scss';
+
+.hero-sheet .immunities-weaknesses.card {
+    padding-left: 10px;
+    padding-right: 10px;
+
+    h3:not(:first-child) {
+        margin-top: 5px;
+    }
+
+    ul {
+        list-style: none;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 5px 7px;
+        margin: 0;
+        padding: 0;
+
+        li {
+            border: 1px solid common.$color-light;
+            background: common.$color-extra-light;
+            border-radius: 3px;
+            padding: 1px 3px;
+            opacity: 0.8;
+        }
+    }
+}

--- a/src/components/panels/hero-sheet/immunities-weaknesses-card/immunities-weaknesses-card.tsx
+++ b/src/components/panels/hero-sheet/immunities-weaknesses-card/immunities-weaknesses-card.tsx
@@ -1,0 +1,45 @@
+import { CharacterSheet } from '../../../../models/character-sheet';
+
+import { useMemo } from 'react';
+
+import './immunities-weaknesses-card.scss';
+
+interface Props {
+	character: CharacterSheet;
+}
+
+export const ImmunitiesWeaknessesCard = (props: Props) => {
+	const character = useMemo(
+		() => props.character,
+		[ props.character ]
+	);
+
+	return (
+		<div className='immunities-weaknesses card'>
+			{character.immunities?.length ?
+				<>
+					<h3>Immunities</h3>
+					<ul>
+						{character.immunities?.map(im => (
+							<li className='immunity' key={im.damageType}>
+								{im.damageType} {im.value}
+							</li>
+						))}
+					</ul>
+				</>
+				: undefined }
+			{character.weaknesses?.length ?
+				<>
+					<h3>Weaknesses</h3>
+					<ul>
+						{character.weaknesses?.map(w => (
+							<li className='weakness' key={w.damageType}>
+								{w.damageType} {w.value}
+							</li>
+						))}
+					</ul>
+				</>
+				: undefined }
+		</div>
+	);
+};

--- a/src/components/panels/hero-sheet/modifiers-card/modifiers-card.scss
+++ b/src/components/panels/hero-sheet/modifiers-card/modifiers-card.scss
@@ -66,7 +66,7 @@
         display: grid;
         grid-template-rows: min-content 1fr;
 
-        h4 {
+        h3, h4 {
             margin: 0;
         }
     }

--- a/src/components/panels/hero-sheet/modifiers-card/modifiers-card.tsx
+++ b/src/components/panels/hero-sheet/modifiers-card/modifiers-card.tsx
@@ -8,59 +8,72 @@ import './modifiers-card.scss';
 import rollT1 from '../../../../assets/icons/power-roll-t1.svg';
 import rollT2 from '../../../../assets/icons/power-roll-t2.svg';
 import rollT3 from '../../../../assets/icons/power-roll-t3.svg';
+import { useMemo } from 'react';
 
 interface Props {
 	character: CharacterSheet;
 }
 
 export const ModifiersCard = (props: Props) => {
-	const character = props.character;
+	const character = useMemo(
+		() => props.character,
+		[ props.character ]
+	);
 
-	let shownModifiers = [ 'Kit', 'Prayer', 'Ward', 'Augmentation', 'Enchantment' ];
-	if (character.modifierTypes?.length) {
-		shownModifiers = shownModifiers.filter(t => character.modifierTypes?.includes(t));
-	}
-	const modifierClasses = shownModifiers.map(m => m.toLocaleLowerCase());
+	const shownModifiers = useMemo(
+		() => {
+			let mods = [ 'Kit', 'Prayer', 'Ward', 'Augmentation', 'Enchantment' ];
+			if (character.modifierTypes?.length) {
+				mods = mods.filter(t => character.modifierTypes?.includes(t));
+			}
+			return mods;
+		},
+		[ character.modifierTypes ]
+	);
 
-	const isKit = !character.modifierTypes?.length || character.modifierTypes?.includes('Kit');
-	const kitDamageModificationSection = (isKit ?
-		<>
-			<div className='power-roll-damage-modifiers'>
-				<h4>Ranged Weapon Damage</h4>
-				<div className='roll-tiers'>
-					<div className='tier t1'>
-						<div className='effect'>{CharacterSheetFormatter.addSign(character.modifierRangedDamageT1)}</div>
-						<img src={rollT1} alt='≤ 11' className='range' />
+	const getKitDamageModificationSection = () => {
+		const isKit = !character.modifierTypes?.length || character.modifierTypes?.includes('Kit');
+		if (isKit) {
+			return (
+				<>
+					<div className='power-roll-damage-modifiers'>
+						<h4>Ranged Weapon Damage</h4>
+						<div className='roll-tiers'>
+							<div className='tier t1'>
+								<div className='effect'>{CharacterSheetFormatter.addSign(character.modifierRangedDamageT1)}</div>
+								<img src={rollT1} alt='≤ 11' className='range' />
+							</div>
+							<div className='tier t2'>
+								<div className='effect'>{CharacterSheetFormatter.addSign(character.modifierRangedDamageT2)}</div>
+								<img src={rollT2} alt='12 - 16' className='range' />
+							</div>
+							<div className='tier t3'>
+								<div className='effect'>{CharacterSheetFormatter.addSign(character.modifierRangedDamageT3)}</div>
+								<img src={rollT3} alt='17 +' className='range' />
+							</div>
+						</div>
 					</div>
-					<div className='tier t2'>
-						<div className='effect'>{CharacterSheetFormatter.addSign(character.modifierRangedDamageT2)}</div>
-						<img src={rollT2} alt='12 - 16' className='range' />
+					<div className='power-roll-damage-modifiers'>
+						<h4>Melee Weapon Damage</h4>
+						<div className='roll-tiers'>
+							<div className='tier t1'>
+								<div className='effect'>{CharacterSheetFormatter.addSign(character.modifierMeleeDamageT1)}</div>
+								<img src={rollT1} alt='≤ 11' className='range' />
+							</div>
+							<div className='tier t2'>
+								<div className='effect'>{CharacterSheetFormatter.addSign(character.modifierMeleeDamageT2)}</div>
+								<img src={rollT2} alt='12 - 16' className='range' />
+							</div>
+							<div className='tier t3'>
+								<div className='effect'>{CharacterSheetFormatter.addSign(character.modifierMeleeDamageT3)}</div>
+								<img src={rollT3} alt='17 +' className='range' />
+							</div>
+						</div>
 					</div>
-					<div className='tier t3'>
-						<div className='effect'>{CharacterSheetFormatter.addSign(character.modifierRangedDamageT3)}</div>
-						<img src={rollT3} alt='17 +' className='range' />
-					</div>
-				</div>
-			</div>
-			<div className='power-roll-damage-modifiers'>
-				<h4>Melee Weapon Damage</h4>
-				<div className='roll-tiers'>
-					<div className='tier t1'>
-						<div className='effect'>{CharacterSheetFormatter.addSign(character.modifierMeleeDamageT1)}</div>
-						<img src={rollT1} alt='≤ 11' className='range' />
-					</div>
-					<div className='tier t2'>
-						<div className='effect'>{CharacterSheetFormatter.addSign(character.modifierMeleeDamageT2)}</div>
-						<img src={rollT2} alt='12 - 16' className='range' />
-					</div>
-					<div className='tier t3'>
-						<div className='effect'>{CharacterSheetFormatter.addSign(character.modifierMeleeDamageT3)}</div>
-						<img src={rollT3} alt='17 +' className='range' />
-					</div>
-				</div>
-			</div>
-		</>
-		: undefined);
+				</>
+			);
+		}
+	};
 
 	return (
 		<div className='modifiers card'>
@@ -81,7 +94,7 @@ export const ModifiersCard = (props: Props) => {
 				additionalClasses={[ 'name' ]}
 			/>
 
-			<div className={[ 'modifier-augmentations' ].concat(modifierClasses).join(' ')}>
+			<div className={[ 'modifier-augmentations' ].concat(shownModifiers.map(m => m.toLocaleLowerCase())).join(' ')}>
 				<div className='proficiencies'>
 					<LabeledTextField
 						label='Weapon/Implement'
@@ -121,13 +134,13 @@ export const ModifiersCard = (props: Props) => {
 				</div>
 			</div>
 
-			<div className={[ 'effects' ].concat(modifierClasses).join(' ')}>
+			<div className={[ 'effects' ].concat(shownModifiers.map(m => m.toLocaleLowerCase())).join(' ')}>
 				<div className='damage-modifiers'>
-					{kitDamageModificationSection}
+					{getKitDamageModificationSection()}
 				</div>
 
 				<div className='benefits'>
-					<h4>Benefits</h4>
+					<h3>Benefits</h3>
 					<div className='features'>
 						{character.modifierBenefits?.map(f =>
 							<FeatureComponent

--- a/src/components/panels/hero-sheet/reference/feature-reference-card.scss
+++ b/src/components/panels/hero-sheet/reference/feature-reference-card.scss
@@ -1,0 +1,5 @@
+.feature-reference.card {
+    li li {
+        list-style-type: disc;
+    }
+}

--- a/src/components/panels/hero-sheet/reference/feature-reference-card.tsx
+++ b/src/components/panels/hero-sheet/reference/feature-reference-card.tsx
@@ -1,6 +1,8 @@
 import { CharacterSheet } from '../../../../models/character-sheet';
 import { FeatureComponent } from '../components/feature-component';
 
+import './feature-reference-card.scss';
+
 interface Props {
 	character: CharacterSheet;
 	classes?: string | string[];

--- a/src/components/panels/hero-sheet/reference/turn-reference-card.tsx
+++ b/src/components/panels/hero-sheet/reference/turn-reference-card.tsx
@@ -77,7 +77,10 @@ export const PrimaryReferenceCard = (props: Props) => {
 	};
 
 	const getTurnReference = () => {
-		if ((character.heroicResourceFeature?.data.gains.length || 0) <= 3) {
+		const hasManyHeroicResourceGains = (character.heroicResourceFeature?.data.gains.length || 0) > 3;
+		const hasDamageImmunitiesWeaknesses = (character.immunities?.length || character.weaknesses?.length);
+		const showTurnOverview = !(hasManyHeroicResourceGains || hasDamageImmunitiesWeaknesses);
+		if (showTurnOverview) {
 			return (
 				<>
 					<h3>Your Turn</h3>

--- a/src/components/panels/hero-sheet/reference/turn-reference-card.tsx
+++ b/src/components/panels/hero-sheet/reference/turn-reference-card.tsx
@@ -1,5 +1,6 @@
+import { Fragment, useMemo } from 'react';
+
 import { CharacterSheet } from '../../../../models/character-sheet';
-import { Fragment } from 'react';
 
 import './turn-reference-card.scss';
 
@@ -7,78 +8,95 @@ interface Props {
 	character: CharacterSheet;
 }
 
-export const TurnReferenceCard = (props: Props) => {
-	const character = props.character;
-	const resourceGainsCount = character.heroicResourceFeature?.data.gains.length || 0;
-	const resourceSection = (character.heroicResourceFeature ?
-		<>
-			<h3>Heroic Resource</h3>
-			<p>You gain {character.heroicResourceName} in the following ways:</p>
-			<div className='heroic-resource-gain'>
-				<div className='header value'>Amount</div>
-				<div className='header trigger'>When</div>
-				{character.heroicResourceFeature.data.gains.map((g, n) =>
-					<Fragment key={n}>
-						<div className='value'>{g.value}</div>
-						<div className='trigger'>{g.trigger}</div>
-					</Fragment>
-				)}
-			</div>
-		</>
-		: undefined);
-
-	const actionsDetails = (resourceSection
-		? undefined :
-		<div className='actions-maneuvers'>
-			<div className='move-actions'>
-				<h5>Move Actions</h5>
-				<ul>
-					<li>Advance</li>
-					<li>Disengage</li>
-					<li>Ride</li>
-				</ul>
-			</div>
-			<div className='main-actions'>
-				<h5>Main Actions</h5>
-				<ul>
-					<li>Charge</li>
-					<li>Defend</li>
-					<li>Heal</li>
-					<li>Free Strike</li>
-					<li>Trade for Maneuver</li>
-					<li>Trade for Move</li>
-				</ul>
-			</div>
-			<div className='maneuvers'>
-				<h5>Maneuvers</h5>
-				<ul>
-					<li>Aid Attack</li>
-					<li>Catch Breath</li>
-					<li>Escape Grab</li>
-					<li>Grab</li>
-					<li>Make or Assist Test</li>
-					<li>Search for Hidden Creature</li>
-					<li>Stand Up</li>
-					<li>Use Consumable</li>
-				</ul>
-			</div>
-		</div>
+export const PrimaryReferenceCard = (props: Props) => {
+	const character = useMemo(
+		() => props.character,
+		[ props.character ]
 	);
+
+	const getResourceSection = () => {
+		if (character.heroicResourceFeature) {
+			return (
+				<>
+					<h3>Heroic Resource</h3>
+					<p>You gain {character.heroicResourceName} in the following ways:</p>
+					<div className='heroic-resource-gain'>
+						<div className='header value'>Amount</div>
+						<div className='header trigger'>When</div>
+						{character.heroicResourceFeature.data.gains.map((g, n) =>
+							<Fragment key={n}>
+								<div className='value'>{g.value}</div>
+								<div className='trigger'>{g.trigger}</div>
+							</Fragment>
+						)}
+					</div>
+				</>
+			);
+		};
+	};
+
+	const getActionsDetails = () => {
+		if (!getResourceSection()) {
+			return (
+				<div className='actions-maneuvers'>
+					<div className='move-actions'>
+						<h5>Move Actions</h5>
+						<ul>
+							<li>Advance</li>
+							<li>Disengage</li>
+							<li>Ride</li>
+						</ul>
+					</div>
+					<div className='main-actions'>
+						<h5>Main Actions</h5>
+						<ul>
+							<li>Charge</li>
+							<li>Defend</li>
+							<li>Heal</li>
+							<li>Free Strike</li>
+							<li>Trade for Maneuver</li>
+							<li>Trade for Move</li>
+						</ul>
+					</div>
+					<div className='maneuvers'>
+						<h5>Maneuvers</h5>
+						<ul>
+							<li>Aid Attack</li>
+							<li>Catch Breath</li>
+							<li>Escape Grab</li>
+							<li>Grab</li>
+							<li>Make or Assist Test</li>
+							<li>Search for Hidden Creature</li>
+							<li>Stand Up</li>
+							<li>Use Consumable</li>
+						</ul>
+					</div>
+				</div>
+			);
+		}
+	};
+
+	const getTurnReference = () => {
+		if ((character.heroicResourceFeature?.data.gains.length || 0) <= 3) {
+			return (
+				<>
+					<h3>Your Turn</h3>
+					<p>Each creature can take a move action, a maneuver, and an action on their turn — in any order</p>
+					{getActionsDetails()}
+				</>
+			);
+		}
+	};
+
 	return (
 		<div className='turn-reference card'>
-			{resourceSection}
+			{getResourceSection()}
 			<h3>Spending Hero Tokens</h3>
 			<p><strong>1 Token:</strong> Gain 2 Surges.</p>
 			<p><strong>1 Token:</strong> Succeed on a saving throw instead of failing.</p>
 			<p><strong>1 Token:</strong> Reroll a test and use the new result.</p>
 			<p><strong>2 Tokens:</strong> On your turn or when you take damage, regain Stamina equal to your Recovery value without spending a Recovery.</p>
-			{resourceGainsCount > 3
-				? undefined :
-				<>
-					<h3>Your Turn</h3>
-					<p>Each creature can take a move action, a maneuver, and an action on their turn — in any order</p>
-					{actionsDetails}
-				</>}
+			{getTurnReference()}
 		</div>
 	);
 };

--- a/src/utils/character-sheet-formatter.ts
+++ b/src/utils/character-sheet-formatter.ts
@@ -6,6 +6,10 @@ import { Feature } from '../models/feature';
 import { FeatureType } from '../enums/feature-type';
 import { Utils } from './utils';
 
+import rollT1Icon from '../assets/icons/power-roll-t1.svg';
+import rollT2Icon from '../assets/icons/power-roll-t2.svg';
+import rollT3Icon from '../assets/icons/power-roll-t3.svg';
+
 export class CharacterSheetFormatter {
 	static getPageId = (heroId: string, pageNum: number) => {
 		return `hero-sheet-${heroId}-page-${pageNum}`;
@@ -47,6 +51,30 @@ export class CharacterSheetFormatter {
 			.replace(/11 -\t/g, '≤ 11\t')
 			.replace(/17 \+/g, '17+\t')
 			.replace(/\n\* \*\*(.*?)\*\*(:) /g, '\n   • $1$2\t')
+			.replace(/\n\* /g, '\n   • ');
+		return text;
+	};
+
+	static enhanceFeatures = (features: Feature[]): Feature[] => {
+		features.sort(this.sortFeatures);
+		const results: Feature[] = [];
+		for (const feature of features) {
+			results.push(this.enhanceFeature(feature));
+		}
+		return results;
+	};
+
+	static enhanceFeature = (feature: Feature): Feature => {
+		const result = Utils.copy(feature);
+		result.description = this.enhanceMarkdown(feature.description);
+		return result;
+	};
+
+	static enhanceMarkdown = (text: string) => {
+		text = text
+			.replace(/\|\s+≤\s*11\s+\|/g, `|![≤ 11](${rollT1Icon})|`)
+			.replace(/\|\s+12\s*-\s*16\s+\|/g, `|![12 - 16](${rollT2Icon})|`)
+			.replace(/\|\s+≥?\s*17\s*\+?\s+\|/g, `|![17+](${rollT3Icon})|`)
 			.replace(/\n\* /g, '\n   • ');
 		return text;
 	};
@@ -167,7 +195,8 @@ export class CharacterSheetFormatter {
 		const lines: string[] = [];
 		for (const section of sections) {
 			let text = CharacterSheetFormatter.abilitySection(section);
-			text = CharacterSheetFormatter.cleanupText(text);
+			// text = CharacterSheetFormatter.cleanupText(text);
+			text = CharacterSheetFormatter.enhanceMarkdown(text);
 			lines.push(text);
 		}
 		return lines.join('\n');
@@ -181,9 +210,9 @@ export class CharacterSheetFormatter {
 				break;
 			case 'field':
 				if (section.value !== 0) {
-					text = `\n${section.name} ${section.value}${section.repeatable ? '+' : ''}:\n${section.effect}`;
+					text = `\n**${section.name} ${section.value}${section.repeatable ? '+' : ''}:**\n${section.effect}`;
 				} else {
-					text = `\n${section.name}:\n${section.effect}`;
+					text = `\n**${section.name}:**\n${section.effect}`;
 				}
 				break;
 		}

--- a/src/utils/character-sheet-formatter.ts
+++ b/src/utils/character-sheet-formatter.ts
@@ -74,22 +74,20 @@ export class CharacterSheetFormatter {
 		text = text
 			.replace(/\|\s+≤\s*11\s+\|/g, `|![≤ 11](${rollT1Icon})|`)
 			.replace(/\|\s+12\s*-\s*16\s+\|/g, `|![12 - 16](${rollT2Icon})|`)
-			.replace(/\|\s+≥?\s*17\s*\+?\s+\|/g, `|![17+](${rollT3Icon})|`)
-			.replace(/\n\* /g, '\n   • ');
+			.replace(/\|\s+≥?\s*17\s*\+?\s+\|/g, `|![17+](${rollT3Icon})|`);
 		return text;
 	};
 
-	private static splitAt = 2;
-	static shortenText = (text: string) => {
+	static shortenText = (text: string, splitAt: number = 2) => {
 		const split = text.split('\n');
-		if (split.length > this.splitAt) {
-			text = split.slice(0, this.splitAt).join('\n') + '\n*…(continued in reference)…*';
+		if (split.length > splitAt) {
+			text = split.slice(0, splitAt).join('\n') + '\n*…(continued in reference)…*';
 		}
 		return this.cleanupText(text);
 	};
 
-	static isLongFeature = (f: Feature): boolean => {
-		return f.description.split('\n').length > this.splitAt;
+	static isLongFeature = (f: Feature, check: number = 2): boolean => {
+		return f.description.split('\n').length > check;
 	};
 
 	// There are some that might just be *too* long for the Class Features section,
@@ -157,11 +155,17 @@ export class CharacterSheetFormatter {
 
 	static calculateAbilitySize = (ability: AbilitySheet): number => {
 		let size = 0;
-		size += Math.ceil(ability.rollT1Effect?.length || 0 / 40);
-		size += Math.ceil(ability.rollT2Effect?.length || 0 / 40);
-		size += Math.ceil(ability.rollT3Effect?.length || 0 / 40);
-		size += Math.ceil(ability.effect?.length || 0 / 50);
+		size += this.countLines(ability.rollT1Effect, 40);
+		size += this.countLines(ability.rollT2Effect, 40);
+		size += this.countLines(ability.rollT3Effect, 40);
+		size += this.countLines(ability.effect, 50);
 		return size;
+	};
+
+	static countLines = (text: string | undefined, lineWidth: number) => {
+		return text?.split('\n').reduce((n, l) => {
+			return n + Math.ceil(l.length / lineWidth);
+		}, 0) || 0;
 	};
 
 	static characteristicOrder: string[] = [
@@ -195,7 +199,6 @@ export class CharacterSheetFormatter {
 		const lines: string[] = [];
 		for (const section of sections) {
 			let text = CharacterSheetFormatter.abilitySection(section);
-			// text = CharacterSheetFormatter.cleanupText(text);
 			text = CharacterSheetFormatter.enhanceMarkdown(text);
 			lines.push(text);
 		}
@@ -210,9 +213,9 @@ export class CharacterSheetFormatter {
 				break;
 			case 'field':
 				if (section.value !== 0) {
-					text = `\n**${section.name} ${section.value}${section.repeatable ? '+' : ''}:**\n${section.effect}`;
+					text = `\n#### ${section.name} ${section.value}${section.repeatable ? '+' : ''}:\n${section.effect}`;
 				} else {
-					text = `\n**${section.name}:**\n${section.effect}`;
+					text = `\n#### ${section.name}:\n${section.effect}`;
 				}
 				break;
 		}

--- a/src/utils/sheet-builder.ts
+++ b/src/utils/sheet-builder.ts
@@ -217,7 +217,8 @@ export class CharacterSheetBuilder {
 				.filter(f => f.type === FeatureType.Text)
 				.filter(CharacterSheetFormatter.isLongFeature);
 			sheet.classFeatures = CharacterSheetFormatter.convertFeatures(classFeatures);
-			sheet.featuresReferenceOther = sheet.featuresReferenceOther?.concat(CharacterSheetFormatter.convertFeatures(longFeatures));
+			sheet.featuresReferenceOther = sheet.featuresReferenceOther?.concat(CharacterSheetFormatter.enhanceFeatures(longFeatures));
+			// sheet.featuresReferenceOther = sheet.featuresReferenceOther?.concat(longFeatures.sort(CharacterSheetFormatter.sortFeatures));
 
 			coveredFeatureIds = coveredFeatureIds.concat(classFeatures.map(f => f.id));
 		}
@@ -225,7 +226,7 @@ export class CharacterSheetBuilder {
 		if (hero.career) {
 			sheet.careerName = hero.career.name;
 			const careerFeatures = hero.career.features;
-			sheet.careerBenefits = careerFeatures;
+			sheet.careerBenefits = CharacterSheetFormatter.convertFeatures(careerFeatures);
 			coveredFeatureIds = coveredFeatureIds.concat(careerFeatures.map(f => f.id));
 
 			const incident = hero.career.incitingIncidents.options.find(

--- a/src/utils/sheet-builder.ts
+++ b/src/utils/sheet-builder.ts
@@ -49,7 +49,7 @@ export class CharacterSheetBuilder {
 			const ancestryTraits = ancestryFeatures.filter(f => f.type !== FeatureType.Choice);
 			const longFeatures = ancestryTraits
 				.filter(f => f.type === FeatureType.Text)
-				.filter(CharacterSheetFormatter.isLongFeature);
+				.filter(f => CharacterSheetFormatter.isLongFeature(f));
 			sheet.ancestryTraits = CharacterSheetFormatter.convertFeatures(ancestryTraits);
 			sheet.featuresReferenceOther = sheet.featuresReferenceOther?.concat(longFeatures);
 
@@ -218,7 +218,6 @@ export class CharacterSheetBuilder {
 				.filter(CharacterSheetFormatter.isLongFeature);
 			sheet.classFeatures = CharacterSheetFormatter.convertFeatures(classFeatures);
 			sheet.featuresReferenceOther = sheet.featuresReferenceOther?.concat(CharacterSheetFormatter.enhanceFeatures(longFeatures));
-			// sheet.featuresReferenceOther = sheet.featuresReferenceOther?.concat(longFeatures.sort(CharacterSheetFormatter.sortFeatures));
 
 			coveredFeatureIds = coveredFeatureIds.concat(classFeatures.map(f => f.id));
 		}


### PR DESCRIPTION
- Adds a card underneath the 'Turn Reference' card that displays Damage Immunities and Weaknesses if the her has any.
- Improved logic for ensuring Ancestry Traits don't go on too long and cause clipping at the bottom of the page
- Improved display/rendering of Ability Effects, including using power roll tier icons in roll tables.