### PR TITLE
Further Classic Encounter sheet improvements

### DIFF
--- a/src/components/pages/classic-sheet/common.scss
+++ b/src/components/pages/classic-sheet/common.scss
@@ -107,12 +107,12 @@ main#classic-sheet {
         }
 
         h3 {
-            line-height: 1.6rem;
+            line-height: round(1.6rem, 1px);
             font-size: round(1.2rem, 1px);
         }
 
         h4 {
-            line-height: 1.4rem;
+            line-height: round(1.4rem, 1px);
             text-transform: none;
             font-size: round(1.1rem, 1px);
             font-weight: 450;
@@ -151,7 +151,7 @@ main#classic-sheet {
         section.container,
         .beveled {
             @include borders.beveled(10px, 2px, $color-light);
-            padding: 0.5rem;
+            padding: round(0.5rem, 1px);
         }
 
         .card section.bordered {
@@ -161,8 +161,8 @@ main#classic-sheet {
 
             h3 {
                 font-size: round(1rem, 1px);
-                line-height: 1rem;
-                height: 1rem;
+                line-height: round(1rem, 1px);
+                height: round(1rem, 1px);
                 font-weight: 450;
                 background: #fff;
                 display: inline-block;
@@ -186,7 +186,7 @@ main#classic-sheet {
 
             &.two-column {
                 column-count: 2;
-                column-gap: 25px;
+                column-gap: 15px;
 
                 background-image: linear-gradient(0deg, $color-light, $color-light);
                 background-size: 2px 100%;
@@ -196,11 +196,13 @@ main#classic-sheet {
 
             &.three-column {
                 column-count: 3;
-                column-gap: 25px;
+                $gap: 15px;
+                column-gap: $gap;
 
-                $l1-s: calc(100% / 3 - 1px);
+                $col-w: calc((100% - 2 * $gap)/ 3);
+                $l1-s: calc($col-w + ($gap / 2) - 1px);
                 $l1-e: calc($l1-s + 2px);
-                $l2-s: calc(200% / 3 - 1px);
+                $l2-s: calc(2 * $col-w + (3 * $gap / 2) - 1px);
                 $l2-e: calc($l2-s + 2px);
                 background-image: linear-gradient(90deg, transparent $l1-s,
                     $color-light $l1-s, $color-light $l1-e,

--- a/src/components/panels/classic-sheet/career-card/career-card.scss
+++ b/src/components/panels/classic-sheet/career-card/career-card.scss
@@ -11,7 +11,7 @@
             @include common.font-serif;
             text-align: center;
             font-size: round(1.3rem, 1px);
-            line-height: 1.6rem;
+            line-height: round(1.6rem, 1px);
             padding: 7px 0;
             margin: 10px 25px 20px;
             min-height: 36px;

--- a/src/components/panels/classic-sheet/components/ability-component.scss
+++ b/src/components/panels/classic-sheet/components/ability-component.scss
@@ -59,10 +59,6 @@
             gap: 5px;
         }
 
-        .distance-target {
-            margin-left: -5px;
-        }
-
         .action-type {
             text-align: right;
         }
@@ -91,7 +87,6 @@
             }
         }
     }
-
 
     p.trigger,
     .effect p {

--- a/src/components/panels/classic-sheet/components/feature-component.scss
+++ b/src/components/panels/classic-sheet/components/feature-component.scss
@@ -82,6 +82,10 @@
             }
         }
 
+        strong {
+            font-weight: 700;
+        }
+
         blockquote, blockquote * {
             font-style: italic;
         }
@@ -89,7 +93,9 @@
         .potency {
             @include common.font-potency();
             display: inline-block;
-            transform: translateY(1px);
+            transform: translateY(2px);
+            margin-top: 0;
+            margin-bottom: 0;
         }
     }
 

--- a/src/components/panels/classic-sheet/components/feature-component.tsx
+++ b/src/components/panels/classic-sheet/components/feature-component.tsx
@@ -383,7 +383,7 @@ const MaliceFeatureComponent = (feature: FeatureMalice) => {
 		return `${characteristics.join(' or ')} Test`;
 	};
 	const sections = (feature.data.sections ?? []).map((section, n) => (typeof section === 'string') ?
-		<Markdown key={n} text={section} />
+		<Markdown key={n} text={section} className='feature-description' />
 		:
 		<div className='power-roll' key={n}>
 			<div className='header'>{getHeader(section.characteristic)}</div>
@@ -413,12 +413,12 @@ const MaliceFeatureComponent = (feature: FeatureMalice) => {
 
 	return (
 		<div className='feature feature-malice ability' key={feature.id}>
-			<div className='cost'>{feature.data.cost}</div>
+			<img src={iconSrc} className='icon' />
 			<div className='details'>
 				<div className='header'>
 					<label className='name'>{feature.name}</label>
 					<div className='ability-type'>
-						<img src={iconSrc} className='icon' />
+						{feature.data.cost} Malice
 					</div>
 				</div>
 				{sections}
@@ -429,14 +429,15 @@ const MaliceFeatureComponent = (feature: FeatureMalice) => {
 
 const MaliceAbilityFeatureComponent = (feature: FeatureMaliceAbility) => {
 	const abilitySheet = ClassicSheetBuilder.buildAbilitySheet(feature.data.ability, undefined);
-	abilitySheet.abilityType = undefined;
+	// abilitySheet.abilityType = undefined;
+	const icon = SheetFormatter.getAbilityIcon(abilitySheet);
+
 	return (
 		<div className='feature feature-malice' key={feature.id}>
-			<div className='cost'>{feature.data.ability.cost}</div>
+			<img src={icon} className='icon' />
 			<div className='details'>
 				<AbilityComponent
 					ability={abilitySheet}
-					includeIcon={true}
 				/>
 			</div>
 		</div>

--- a/src/components/panels/classic-sheet/encounter-header/encounter-header.scss
+++ b/src/components/panels/classic-sheet/encounter-header/encounter-header.scss
@@ -20,8 +20,8 @@
 
         .labeled-field.difficulty {
             span {
-                padding: 0 10px;
-                min-width: 75px;
+                padding: 0 20px;
+                min-width: 100px;
             }
         }
 

--- a/src/components/panels/classic-sheet/encounter-roster/encounter-roster.scss
+++ b/src/components/panels/classic-sheet/encounter-roster/encounter-roster.scss
@@ -153,6 +153,10 @@
                 common.$color-light calc(100% - 7px), transparent calc(100% - 7px)) 1 100%;
     }
 
+    .terrain-object .ev {
+        margin-top: -10px;
+    }
+
     .stamina-tracker {
         padding-left: 0;
         padding-right: 0;

--- a/src/components/panels/classic-sheet/encounter-sheet/encounter-sheet-page.scss
+++ b/src/components/panels/classic-sheet/encounter-sheet/encounter-sheet-page.scss
@@ -7,5 +7,5 @@
 #classic-sheet .page-1 {
     display: grid;
     place-items: stretch;
-    grid-template-rows: min-content min-content 1fr;
+    grid-template-rows: min-content 1fr min-content;
 }

--- a/src/components/panels/classic-sheet/immunities-weaknesses-card/immunities-weaknesses-card.scss
+++ b/src/components/panels/classic-sheet/immunities-weaknesses-card/immunities-weaknesses-card.scss
@@ -16,6 +16,7 @@
         @include common.font-serif();
         display: block;
         text-align: center;
+        margin: -4px -4px 4px;
     }
 
     ul {

--- a/src/components/panels/classic-sheet/malice-card/malice-card.scss
+++ b/src/components/panels/classic-sheet/malice-card/malice-card.scss
@@ -24,5 +24,16 @@
             background-image: linear-gradient(180deg, common.$color-general-monster, transparent);
             border-radius: 6px 6px 0 0;
         }
+
+        .feature {
+            .power-roll {
+                // margin-left: -10px;
+
+                .header {
+                    margin-top: -5px;
+                    margin-left: 0;
+                }
+            }
+        }
     }
 }

--- a/src/components/panels/classic-sheet/malice-card/malice-card.tsx
+++ b/src/components/panels/classic-sheet/malice-card/malice-card.tsx
@@ -21,38 +21,36 @@ export const MaliceCard = (props: Props) => {
 				<br />
 				<span>At the start of a monster’s turn, you can spend malice to activate a Malice feature</span>
 			</h2>
-			<div className='malice-features'>
-				<ul className='features-container three-column'>
-					{MonsterData.malice.map((basicMalice, i) => {
-						return (
-							<li key={basicMalice.id}>
-								{
-									i === 0 ?
-										<h3>
-											Basic Malice Features
-											<br />
-											<span>All creatures have the following Malice features</span>
-										</h3>
-										: null
-								}
-								<FeatureComponent feature={basicMalice} />
-							</li>
-						);
-					})}
-					{encounter.malice?.map(m => {
-						return (
-							<Fragment key={`malice-group-${m.monster}`}>
-								{m.malice.map((malice, i) =>
-									<li key={malice.id}>
-										{i === 0 ? <h3>{m.monster} Malice</h3> : null}
-										<FeatureComponent feature={malice} />
-									</li>
-								)}
-							</Fragment>
-						);
-					})}
-				</ul>
-			</div>
+			<ul className='malice-features features-container three-column'>
+				{MonsterData.malice.map((basicMalice, i) => {
+					return (
+						<li key={basicMalice.id}>
+							{
+								i === 0 ?
+									<h3>
+										Basic Malice Features
+										<br />
+										<span>All creatures have the following Malice features</span>
+									</h3>
+									: null
+							}
+							<FeatureComponent feature={basicMalice} />
+						</li>
+					);
+				})}
+				{encounter.malice?.map(m => {
+					return (
+						<Fragment key={`malice-group-${m.monster}`}>
+							{m.malice.map((malice, i) =>
+								<li key={malice.id}>
+									{i === 0 ? <h3>{m.monster} Malice</h3> : null}
+									<FeatureComponent feature={malice} />
+								</li>
+							)}
+						</Fragment>
+					);
+				})}
+			</ul>
 		</div>
 	);
 };

--- a/src/components/panels/classic-sheet/reference/primary-reference-card.scss
+++ b/src/components/panels/classic-sheet/reference/primary-reference-card.scss
@@ -23,7 +23,7 @@
     padding: 10px 15px;
 
     font-size: round(1.1rem, 1px);
-    line-height: 1.3rem;
+    line-height: round(1.3rem, 1px);
     strong {
         font-weight: 500;
     }
@@ -52,7 +52,7 @@
 
         .trigger {
             margin-bottom: 2px;
-            line-height: 1.4rem;
+            line-height: round(1.4re, 1px);
         }
 
         .header {

--- a/src/components/panels/classic-sheet/reference/reference-cards.scss
+++ b/src/components/panels/classic-sheet/reference/reference-cards.scss
@@ -49,7 +49,7 @@
     *:not(h2) {
         @include common.font-serif();
         font-size: round(1.1rem, 1px);
-        line-height: 1.3rem;
+        line-height: round(1.3rem, 1px);
         color: var(--color-text-lighter);
     }
 

--- a/src/logic/classic-sheet/classic-sheet-builder.ts
+++ b/src/logic/classic-sheet/classic-sheet-builder.ts
@@ -29,33 +29,47 @@ export class ClassicSheetBuilder {
 
 		sheet.name = sheet.name.replace(/\s*Benefit and Drawback\s*/, '').trim();
 
-		if (ability.cost === 'signature') {
-			sheet.isSignature = true;
-			sheet.abilityType = 'Signature Ability';
-		} else if (ability.cost > 0) {
-			sheet.abilityType = 'Heroic Ability';
-		} else if (ability.type.usage === AbilityUsage.Trigger) {
-			sheet.abilityType = 'Triggered Action';
-		} else if (ability.type.usage === AbilityUsage.FreeStrike) {
-			sheet.abilityType = 'Free Strike';
-			if (ability.name.toLowerCase().includes('melee')) {
-				sheet.name = 'Melee Free Strike';
-			} else if (ability.name.toLowerCase().includes('ranged')) {
-				sheet.name = 'Ranged Free Strike';
+		if (isHero) {
+			if (ability.cost === 'signature') {
+				sheet.isSignature = true;
+				sheet.abilityType = 'Signature Ability';
+			} else if (ability.cost > 0) {
+				sheet.abilityType = 'Heroic Ability';
+			} else if (ability.type.usage === AbilityUsage.Trigger) {
+				sheet.abilityType = 'Triggered Action';
+			} else if (ability.type.usage === AbilityUsage.FreeStrike) {
+				sheet.abilityType = 'Free Strike';
+				if (ability.name.toLowerCase().includes('melee')) {
+					sheet.name = 'Melee Free Strike';
+				} else if (ability.name.toLowerCase().includes('ranged')) {
+					sheet.name = 'Ranged Free Strike';
+				}
+			} else if (ability.type.usage === AbilityUsage.Maneuver) {
+				sheet.abilityType = 'Maneuver';
+			} else if (ability.type.usage === AbilityUsage.Move) {
+				sheet.abilityType = 'Move Action';
+			} else if (ability.keywords.includes('Performance')) {
+				sheet.abilityType = 'Performance';
 			}
-		} else if (ability.type.usage === AbilityUsage.Maneuver) {
-			sheet.abilityType = 'Maneuver';
-		} else if (ability.type.usage === AbilityUsage.Move) {
-			sheet.abilityType = 'Move Action';
-		} else if (ability.keywords.includes('Performance')) {
-			sheet.abilityType = 'Performance';
 		}
 
 		if (isMonster) {
-			if (sheet.isSignature) {
+			if (ability.cost === 'signature') {
 				sheet.abilityType = 'Signature Ability';
-			} else {
+			} else if (ability.cost > 0) {
+				sheet.abilityType = `${ability.cost} Malice`;
+			} else if (creature.retainer?.level) {
 				sheet.abilityType = 'Encounter';
+			} else {
+				sheet.abilityType = '';
+			}
+		}
+
+		if (creature === undefined) {
+			if (ability.cost !== 'signature' && ability.cost > 0) {
+				sheet.abilityType = `${ability.cost} Malice`;
+			} else {
+				sheet.abilityType = '';
 			}
 		}
 

--- a/src/logic/classic-sheet/sheet-formatter.ts
+++ b/src/logic/classic-sheet/sheet-formatter.ts
@@ -613,6 +613,8 @@ export class SheetFormatter {
 		// Ability Type
 		if (type?.includes('Trigger')) {
 			abilityIcon = triggerIcon;
+		} else if (type?.includes('Villain')) {
+			abilityIcon = skullIcon;
 		}
 
 		return abilityIcon;

--- a/src/logic/hero-sheet/hero-sheet-builder.ts
+++ b/src/logic/hero-sheet/hero-sheet-builder.ts
@@ -234,7 +234,7 @@ export class HeroSheetBuilder {
 			}
 			const dividedClassFeatures = SheetFormatter.divideFeatures(classFeatures.map(f => f.feature), classFeatureSpace);
 
-			sheet.classFeatures = SheetFormatter.convertFeatures(dividedClassFeatures.displayed);
+			sheet.classFeatures = SheetFormatter.enhanceFeatures(SheetFormatter.convertFeatures(dividedClassFeatures.displayed));
 
 			const referenceFeatures = classFeatures.filter(f => dividedClassFeatures.referenceIds.includes(f.feature.id));
 			sheet.featuresReferenceOther = sheet.featuresReferenceOther?.concat(referenceFeatures);

--- a/src/logic/playbook-sheets/encounter-sheet-builder.ts
+++ b/src/logic/playbook-sheets/encounter-sheet-builder.ts
@@ -54,13 +54,19 @@ export class EncounterSheetBuilder {
 		sheet.monsters = encounterMonsters.map(this.buildMonsterSheet);
 
 		const monsterGroups = EncounterLogic.getMonsterGroups(encounter, sourcebooks);
+
+		const seenMalice = new Set<string>();
 		sheet.malice = monsterGroups.filter(group => group.malice.length > 0)
 			.map(group => {
 				const maxLvl = encounterMonsters.reduce((maxLvl, monster) => Math.max(maxLvl, monster.level), 0);
 				const echelon = CreatureLogic.getEchelon(maxLvl);
-				const usableMalice = group.malice.filter(m => m.data.echelon <= echelon);
+				const usableMalice = group.malice
+					.filter(m => m.data.echelon <= echelon)
+					.filter(m => seenMalice.has(m.id) ? false : seenMalice.add(m.id));
 				return ({ monster: group.name, malice: usableMalice });
-			});
+			})
+			.filter(mg => mg.malice.length);
+
 		return sheet;
 	};
 


### PR DESCRIPTION
Fixes several minor bugs in the classic sheet, primarily in the Encounter Sheet

- Duplicate Malice features now get filtered out from displaying on the encounter sheet
- Malice abilities in monster stat blocks now correctly show malice cost instead of 'Encounter'
- Encounter malice features now use the same display format as monster abilities (this also saves space)
- Potencies now get properly displayed in Class Features on hero sheets
- a lot of small css tweaks