### PR TITLE
Fix cache version update on build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,6 +27,12 @@ export default defineConfig({
 			name: 'dev-pwa-files',
 			configureServer(server) {
 				// Serve manifest.json during development
+				// Handle both possible paths due to Vite's base path resolution
+				server.middlewares.use('/forgesteel/forgesteel/manifest.json', (_, res) => {
+					const manifest = generateManifest();
+					res.setHeader('Content-Type', 'application/json');
+					res.end(JSON.stringify(manifest, null, 2));
+				});
 				server.middlewares.use('/forgesteel/manifest.json', (_, res) => {
 					const manifest = generateManifest();
 					res.setHeader('Content-Type', 'application/json');


### PR DESCRIPTION
This let me simplify some other code. I'm sorry this didn't even occur to me when I first wrote it.

The date stamp obviously generates every time the TypeScript is transpiled, so the cache name should always be unique now.

I also changed it so that we're _only_ using the cache for offline. When online, we should never even look at the cache.

Lastly, I think I figured out why the `manifest.json` was returning an error sometimes. It had to do with the base URL from Vite. An update to the manifest plugin should solve the issue once and for all 🤞