### PR TITLE
[Classic Sheet] Disable showCurrentState every session

### DIFF
--- a/src/logic/factory-logic.ts
+++ b/src/logic/factory-logic.ts
@@ -1009,11 +1009,11 @@ export class FactoryLogic {
 			showSkillsInGroups: true,
 			dimUnavailableAbilities: true,
 			showSources: true,
-			includePlayState: true,
 			compactView: false,
 			abilityWidth: PanelWidth.Medium,
 			shownStandardAbilities: [],
 			// Classic Sheet
+			includePlayState: false,
 			classicSheetPageSize: SheetPageSize.Letter,
 			colorSheet: true,
 			sheetTextColor: 'default',

--- a/src/logic/update/options-update-logic.ts
+++ b/src/logic/update/options-update-logic.ts
@@ -24,9 +24,9 @@ export class OptionsUpdateLogic {
 			options.abilityWidth = PanelWidth.Medium;
 		}
 
-		if (options.includePlayState === undefined) {
-			options.includePlayState = false;
-		}
+		// Rather than remove this feature, disable it every session
+		// to minimize confusion for those who don't know it's even there
+		options.includePlayState = false;
 
 		if (options.colorSheet === undefined) {
 			options.colorSheet = true;


### PR DESCRIPTION
Rather than remove the 'show current play state' option from the classic sheet (in case someone does actually use it), turn it off every new session. 

That should make it so that users that don't care about it (or aren't aware of it) get the 'better' behavior of not having current stamina/etc on the print output - but anyone that *does* want that can still turn it on (they'd just have to turn it on explicitly every session)