### PR TITLE
[Classic Sheet] Fix standard abilities page roll calc, add ability roll calc toggle

### DIFF
--- a/src/components/modals/settings/settings-modal.tsx
+++ b/src/components/modals/settings/settings-modal.tsx
@@ -229,6 +229,13 @@ export const SettingsModal = (props: Props) => {
 			props.setOptions(copy);
 		};
 
+		const setShowPowerRollCalculation = (value: boolean) => {
+			const copy = Utils.copy(options);
+			copy.showPowerRollCalculation = value;
+			setOptions(copy);
+			props.setOptions(copy);
+		};
+
 		const setFeaturesInclude = (value: 'minimal' | 'no-basic' | 'all') => {
 			const copy = Utils.copy(options);
 			copy.featuresInclude = value;
@@ -240,6 +247,7 @@ export const SettingsModal = (props: Props) => {
 			<Expander title='Heroes - Classic Sheet'>
 				<Space direction='vertical' style={{ width: '100%', paddingTop: '15px' }}>
 					<Toggle label='Show play state' value={options.includePlayState} onChange={setIncludePlayState} />
+					<Toggle label='Calculate Power Roll bonuses' value={options.showPowerRollCalculation} onChange={setShowPowerRollCalculation} />
 					<Toggle label='Use color' value={options.colorSheet} onChange={setColorSheet} />
 					<LabelControl
 						label='Show class features'

--- a/src/components/pages/classic-sheet/common.scss
+++ b/src/components/pages/classic-sheet/common.scss
@@ -237,13 +237,12 @@ main#classic-sheet {
             }
             .power  {
                 font-weight: 600;
-                margin: 0 10px 10px;
+                margin: 0 10px 5px;
                 .symbol-text {
                     display: inline-block;
                     font-size: round(1.2rem, 1px);
                     font-weight: 500;
-                    padding: 0 5px;
-                    border-bottom: 1px solid colors.$medium;
+                    padding: 0;
                 }
             }
 

--- a/src/components/pages/heroes/hero-sheet/hero-sheet-page.tsx
+++ b/src/components/pages/heroes/hero-sheet/hero-sheet-page.tsx
@@ -126,7 +126,7 @@ export const HeroSheetPage = (props: Props) => {
 		const numLeveledTreasures = character.inventory?.filter(i => ItemLogic.isLeveledTreasure(i.item)).length ?? 0;
 		if (numLeveledTreasures > 3) {
 			required.push({
-				element: <CarryThreeSafelyReference />,
+				element: <CarryThreeSafelyReference key='carry-three-safely-reference' />,
 				width: 1,
 				height: 31,
 				shown: false

--- a/src/components/pages/heroes/hero-sheet/standard-abilities-page.tsx
+++ b/src/components/pages/heroes/hero-sheet/standard-abilities-page.tsx
@@ -2,19 +2,22 @@ import { ExtraCards, SheetLayout } from '@/logic/classic-sheet/sheet-layout';
 import { AbilityData } from '@/data/ability-data';
 import { ClassicSheetBuilder } from '@/logic/classic-sheet/classic-sheet-builder';
 import { ErrorBoundary } from '@/components/controls/error-boundary/error-boundary';
-import { FactoryLogic } from '@/logic/factory-logic';
+import { Hero } from '@/models/hero';
 import { Options } from '@/models/options';
 import { SheetFormatter } from '@/logic/classic-sheet/sheet-formatter';
 import { useMemo } from 'react';
 
 interface Props {
+	hero: Hero;
 	options: Options;
 };
 
 export const StandardAbilitiesPage = (props: Props) => {
-	const hero = FactoryLogic.createHero([]);
-	const abilities = AbilityData.standardAbilities.map(a => ClassicSheetBuilder.buildAbilitySheet(a, hero));
-	abilities.sort(SheetFormatter.sortAbilitiesByType);
+	const abilities = useMemo(
+		() => AbilityData.standardAbilities.map(a => ClassicSheetBuilder.buildAbilitySheet(a, props.hero, undefined, props.options)),
+		[ props.hero, props.options ]
+	);
+	abilities.sort((a, b) => SheetFormatter.sortAbilitiesByType(a, b, 'asc'));
 
 	const layout = useMemo(
 		() => SheetLayout.getAbilityLayout(props.options),
@@ -43,7 +46,7 @@ export const StandardAbilitiesPage = (props: Props) => {
 	return (
 		<ErrorBoundary>
 			<main id='classic-sheet'>
-				<div className={sheetClasses.join(' ')} id={hero.id}>
+				<div className={sheetClasses.join(' ')} id={props.hero.id}>
 					{
 						SheetLayout.getAbilityPages(abilities, extraCards, layout, p => SheetFormatter.getPageId('hero-sheet', 'standard-abilities', `abilities-${p}`))
 					}

--- a/src/components/pages/heroes/hero-view/hero-view-page.tsx
+++ b/src/components/pages/heroes/hero-view/hero-view-page.tsx
@@ -114,7 +114,7 @@ export const HeroViewPage = (props: Props) => {
 				);
 			case 'abilities':
 				return (
-					<StandardAbilitiesPage options={props.options} />
+					<StandardAbilitiesPage options={props.options} hero={hero} />
 				);
 			case 'notes':
 				return (

--- a/src/components/panels/classic-sheet/ability-card/ability-card.scss
+++ b/src/components/panels/classic-sheet/ability-card/ability-card.scss
@@ -138,15 +138,10 @@
         .roll-tiers {
             display: grid;
             grid-template-rows: min-content min-content min-content;
-            margin: 0 10px 10px;
+            margin: 0 10px;
 
             .tier {
                 margin: 5px 0;
-
-                .effect {
-                    border-bottom: 2px solid common.$color-light;
-                    padding-bottom: 5px;
-                }
             }
 
         }

--- a/src/data/ability-data.ts
+++ b/src/data/ability-data.ts
@@ -175,6 +175,7 @@ A creature who is dying can’t use the Catch Breath maneuver, but other creatur
 		type: FactoryLogic.type.createManeuver(),
 		keywords: [ AbilityKeyword.Melee, AbilityKeyword.Weapon ],
 		distance: [ FactoryLogic.distance.createMelee() ],
+		target: 'One creature',
 		sections: [
 			FactoryLogic.createAbilitySectionText('A creature seeking to keep a foe close and locked down can attempt to grab a creature using this ability.'),
 			FactoryLogic.createAbilitySectionRoll(
@@ -210,6 +211,7 @@ A creature who is dying can’t use the Catch Breath maneuver, but other creatur
 		type: FactoryLogic.type.createManeuver(),
 		keywords: [ AbilityKeyword.Melee, AbilityKeyword.Weapon ],
 		distance: [ FactoryLogic.distance.createMelee() ],
+		target: 'One creature',
 		sections: [
 			FactoryLogic.createAbilitySectionText('A creature wanting to push an adjacent creature away from them can attempt to shove that creature using this ability.'),
 			FactoryLogic.createAbilitySectionRoll(

--- a/src/logic/classic-sheet/classic-sheet-builder.test.ts
+++ b/src/logic/classic-sheet/classic-sheet-builder.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, test } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { AbilityData } from '@/data/ability-data';
 import { ArtifactData } from '@/data/items/artifact-data';
 import { ClassicSheetBuilder } from '@/logic/classic-sheet/classic-sheet-builder';
 import { FactoryLogic } from '@/logic/factory-logic';
+import { HeroLogic } from '../hero-logic';
 import { Options } from '@/models/options';
 import { goblin } from '@/data/monsters/goblin';
 
@@ -36,5 +38,36 @@ describe('buildItemSheet', () => {
 		const result = ClassicSheetBuilder.buildItemSheet(artifact, hero, options);
 		expect(result.effect).toContain('**Suited for Victory**');
 		expect(result.effect).toContain('**Turn the Tide**');
+	});
+});
+
+describe('buildAbilitySheet', () => {
+	afterEach(() => {
+		vi.resetAllMocks();
+	});
+
+	test('when showPowerRollCalc is false, uses characteristics', () => {
+		const ability = AbilityData.escapeGrab;
+		const hero = FactoryLogic.createHero([]);
+
+		const options = {
+			showPowerRollCalculation: false
+		} as Options;
+
+		const result = ClassicSheetBuilder.buildAbilitySheet(ability, hero, undefined, options);
+		expect(result.rollPower).toBe('M or A');
+	});
+
+	test('when showPowerRollCalc is true, calculates value', () => {
+		const ability = AbilityData.escapeGrab;
+		const hero = FactoryLogic.createHero([]);
+		vi.spyOn(HeroLogic, 'getCharacteristic').mockReturnValue(4);
+
+		const options = {
+			showPowerRollCalculation: true
+		} as Options;
+
+		const result = ClassicSheetBuilder.buildAbilitySheet(ability, hero, undefined, options);
+		expect(result.rollPower).toBe('4');
 	});
 });

--- a/src/logic/classic-sheet/classic-sheet-builder.ts
+++ b/src/logic/classic-sheet/classic-sheet-builder.ts
@@ -104,7 +104,7 @@ export class ClassicSheetBuilder {
 	// #endregion
 
 	// #region Ability Sheet
-	static buildAbilitySheet = (ability: Ability, creature: Hero | Monster | Summon | undefined, summoner?: Hero): AbilitySheet => {
+	static buildAbilitySheet = (ability: Ability, creature: Hero | Monster | Summon | undefined, summoner?: Hero, options?: Options): AbilitySheet => {
 		const isMonster = CreatureLogic.isMonster(creature);
 		const isHero = CreatureLogic.isHero(creature);
 		const isSummon = CreatureLogic.isSummon(creature);
@@ -203,11 +203,17 @@ export class ClassicSheetBuilder {
 			if (rollSections.length > 1) {
 				console.warn('More than one roll section!', ability.name, rollSections);
 			}
+			const rollAutoCalc = options?.showPowerRollCalculation ?? true;
 
-			if (isSummon) {
-				sheet.rollPower = AbilityLogic.getPowerRollBonusValue(ability, summoner).toString();
+			if (rollAutoCalc) {
+				if (isSummon) {
+					sheet.rollPower = AbilityLogic.getPowerRollBonusValue(ability, summoner).toString();
+				} else {
+					sheet.rollPower = AbilityLogic.getPowerRollBonusValue(ability, refCreature).toString();
+				}
 			} else {
-				sheet.rollPower = AbilityLogic.getPowerRollBonusValue(ability, refCreature).toString();
+				sheet.rollPower = SheetFormatter.joinCommasOr(AbilityLogic.getPowerRollCharacteristics(ability, undefined)
+					.map(c => c.toString().slice(0, 1)));
 			}
 
 			sheet.rollT1Effect = SheetFormatter.formatAbilityTier(rollSection.roll.tier1, 1, ability, refCreature);

--- a/src/logic/classic-sheet/sheet-formatter.test.ts
+++ b/src/logic/classic-sheet/sheet-formatter.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
+import { Ability } from '@/models/ability';
+import { AbilityData } from '@/data/ability-data';
+import { ClassicSheetBuilder } from './classic-sheet-builder';
 import { FactoryLogic } from '@/logic/factory-logic';
 import { Feature } from '@/models/feature';
 import { FeatureType } from '@/enums/feature-type';
@@ -458,5 +461,20 @@ describe('calculateProjectsOverviewCardSize', () => {
 
 		const result = SheetFormatter.calculateProjectsOverviewCardSize(sheets, 54);
 		expect(result).toBeCloseTo(50.5, 0.2);
+	});
+});
+
+describe('calculateAbilitySize', () => {
+	test.each([
+		[ AbilityData.heal, 14.7 ],
+		[ AbilityData.freeStrike, 11 ],
+		[ AbilityData.escapeGrab, 26.1 ],
+		[ AbilityData.clawDirt, 23.1 ]
+	])('calculates size properly for standard abilities', (ability: Ability, expected: number) => {
+		const hero = FactoryLogic.createHero([]);
+		const sheet = ClassicSheetBuilder.buildAbilitySheet(ability, hero);
+
+		const result = SheetFormatter.calculateAbilitySize(sheet, 54);
+		expect(result).toBeCloseTo(expected, 0.2);
 	});
 });

--- a/src/logic/classic-sheet/sheet-formatter.ts
+++ b/src/logic/classic-sheet/sheet-formatter.ts
@@ -745,18 +745,23 @@ export class SheetFormatter {
 
 	static calculateAbilitySize = (ability: AbilitySheet | undefined, lineWidth: number): number => {
 		let size = 0;
-		const rollLineLen = Math.ceil(0.8 * lineWidth);
+		const rollLineLen = Math.ceil(0.8 * lineWidth) - 10;
 		if (ability) {
 			size += 4; // title
 			size += this.countLines(ability.description, lineWidth);
 			size += 2.5; // keywords, distance, etc
 			size += ability.hasPowerRoll ? 2 : 0;
-			size += 2 * this.countLines(ability.rollT1Effect, rollLineLen);
-			size += 2 * this.countLines(ability.rollT2Effect, rollLineLen);
-			size += 2 * this.countLines(ability.rollT3Effect, rollLineLen);
+			if (ability.hasPowerRoll) {
+				size += 0.3 + this.countLines(ability.rollT1Effect, rollLineLen);
+				size += 0.3 + this.countLines(ability.rollT2Effect, rollLineLen);
+				size += 0.3 + this.countLines(ability.rollT3Effect, rollLineLen);
+			}
 			if (ability.trigger)
 				size += 1 + this.countLines(ability.trigger, lineWidth);
 			if (ability.effect) {
+				if (ability.hasPowerRoll) {
+					size += 0.5; // extra padding when effect follows power roll
+				}
 				const effectSize = this.countLines(ability.effect, lineWidth, 1);
 				size += 2 + effectSize;
 			}
@@ -873,7 +878,7 @@ export class SheetFormatter {
 		'Move Action'
 	];
 
-	static sortAbilitiesByType = (a: AbilitySheet, b: AbilitySheet): number => {
+	static sortAbilitiesByType = (a: AbilitySheet, b: AbilitySheet, order: 'asc' | 'desc' = 'desc'): number => {
 		const aType = a.actionType || '';
 		const bType = b.actionType || '';
 		const aSort = aType.length && this.abilityTypeOrder.includes(aType);
@@ -884,7 +889,7 @@ export class SheetFormatter {
 			if (s === 0) {
 				s = a.cost - b.cost;
 				if (s === 0) {
-					return this.sortAbilitiesByLength(a, b, 'desc');
+					return this.sortAbilitiesByLength(a, b, order);
 				} else {
 					return s;
 				}

--- a/src/logic/factory-logic.ts
+++ b/src/logic/factory-logic.ts
@@ -1017,6 +1017,7 @@ export class FactoryLogic {
 			includePlayState: false,
 			classicSheetPageSize: SheetPageSize.Letter,
 			colorSheet: true,
+			showPowerRollCalculation: true,
 			sheetTextColor: 'default',
 			featuresInclude: 'all',
 			pageOrientation: 'portrait',

--- a/src/logic/hero-sheet/hero-sheet-builder.ts
+++ b/src/logic/hero-sheet/hero-sheet-builder.ts
@@ -385,10 +385,10 @@ export class HeroSheetBuilder {
 		const abilities = HeroLogic.getAbilities(hero, sourcebooks, []).map(a => a.ability);
 
 		const freeStrikes = [ AbilityData.freeStrikeMelee, AbilityData.freeStrikeRanged ]
-			.map(a => ClassicSheetBuilder.buildAbilitySheet(a, hero));
-		sheet.abilities = abilities.map(a => ClassicSheetBuilder.buildAbilitySheet(a, hero)).concat(freeStrikes);
+			.map(a => ClassicSheetBuilder.buildAbilitySheet(a, hero, undefined, options));
+		sheet.abilities = abilities.map(a => ClassicSheetBuilder.buildAbilitySheet(a, hero, undefined, options)).concat(freeStrikes);
 
-		sheet.standardAbilities = AbilityData.standardAbilities.map(a => ClassicSheetBuilder.buildAbilitySheet(a, hero));
+		sheet.standardAbilities = AbilityData.standardAbilities.map(a => ClassicSheetBuilder.buildAbilitySheet(a, hero, undefined, options));
 
 		coveredFeatureIds.push(...allFeatures
 			.filter(f => [ FeatureType.ClassAbility, FeatureType.Ability ].includes(f.feature.type))

--- a/src/logic/update/options-update-logic.ts
+++ b/src/logic/update/options-update-logic.ts
@@ -32,6 +32,10 @@ export class OptionsUpdateLogic {
 			options.colorSheet = true;
 		}
 
+		if (options.showPowerRollCalculation === undefined) {
+			options.showPowerRollCalculation = true;
+		}
+
 		if (options.sheetTextColor === undefined) {
 			options.sheetTextColor = 'default';
 		}

--- a/src/models/options.ts
+++ b/src/models/options.ts
@@ -18,6 +18,7 @@ export interface Options {
 	includePlayState: boolean;
 	classicSheetPageSize: SheetPageSize;
 	colorSheet: boolean;
+	showPowerRollCalculation: boolean;
 	sheetTextColor: 'light' | 'default' | 'dark';
 	featuresInclude: 'minimal' | 'no-basic' | 'all';
 	pageOrientation: 'portrait' | 'landscape';


### PR DESCRIPTION
Fixes a bug in the Heroes Standard Ability view where all of the power roll calculations were showing as 0. Now the calculation is correctly done based on the currently selected Hero.
<img width="851" height="234" alt="image" src="https://github.com/user-attachments/assets/c8049a43-211b-4be1-a4c9-ffea37a464c0" />

*However*, you may want to create a general 'Standard Abilities' reference sheet, and *not* have the power roll values pre-calculated! So, I also added a new option to the 'Heroes - Classic Sheet- section to enable/disable the ability power roll calculation (similar to the Modern View):
<img width="469" height="192" alt="image" src="https://github.com/user-attachments/assets/9f789c98-1952-4e8d-b7bf-c7512c2feb50" />
With it turned off (default is on - so no change in current behavior), the roll characteristics are shown:
<img width="822" height="236" alt="image" src="https://github.com/user-attachments/assets/312919a2-996c-49f6-b487-02acdfe841f0" />
