### PR TITLE
fix PowerRollPanel header: normal monster logic was not reached

### DIFF
--- a/src/components/panels/power-roll/power-roll-panel.tsx
+++ b/src/components/panels/power-roll/power-roll-panel.tsx
@@ -42,8 +42,8 @@ export const PowerRollPanel = (props: Props) => {
 			return `${props.powerRoll.characteristic.join(' or ')} Test`;
 		}
 
-		if (props.creature && props.autoCalc) {
-			const values = props.powerRoll.characteristic.map(ch => CreatureLogic.getCharacteristic(props.creature!, ch));
+		if ((CreatureLogic.isHero(props.creature) || (CreatureLogic.isMonster(props.creature) && props.creature.retainer)) && props.autoCalc) {
+			const values = props.powerRoll.characteristic.map(ch => CreatureLogic.getCharacteristic(props.creature, ch));
 			const bonus = Collections.max(values, v => v) || 0;
 			const sign = bonus >= 0 ? '+' : '';
 			return `2d10 ${sign} ${bonus}`;


### PR DESCRIPTION
Caused by c9c191f82e1802af53db4926575f07a56ec95155
The last return in `getHeader` of `PowerRollPanel` is the logic for normal monsters (i.e. not retainers), but was not reached anymore, since the `if (props.creature ...`-check for the logic, that should only be used for heroes and retainers, also matched for normal monsters.

Before:
<img width="409" height="367" alt="before" src="https://github.com/user-attachments/assets/e1dacbd2-2f2f-4543-8072-cc60ea71ec08" />

After:
<img width="414" height="366" alt="after" src="https://github.com/user-attachments/assets/270e9064-2834-469d-8066-73be395f9916" />

