### PR TITLE
[Classic Sheet] Add standard ability selection to classic sheet options

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -492,6 +492,9 @@ html[data-theme="dark"] {
 				color: rgba(0, 0, 0, 0.88);
 			}
 		}
+		.ant-select-item {
+			color: rgba(255, 255, 255, 0.88);
+		}
 	}
 
 	.ant-slider .ant-slider-rail {

--- a/src/logic/classic-sheet/sheet-layout.tsx
+++ b/src/logic/classic-sheet/sheet-layout.tsx
@@ -165,9 +165,8 @@ export class SheetLayout {
 	static getAbilityPages = (character: HeroSheet, extraCards: ExtraCards, layout: CardPageLayout, options: Options) => {
 		let allAbilities = character.abilities;
 
-		// future: Allow filtering *these* separately?
-		if (options.showStandardAbilities) {
-			allAbilities = allAbilities.concat(character.standardAbilities);
+		if (options.shownStandardAbilities.length) {
+			allAbilities = allAbilities.concat(character.standardAbilities.filter(a => options.shownStandardAbilities.includes(a.id)));
 		}
 
 		if (options.abilitySort === 'type') {

--- a/src/logic/factory-logic.ts
+++ b/src/logic/factory-logic.ts
@@ -1008,6 +1008,7 @@ export class FactoryLogic {
 			compactView: false,
 			abilityWidth: PanelWidth.Medium,
 			// Classic Sheet
+			shownStandardAbilities: [],
 			classicSheetPageSize: SheetPageSize.Letter,
 			colorSheet: true,
 			sheetTextColor: 'default',

--- a/src/models/options.ts
+++ b/src/models/options.ts
@@ -13,6 +13,7 @@ export interface Options {
 	compactView: boolean;
 	abilityWidth: PanelWidth;
 	// Classic Sheet
+	shownStandardAbilities: string[];
 	classicSheetPageSize: SheetPageSize;
 	colorSheet: boolean;
 	sheetTextColor: 'light' | 'default' | 'dark';


### PR DESCRIPTION
Changes the boolean toggle for showing/not showing standard abilities in the classic hero sheet to a Select so that users can pick and choose which standard abilities they want to show.

Useful for players to have the reminder/description of common things like Knockback, Grab, etc - but not clutter their sheet with things like 'Ride' or 'Advance' if they don't apply.

<img width="350" height="379" alt="image" src="https://github.com/user-attachments/assets/b78b361d-9002-459d-9c1b-7012f82eb519" />

Also adds tooltips to the 'Include Class Features' options to be more descriptive:
<img width="335" height="162" alt="image" src="https://github.com/user-attachments/assets/c3ad4bcd-4076-4543-8ea7-22475a0ba2b1" />
