### PR TITLE
Add 'with captain' to minion stat blocks

### DIFF
--- a/src/components/panels/classic-sheet/monster-card/monster-card.scss
+++ b/src/components/panels/classic-sheet/monster-card/monster-card.scss
@@ -132,12 +132,13 @@ main#classic-sheet .encounter-sheet .monster {
             flex-basis: 100%;
 
             display: grid;
-            grid-template-columns: 1fr 1fr;
+            grid-template-columns: 1fr max-content;
             grid-template-rows: 1fr 1fr;
 
             .weakness,
             .with-captain {
                 text-align: right;
+                text-wrap: nowrap;
             }
         }
     }

--- a/src/components/panels/classic-sheet/monster-card/monster-card.scss
+++ b/src/components/panels/classic-sheet/monster-card/monster-card.scss
@@ -135,7 +135,8 @@ main#classic-sheet .encounter-sheet .monster {
             grid-template-columns: 1fr 1fr;
             grid-template-rows: 1fr 1fr;
 
-            .weakness {
+            .weakness,
+            .with-captain {
                 text-align: right;
             }
         }

--- a/src/components/panels/classic-sheet/monster-card/monster-card.tsx
+++ b/src/components/panels/classic-sheet/monster-card/monster-card.tsx
@@ -55,6 +55,14 @@ export const MonsterCard = (props: Props) => {
 						<label>Movement:</label>
 						<span>{Utils.valueOrDefault(monster.movement, '—')}</span>
 					</div>
+					{
+						monster.withCaptain.length ?
+							<div className='stat with-captain'>
+								<label>With Captain:</label>
+								<span>{monster.withCaptain}</span>
+							</div>
+							: null
+					}
 				</div>
 			</div>
 		);

--- a/src/logic/playbook-sheets/encounter-sheet-builder.ts
+++ b/src/logic/playbook-sheets/encounter-sheet-builder.ts
@@ -128,7 +128,7 @@ export class EncounterSheetBuilder {
 
 	static buildMonsterSheet = (monster: Monster): MonsterSheet => {
 		const level = MonsterLogic.getMonsterLevel(monster);
-		const monsterType = `Lvl ${level} ${monster.role.type}`;
+		const monsterType = `Lvl ${level} ${monster.role.organization} ${monster.role.type}`;
 
 		const speed = MonsterLogic.getSpeed(monster);
 		const immunities = MonsterLogic.getDamageModifiers(monster, DamageModifierType.Immunity);
@@ -154,7 +154,8 @@ export class EncounterSheetBuilder {
 			freeStrike: MonsterLogic.getFreeStrikeDamage(monster),
 			immunity: immunities.map(mod => `${mod.damageType} ${mod.value}`).join(', '),
 			weakness: weaknesses.map(mod => `${mod.damageType} ${mod.value}`).join(', '),
-			movement: speed.modes.map(m => Format.capitalize(m)).join(', ')
+			movement: speed.modes.map(m => Format.capitalize(m)).join(', '),
+			withCaptain: monster.withCaptain
 		};
 
 		sheet.features = MonsterLogic.getFeatures(monster)

--- a/src/models/classic-sheets/encounter-sheet.ts
+++ b/src/models/classic-sheets/encounter-sheet.ts
@@ -57,9 +57,6 @@ export interface MonsterSheet {
 	intuition: number;
 	presence: number;
 
-	// skills?: string[];
-	// languages?: string[];
-
 	keywords: string;
 
 	size: string;
@@ -72,7 +69,7 @@ export interface MonsterSheet {
 	weakness: string;
 	movement: string;
 
-	// recoveries?: RecoveriesSheet;
+	withCaptain: string;
 
 	features?: Feature[];
 	abilities?: AbilitySheet[];


### PR DESCRIPTION
- Adds the 'With Captain' data to Minion stat blocks.
- Also adds monster organization type to the header info

<img width="632" height="272" alt="image" src="https://github.com/user-attachments/assets/284c80f3-3fc2-40f3-945f-eb8dd51d5b0d" />
