### PR TITLE
Fix montage success/failure calculation

### DIFF
--- a/src/logic/montage-logic.test.ts
+++ b/src/logic/montage-logic.test.ts
@@ -1,0 +1,150 @@
+import { Montage, MontageChallenge, MontageSection } from '@/models/montage';
+import { describe, expect, test } from 'vitest';
+import { EncounterDifficulty } from '@/enums/encounter-difficulty';
+import { FactoryLogic } from './factory-logic';
+import { Hero } from '@/models/hero';
+import { MontageLogic } from './montage-logic';
+import { Options } from '@/models/options';
+
+describe('getSuccessLimit', () => {
+	test.each([
+		[ EncounterDifficulty.Easy, 5, 5 ],
+		[ EncounterDifficulty.Standard, 5, 6 ],
+		[ EncounterDifficulty.Hard, 5, 7 ],
+		[ EncounterDifficulty.Easy, 3, 3 ],
+		[ EncounterDifficulty.Standard, 3, 4 ],
+		[ EncounterDifficulty.Hard, 3, 5 ],
+		[ EncounterDifficulty.Easy, 1, 2 ], // Minimum of 2!
+		[ EncounterDifficulty.Easy, 7, 7 ],
+		[ EncounterDifficulty.Standard, 7, 8 ],
+		[ EncounterDifficulty.Hard, 7, 9 ]
+	])('returns the proper success limit for various party sizes and difficulties', (difficulty: EncounterDifficulty, numHeroes: number, expectedSuccesses: number) => {
+		const montage = {
+			difficulty: difficulty
+		} as Montage;
+		const partyHero = FactoryLogic.createHero([]);
+		partyHero.folder = 'test';
+		const heroes: Hero[] = new Array(numHeroes).fill(partyHero);
+		const options = {
+			heroParty: 'test'
+		} as Options;
+
+		const result = MontageLogic.getSuccessLimit(montage, heroes, options);
+		expect(result).toBe(expectedSuccesses);
+	});
+});
+
+describe('getFailureLimit', () => {
+	test.each([
+		[ EncounterDifficulty.Easy, 5, 5 ],
+		[ EncounterDifficulty.Standard, 5, 4 ],
+		[ EncounterDifficulty.Hard, 5, 3 ],
+		[ EncounterDifficulty.Easy, 3, 3 ],
+		[ EncounterDifficulty.Standard, 3, 2 ],
+		[ EncounterDifficulty.Hard, 3, 2 ], // Minimum of 2!
+		[ EncounterDifficulty.Easy, 7, 7 ],
+		[ EncounterDifficulty.Standard, 7, 6 ],
+		[ EncounterDifficulty.Hard, 7, 5 ]
+	])('returns the proper success limit for various party sizes and difficulties', (difficulty: EncounterDifficulty, numHeroes: number, expectedSuccesses: number) => {
+		const montage = {
+			difficulty: difficulty
+		} as Montage;
+		const options = {
+			heroCount: numHeroes
+		} as Options;
+
+		const result = MontageLogic.getFailureLimit(montage, [], options);
+		expect(result).toBe(expectedSuccesses);
+	});
+});
+
+describe('getOutcome', () => {
+	test.each([
+		[ EncounterDifficulty.Easy, 5, 5 ],
+		[ EncounterDifficulty.Easy, 5, 6 ],
+		[ EncounterDifficulty.Standard, 5, 6 ],
+		[ EncounterDifficulty.Hard, 5, 7 ]
+	])('correctly identifies total successes', (difficulty: EncounterDifficulty, numHeroes: number, numSuccesses: number) => {
+		const challenge: MontageChallenge = {
+			successes: numSuccesses
+		} as MontageChallenge;
+		const montage = {
+			difficulty: difficulty,
+			sections: [ {
+				challenges: [ challenge ]
+			} as MontageSection ]
+		} as Montage;
+		const options = {
+			heroCount: numHeroes
+		} as Options;
+
+		const result = MontageLogic.getOutcome(montage, [], options);
+		expect(result).toBe('Total Success');
+	});
+
+	test.each([
+		[ EncounterDifficulty.Hard, 5, 6, 4 ],
+		[ EncounterDifficulty.Hard, 4, 5, 3 ]
+	])('correctly identifies partial successes', (difficulty: EncounterDifficulty, numHeroes: number, numSuccesses: number, numFailures: number) => {
+		const challenge: MontageChallenge = {
+			successes: numSuccesses,
+			failures: numFailures
+		} as MontageChallenge;
+		const montage = {
+			difficulty: difficulty,
+			sections: [ {
+				challenges: [ challenge ]
+			} as MontageSection ]
+		} as Montage;
+		const options = {
+			heroCount: numHeroes
+		} as Options;
+
+		const result = MontageLogic.getOutcome(montage, [], options);
+		expect(result).toBe('Partial Success');
+	});
+
+	test.each([
+		[ EncounterDifficulty.Easy, 5, 4, 5 ],
+		[ EncounterDifficulty.Standard, 5, 5, 4 ],
+		[ EncounterDifficulty.Hard, 5, 4, 3 ]
+	])('correctly identifies total failures', (difficulty: EncounterDifficulty, numHeroes: number, numSuccesses: number, numFailures: number) => {
+		const challenge: MontageChallenge = {
+			successes: numSuccesses,
+			failures: numFailures
+		} as MontageChallenge;
+		const montage = {
+			difficulty: difficulty,
+			sections: [ {
+				challenges: [ challenge ]
+			} as MontageSection ]
+		} as Montage;
+		const options = {
+			heroCount: numHeroes
+		} as Options;
+
+		const result = MontageLogic.getOutcome(montage, [], options);
+		expect(result).toBe('Total Failure');
+	});
+
+	test.each([
+		[ EncounterDifficulty.Easy, 5, 4, 4 ]
+	])('correctly identifies in progress montage tests', (difficulty: EncounterDifficulty, numHeroes: number, numSuccesses: number, numFailures: number) => {
+		const challenge: MontageChallenge = {
+			successes: numSuccesses,
+			failures: numFailures
+		} as MontageChallenge;
+		const montage = {
+			difficulty: difficulty,
+			sections: [ {
+				challenges: [ challenge ]
+			} as MontageSection ]
+		} as Montage;
+		const options = {
+			heroCount: numHeroes
+		} as Options;
+
+		const result = MontageLogic.getOutcome(montage, [], options);
+		expect(result).toBe('In Progress');
+	});
+});

--- a/src/logic/montage-logic.ts
+++ b/src/logic/montage-logic.ts
@@ -26,7 +26,7 @@ export class MontageLogic {
 			heroCount = party.length;
 		}
 		if (heroCount < 5) {
-			value -= 2 * (5 - heroCount);
+			value = Math.max(2, value - (5 - heroCount));
 		}
 		if (heroCount > 5) {
 			value += (heroCount - 5);
@@ -56,7 +56,7 @@ export class MontageLogic {
 			heroCount = party.length;
 		}
 		if (heroCount < 5) {
-			value -= 2 * (5 - heroCount);
+			value = Math.max(2, value - (5 - heroCount));
 		}
 		if (heroCount > 5) {
 			value += (heroCount - 5);
@@ -71,13 +71,24 @@ export class MontageLogic {
 		const successLimit = MontageLogic.getSuccessLimit(montage, heroes, options);
 		const failureLimit = MontageLogic.getFailureLimit(montage, heroes, options);
 
+		let heroCount = options.heroCount;
+		if (options.heroParty) {
+			const party = heroes.filter(h => h.folder === options.heroParty);
+			heroCount = party.length;
+		}
+		// 2 rounds = 2 * number of heroes chances
+		const totalChances = heroCount * 2;
+		const testsUsed = successes + failures;
+		const timeRanOut = testsUsed >= totalChances;
+
+		// Time runs out or the heroes hit the failure limit
+		const unsuccessful = timeRanOut || (failures >= failureLimit);
+
 		if (successes >= successLimit) {
 			return 'Total Success';
-		}
-		if ((failures >= failureLimit) && (successes >= 2)) {
+		} else if (unsuccessful && (successes - failures >= 2)) { // at least two more successes than failures
 			return 'Partial Success';
-		}
-		if ((failures >= failureLimit) && (successes < 2)) {
+		} else if (unsuccessful && (successes - failures < 2)) {
 			return 'Total Failure';
 		}
 


### PR DESCRIPTION
Fixes the success and failure limit calculations for Montage tests with fewer than 5 heroes.

The success/failure thresholds only go down by 1 for each hero fewer than 5, not 2. 

Also fixes the outcome determination to be in line with p262