### PR TITLE
[Classic Sheet] Convert Standard Abilities page to classic sheet

### DIFF
--- a/src/components/main/main.tsx
+++ b/src/components/main/main.tsx
@@ -317,7 +317,13 @@ export const Main = (props: Props) => {
 	};
 
 	const exportStandardAbilities = () => {
-		Utils.export([ 'actions', 'maneuvers' ], 'Standard Abilities', null, 'hero', 'pdf');
+		setSpinning(true);
+		const pageIds: string[] = [];
+		document.querySelectorAll('[id^=hero-sheet-standard-abilities-page-abilities]').forEach(elem => pageIds.push(elem.id));
+		Utils.elementsToPdf(pageIds, 'Standard Abilities', options.classicSheetPageSize, 'high')
+			.then(() => {
+				setSpinning(false);
+			});
 	};
 
 	const setNotes = (hero: Hero, value: string) => {

--- a/src/components/pages/heroes/hero-sheet/hero-sheet-page.tsx
+++ b/src/components/pages/heroes/hero-sheet/hero-sheet-page.tsx
@@ -202,7 +202,7 @@ export const HeroSheetPage = (props: Props) => {
 	};
 
 	const addAbilityPages = (character: HeroSheet, extraCards: ExtraCards) => {
-		return SheetLayout.getAbilityPages(character, extraCards, layout, props.options);
+		return SheetLayout.getAbilityPagesForCharacter(character, extraCards, layout, props.options);
 	};
 
 	const getFinalCards = (extraCards: ExtraCards) => {

--- a/src/components/pages/heroes/hero-sheet/standard-abilities-page.tsx
+++ b/src/components/pages/heroes/hero-sheet/standard-abilities-page.tsx
@@ -1,0 +1,54 @@
+import { ExtraCards, SheetLayout } from '@/logic/classic-sheet/sheet-layout';
+import { AbilityData } from '@/data/ability-data';
+import { ClassicSheetBuilder } from '@/logic/classic-sheet/classic-sheet-builder';
+import { ErrorBoundary } from '@/components/controls/error-boundary/error-boundary';
+import { FactoryLogic } from '@/logic/factory-logic';
+import { Options } from '@/models/options';
+import { SheetFormatter } from '@/logic/classic-sheet/sheet-formatter';
+import { useMemo } from 'react';
+
+interface Props {
+	options: Options;
+};
+
+export const StandardAbilitiesPage = (props: Props) => {
+	const hero = FactoryLogic.createHero([]);
+	const abilities = AbilityData.standardAbilities.map(a => ClassicSheetBuilder.buildAbilitySheet(a, hero));
+	abilities.sort(SheetFormatter.sortAbilitiesByType);
+
+	const layout = useMemo(
+		() => SheetLayout.getAbilityLayout(props.options),
+		[ props.options ]
+	);
+
+	const sheetClasses = useMemo(
+		() => {
+			const classes = [
+				'hero-sheet',
+				props.options.classicSheetPageSize.toLowerCase()
+			];
+			if (props.options.colorSheet) {
+				classes.push('color');
+			}
+			return classes;
+		},
+		[ props.options.classicSheetPageSize, props.options.colorSheet ]
+	);
+
+	const extraCards = {
+		required: [],
+		optional: []
+	} as ExtraCards;
+
+	return (
+		<ErrorBoundary>
+			<main id='classic-sheet'>
+				<div className={sheetClasses.join(' ')} id={hero.id}>
+					{
+						SheetLayout.getAbilityPages(abilities, extraCards, layout, p => SheetFormatter.getPageId('hero-sheet', 'standard-abilities', `abilities-${p}`))
+					}
+				</div>
+			</main>
+		</ErrorBoundary>
+	);
+};

--- a/src/components/pages/heroes/hero-view/hero-view-page.tsx
+++ b/src/components/pages/heroes/hero-view/hero-view-page.tsx
@@ -27,7 +27,7 @@ import { OptionsPanel } from '@/components/panels/options/options-panel';
 import { PanelMode } from '@/enums/panel-mode';
 import { RulesPage } from '@/enums/rules-page';
 import { Sourcebook } from '@/models/sourcebook';
-import { StandardAbilitiesPanel } from '@/components/panels/standard-abilities/standard-abilities-panel';
+import { StandardAbilitiesPage } from '../hero-sheet/standard-abilities-page';
 import { SummoningInfo } from '@/models/summon';
 import { Title } from '@/models/title';
 import { useIsSmall } from '@/hooks/use-is-small';
@@ -113,7 +113,7 @@ export const HeroViewPage = (props: Props) => {
 				);
 			case 'abilities':
 				return (
-					<StandardAbilitiesPanel hero={hero} />
+					<StandardAbilitiesPage options={props.options} />
 				);
 			case 'notes':
 				return (
@@ -216,9 +216,9 @@ export const HeroViewPage = (props: Props) => {
 					</Popover>
 					<Popover
 						trigger='click'
-						content={<OptionsPanel mode={view === 'classic' ? 'hero-classic' : 'hero-modern'} options={props.options} heroes={props.heroes} setOptions={props.setOptions} />}
+						content={<OptionsPanel mode={view === 'modern' ? 'hero-modern' : 'hero-classic'} options={props.options} heroes={props.heroes} setOptions={props.setOptions} />}
 					>
-						<Button disabled={![ 'modern', 'classic' ].includes(view)} icon={<SettingOutlined />}>
+						<Button disabled={![ 'modern', 'classic', 'abilities' ].includes(view)} icon={<SettingOutlined />}>
 							Options
 							<DownOutlined />
 						</Button>

--- a/src/logic/classic-sheet/sheet-layout.tsx
+++ b/src/logic/classic-sheet/sheet-layout.tsx
@@ -162,7 +162,7 @@ export class SheetLayout {
 		return refCards;
 	};
 
-	static getAbilityPages = (character: HeroSheet, extraCards: ExtraCards, layout: CardPageLayout, options: Options) => {
+	static getAbilityPagesForCharacter = (character: HeroSheet, extraCards: ExtraCards, layout: CardPageLayout, options: Options) => {
 		let allAbilities = character.abilities;
 
 		if (options.shownStandardAbilities.length) {
@@ -171,6 +171,10 @@ export class SheetLayout {
 
 		allAbilities.sort(SheetFormatter.sortAbilitiesByType);
 
+		return this.getAbilityPages(allAbilities, extraCards, layout, p => SheetFormatter.getPageId('hero-sheet', character.hero.id, `abilities-${p}`));
+	};
+
+	static getAbilityPages = (allAbilities: AbilitySheet[], extraCards: ExtraCards, layout: CardPageLayout, getPageId: (s: string) => string) => {
 		const pageClasses = [ 'abilities', 'page', layout.orientation, `row-cards-${layout.perRow}` ];
 		let p = 1;
 		const abilityCardPages: JSX.Element[] = [];
@@ -321,7 +325,7 @@ export class SheetLayout {
 			abilityCardPages.push(
 				<Fragment key={`abilities-${p++}`}>
 					<hr className='dashed' />
-					<div className={pageClasses.join(' ')} id={SheetFormatter.getPageId('hero-sheet', character.hero.id, `abilities-${p}`)}>
+					<div className={pageClasses.join(' ')} id={getPageId(p.toString())}>
 						{pageAbilityGrid.map((a, i) => {
 							if (a.length > 1) {
 								return (


### PR DESCRIPTION
- Converts the Hero View > Standard Abilities page into a classic sheet view of all the standard abilities, including PDF export support (it fits neatly on 2 pages!)

| <img width="910" height="1175" alt="image" src="https://github.com/user-attachments/assets/730c7813-864a-4fde-b7cc-15ee5800acb4" /> | <img width="910" height="1172" alt="image" src="https://github.com/user-attachments/assets/9bb37d59-6edf-464e-bf38-2c3d8e36f445" /> |
|---|---|

