### PR TITLE
Fix retainer lvl up stamina bonus

### DIFF
--- a/src/logic/monster-logic.ts
+++ b/src/logic/monster-logic.ts
@@ -79,7 +79,7 @@ export class MonsterLogic {
 			});
 
 		if (monster.retainer && monster.retainer.level) {
-			stamina += 10 * (monster.retainer.level - monster.level);
+			stamina += 9 * (monster.retainer.level - monster.level);
 		}
 
 		return stamina;


### PR DESCRIPTION
In the official release (v1) of the rules the retainer level up bonus for stamina 9 not 10.
(btw. was changed in the June update as far as I can see)

Also see: page 353 of `Draw Steel Monsters v1.pdf`