### PR TITLE
Add characteristic symbol hint to Classic sheet

### DIFF
--- a/src/components/panels/hero-sheet/stats-resources-card/stats-resources-card.scss
+++ b/src/components/panels/hero-sheet/stats-resources-card/stats-resources-card.scss
@@ -33,13 +33,12 @@
         }
     }
 
-
     .recoveries .label-above.fancy>.labeled-field-content {
         background-image: none;
         border: 4px solid common.$color-medium;
         border-radius: 50%;
         width: 80px;
-        margin: 0;
+        margin: -2px 0 0;
         align-self: center;
     }
 
@@ -57,6 +56,14 @@
         grid-template-columns: repeat(5, 1fr);
 
         .label-above.fancy {
+            label {
+                text-wrap: nowrap;
+            }
+            .symbol {
+                @include common.font-potency;
+                display: inline-block;
+                transform: translateY(2px);
+            }
             >.labeled-field-content {
                 @include common.beveled-fancy-1(15px, 4px, 3px, 2px, common.$color-medium);
                 align-self: center;
@@ -210,6 +217,10 @@
         display: flex;
         justify-content: center;
         align-items: stretch;
+
+        label {
+            align-self: center;
+        }
     }
     .stamina .reference,
     .recoveries .reference,

--- a/src/components/panels/hero-sheet/stats-resources-card/stats-resources-card.tsx
+++ b/src/components/panels/hero-sheet/stats-resources-card/stats-resources-card.tsx
@@ -1,6 +1,7 @@
 import { LabeledBooleanField, LabeledTextField } from '../components/labeled-field';
 import { CharacterSheet } from '../../../../models/character-sheet';
 import { Options } from '../../../../models/options';
+import { Utils } from '../../../../utils/utils';
 
 import './stats-resources-card.scss';
 
@@ -17,31 +18,26 @@ export const StatsResourcesCard = (props: Props) => {
 		<div className='stats-resources card'>
 			<div className='characteristics-measurements'>
 				<div className='characteristics'>
-					<LabeledTextField
-						label='Might'
-						content={character.might}
-						additionalClasses={[ 'label-above', 'fancy' ]}
-					/>
-					<LabeledTextField
-						label='Agility'
-						content={character.agility}
-						additionalClasses={[ 'label-above', 'fancy' ]}
-					/>
-					<LabeledTextField
-						label='Reason'
-						content={character.reason}
-						additionalClasses={[ 'label-above', 'fancy' ]}
-					/>
-					<LabeledTextField
-						label='Intuition'
-						content={character.intuition}
-						additionalClasses={[ 'label-above', 'fancy' ]}
-					/>
-					<LabeledTextField
-						label='Presence'
-						content={character.presence}
-						additionalClasses={[ 'label-above', 'fancy' ]}
-					/>
+					<div className='labeled-field label-above fancy'>
+						<label><span className='symbol'>M</span>ight</label>
+						<div className='labeled-field-content'><span>{Utils.isNullOrEmpty(character.might?.toString()) ? <>&nbsp;</> : character.might}</span></div>
+					</div>
+					<div className='labeled-field label-above fancy'>
+						<label><span className='symbol'>A</span>gility</label>
+						<div className='labeled-field-content'><span>{Utils.isNullOrEmpty(character.agility?.toString()) ? <>&nbsp;</> : character.agility}</span></div>
+					</div>
+					<div className='labeled-field label-above fancy'>
+						<label><span className='symbol'>R</span>eason</label>
+						<div className='labeled-field-content'><span>{Utils.isNullOrEmpty(character.reason?.toString()) ? <>&nbsp;</> : character.reason}</span></div>
+					</div>
+					<div className='labeled-field label-above fancy'>
+						<label><span className='symbol'>I</span>ntuition</label>
+						<div className='labeled-field-content'><span>{Utils.isNullOrEmpty(character.intuition?.toString()) ? <>&nbsp;</> : character.intuition}</span></div>
+					</div>
+					<div className='labeled-field label-above fancy'>
+						<label><span className='symbol'>P</span>resence</label>
+						<div className='labeled-field-content'><span>{Utils.isNullOrEmpty(character.presence?.toString()) ? <>&nbsp;</> : character.presence}</span></div>
+					</div>
 				</div>
 				<div className='measurements'>
 					<LabeledTextField


### PR DESCRIPTION
Adds a symbol 'hint' to the Characteristics labels on the Classic Sheet to help reinforce which abbreviation is which characteristic:
<img width="484" height="113" alt="image" src="https://github.com/user-attachments/assets/cf902e25-fec5-4d1f-8043-f058a83d4f6b" />
