### PR TITLE
[Classic Sheet] Fix missing options in update logic

### DIFF
--- a/src/logic/update/options-update-logic.ts
+++ b/src/logic/update/options-update-logic.ts
@@ -103,5 +103,13 @@ export class OptionsUpdateLogic {
 		if (options.playerGridSize === undefined) {
 			options.playerGridSize = 50;
 		}
+
+		if (options.showStandardAbilities === undefined) {
+			options.showStandardAbilities = false;
+		}
+
+		if (options.shownStandardAbilities === undefined) {
+			options.shownStandardAbilities = [];
+		}
 	};
 }


### PR DESCRIPTION
Fixes error when trying to view classic sheet for hero:

<img width="529" height="91" alt="image" src="https://github.com/user-attachments/assets/de992eda-3d32-4beb-970b-089f2d9531c4" />
