### PR TITLE
[Classic Sheet] First pass on Negotiation Sheet

### DIFF
--- a/src/components/pages/classic-sheet/common.scss
+++ b/src/components/pages/classic-sheet/common.scss
@@ -35,7 +35,7 @@ main#classic-sheet {
         display: none;
     }
 
-    .hero-sheet, .encounter-sheet, .montage-sheet {
+    .hero-sheet, .encounter-sheet, .montage-sheet, .negotiation-sheet {
         height: 100%;
         font-size: 14px;
         padding: 5px;

--- a/src/components/pages/playbook/playbook-list/playbook-list-page.tsx
+++ b/src/components/pages/playbook/playbook-list/playbook-list-page.tsx
@@ -21,6 +21,7 @@ import { MontagePanel } from '@/components/panels/elements/montage-panel/montage
 import { MontageSheetPage } from '@/components/panels/classic-sheet/montage-sheet/montage-sheet-page';
 import { Negotiation } from '@/models/negotiation';
 import { NegotiationPanel } from '@/components/panels/elements/negotiation-panel/negotiation-panel';
+import { NegotiationSheetPage } from '@/components/panels/classic-sheet/negotiation-sheet/negotiation-sheet-page';
 import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { PlaybookLogic } from '@/logic/playbook-logic';
@@ -67,6 +68,8 @@ export const PlaybookListPage = (props: Props) => {
 	const [ showSidebar, setShowSidebar ] = useState<boolean>(true);
 	const [ view, setView ] = useState<'modern' | 'classic'>('modern');
 	useTitle('Playbook');
+
+	const categoriesWithClassicView = [ 'encounter', 'montage', 'negotiation' ];
 
 	if (kind !== previousCategory) {
 		setCategory(kind || 'adventure');
@@ -269,7 +272,27 @@ export const PlaybookListPage = (props: Props) => {
 				};
 				break;
 			case 'negotiation':
-				getPanel = (element: Element) => <NegotiationPanel key={element.id} negotiation={element as Negotiation} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} />;
+				getPanel = (element: Element) => {
+					if (view === 'classic') {
+						return (
+							<NegotiationSheetPage
+								key={element.id}
+								negotiation={element as Negotiation}
+								options={props.options}
+							/>
+						);
+					} else {
+						return (
+							<NegotiationPanel
+								key={element.id}
+								negotiation={element as Negotiation}
+								sourcebooks={props.sourcebooks}
+								options={props.options}
+								mode={PanelMode.Full}
+							/>
+						);
+					}
+				};
 				break;
 			case 'tactical-map':
 				getPanel = (element: Element) => <TacticalMapPanel key={element.id} map={element as TacticalMap} options={props.options} display={TacticalMapDisplayType.DirectorView} mode={PanelMode.Full} />;
@@ -302,17 +325,17 @@ export const PlaybookListPage = (props: Props) => {
 							:
 							<div style={{ width: '300px', display: 'flex', flexDirection: 'column', gap: '10px' }}>
 								{
-									[ 'encounter', 'montage' ].includes(category) && view !== 'classic' ?
+									categoriesWithClassicView.includes(category) && view !== 'classic' ?
 										<Alert
 											type='info'
 											showIcon={true}
-											message='To export your encounter as a PDF, switch to Classic view.'
+											message='To export as a PDF, switch to Classic view.'
 											action={<Button onClick={() => setView('classic')}>Classic</Button>}
 										/>
 										: null
 								}
 								{
-									[ 'encounter', 'montage' ].includes(category) && view === 'classic' ?
+									categoriesWithClassicView.includes(category) && view === 'classic' ?
 										<>
 											<Button onClick={() => props.exportElementPdf(category, element, 'standard')}>Export as PDF</Button>
 											<Button onClick={() => props.exportElementPdf(category, element, 'high')}>Export as PDF (high res)</Button>
@@ -320,7 +343,7 @@ export const PlaybookListPage = (props: Props) => {
 										: null
 								}
 								{
-									![ 'encounter', 'montage' ].includes(category) ?
+									!categoriesWithClassicView.includes(category) ?
 										<Button onClick={() => props.exportElement(category, element, 'pdf')}>Export As PDF</Button>
 										: null
 								}
@@ -431,7 +454,7 @@ export const PlaybookListPage = (props: Props) => {
 							: null
 					}
 					{
-						(category === 'encounter') || (category === 'montage') ?
+						categoriesWithClassicView.includes(category) ?
 							<Popover
 								trigger='click'
 								content={(

--- a/src/components/panels/classic-sheet/montage-sheet/montage-challenges.tsx
+++ b/src/components/panels/classic-sheet/montage-sheet/montage-challenges.tsx
@@ -21,16 +21,10 @@ export const MontageChallengesCard = (props: Props) => {
 				<section className='bordered'>
 					<h3>Hazards</h3>
 					<Markdown text={montage.hazards} />
-					{/* {
-						montage.hazards.map(h => (<p>{h}</p>))
-					} */}
 				</section>
 				<section className='bordered'>
 					<h3>Events</h3>
 					<Markdown text={montage.eventsNotes} />
-					{/* {
-						montage.eventsNotes.map(n => (<p>{n}</p>))
-					} */}
 				</section>
 			</div>
 			<div className='test-table'>

--- a/src/components/panels/classic-sheet/montage-sheet/montage-header.tsx
+++ b/src/components/panels/classic-sheet/montage-sheet/montage-header.tsx
@@ -101,9 +101,6 @@ export const MontageHeaderCard = (props: Props) => {
 				/>
 				{getLimitsSection()}
 			</section>
-			<div className='montage-objective'>
-
-			</div>
 		</div>
 	);
 };

--- a/src/components/panels/classic-sheet/negotiation-sheet/negotiation-arguments-card.scss
+++ b/src/components/panels/classic-sheet/negotiation-sheet/negotiation-arguments-card.scss
@@ -1,0 +1,55 @@
+@use '../../../pages/classic-sheet/common.scss';
+
+main#classic-sheet .negotiation-arguments.card {
+    .arguments-tracker-table {
+        display: grid;
+        margin-bottom: 5px;
+
+        .row {
+            display: grid;
+            grid-template-columns: 1fr min-content;
+
+            border-bottom: 2px solid common.$color-light;
+            line-height: round(2rem, 1px);
+            padding: 10px 20px;
+            padding-left: 5px;
+
+            &:nth-of-type(even) {
+                background: common.$color-extra-light;
+            }
+
+            &.header {
+                padding-top: 0;
+                & div {
+                    @include common.font-slab;
+                    font-weight: 550;
+                    font-size: round(1.3rem, 1px);
+                    text-wrap: nowrap;
+                }
+            }
+
+            .motivation-indicator {
+                grid-column-start: 2;
+                display: grid;
+                grid-template-columns: min-content min-content;
+
+                .labeled-boolean-content span {
+                    font-size: round(2.2rem, 1px);
+                    font-weight: 700;
+                }
+
+                .space {
+                    margin-left: 5px;
+                    width: 11rem;
+                    border-bottom: 2px solid common.$color-medium;
+                }
+            }
+        }
+    }
+
+    .reference-rolls {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 40px;
+    }
+}

--- a/src/components/panels/classic-sheet/negotiation-sheet/negotiation-arguments-card.tsx
+++ b/src/components/panels/classic-sheet/negotiation-sheet/negotiation-arguments-card.tsx
@@ -1,0 +1,98 @@
+import { LabeledBooleanField } from '../components/labeled-field';
+
+import rollT1Icon from '@/assets/icons/power-roll-t1.svg';
+import rollT2Icon from '@/assets/icons/power-roll-t2.svg';
+import rollT3Icon from '@/assets/icons/power-roll-t3.svg';
+
+import './negotiation-arguments-card.scss';
+
+export const NegotiationArgumentsCard = () => {
+	return (
+		<div className='negotiation-arguments card'>
+			<h2>Arguments</h2>
+			<div className='arguments-tracker-table'>
+				<div className='header row'>
+					<div>Argument</div>
+					<div>Used Motivation?</div>
+				</div>
+				{
+					[ ...Array(6) ].map((_e, i) => {
+						return (
+							<div className='row' key={`negotiaion-arguments-${i}`}>
+								<div className='motivation-indicator'>
+									<LabeledBooleanField value={false} label='' />
+									<div className='space'>&nbsp;</div>
+								</div>
+							</div>
+						);
+					})
+				}
+			</div>
+
+			<div className='reference-rolls'>
+				<div className='appeal-roll'>
+					<h3>Appeal to Motivation</h3>
+					<div className='power-roll'>
+						<div className='power'>Power Roll + Reason, Intuition, or Presence:</div>
+						<div className='roll-tiers'>
+							<div className='tier t1'>
+								<img alt='≤ 11' className='range' src={rollT1Icon} />
+								<span className='effect'>
+									The NPC's patience decreases by 1.
+								</span>
+							</div>
+							<div className='tier t2'>
+								<img alt='12 - 16' className='range' src={rollT2Icon} />
+								<span className='effect'>
+									The NPC's interest increases by 1, and their patience decreases by 1.
+								</span>
+							</div>
+							<div className='tier t3'>
+								<img alt='17 +' className='range' src={rollT3Icon} />
+								<span className='effect'>
+									The NPC's interest increases by 1, and their patience doesn't change.
+								</span>
+							</div>
+						</div>
+					</div>
+					<p>
+						If the heroes attempt to appeal to a motivation that's already
+						been appealed to, the NPC's interest remains the same and their
+						patience decreases by 1.
+					</p>
+				</div>
+				<div className='standard-roll'>
+					<h3>No Motivation or Pitfall</h3>
+					<div className='power-roll'>
+						<div className='power'>Power Roll + Reason, Intuition, or Presence:</div>
+						<div className='roll-tiers'>
+							<div className='tier t1'>
+								<img alt='≤ 11' className='range' src={rollT1Icon} />
+								<span className='effect'>
+									The NPC's patience decreases by 1, and their interest decreases by 1.
+								</span>
+							</div>
+							<div className='tier t2'>
+								<img alt='12 - 16' className='range' src={rollT2Icon} />
+								<span className='effect'>
+									The NPC's patience decreases by 1.
+								</span>
+							</div>
+							<div className='tier t3'>
+								<img alt='17 +' className='range' src={rollT3Icon} />
+								<span className='effect'>
+									The NPC's interest increases by 1, and their patience decreases by 1.
+									(on a natural 19 or 20, the NPC's patience remains the same.)
+								</span>
+							</div>
+						</div>
+					</div>
+					<p>
+						If the heroes try to use the same argument without a pitfall or motivation twice,
+						the test automatically gets a tier 1 result.
+					</p>
+				</div>
+			</div>
+		</div>
+	);
+};

--- a/src/components/panels/classic-sheet/negotiation-sheet/negotiation-header.scss
+++ b/src/components/panels/classic-sheet/negotiation-sheet/negotiation-header.scss
@@ -1,0 +1,22 @@
+@use '../../../pages/classic-sheet/common.scss';
+
+main#classic-sheet .negotiation-header.card {
+    display: grid;
+    grid-template-columns: 4fr 6fr;
+    grid-template-rows: min-content min-content;
+    gap: 10px;
+
+    section.overview {
+        display: flex;
+        align-items: center;
+
+        .labeled-field {
+            flex-grow: 1;
+        }
+    }
+
+    section.stats {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+    }
+}

--- a/src/components/panels/classic-sheet/negotiation-sheet/negotiation-header.tsx
+++ b/src/components/panels/classic-sheet/negotiation-sheet/negotiation-header.tsx
@@ -1,0 +1,49 @@
+import { HeaderImage } from '@/components/panels/classic-sheet/header-image/header-image';
+import { LabeledTextField } from '@/components/panels/classic-sheet/components/labeled-field';
+import { NegotiationSheet } from '@/models/classic-sheets/negotiation-sheet';
+import { useMemo } from 'react';
+
+import './negotiation-header.scss';
+
+interface Props {
+	negotiation: NegotiationSheet;
+}
+
+export const NegotiationHeaderCard = (props: Props) => {
+	const negotiation = useMemo(() => props.negotiation, [ props.negotiation ]);
+
+	return (
+		<div className='negotiation-header card'>
+			<HeaderImage />
+			<section className='container overview'>
+				<LabeledTextField
+					label='Negotiation'
+					content={negotiation.name}
+					additionalClasses={[ 'name', 'no-box', 'text-left' ]}
+				/>
+			</section>
+			<section className='container stats'>
+				<LabeledTextField
+					label='Starting Attitude'
+					content={negotiation.attitude}
+					additionalClasses={[ 'box-both', 'label-above' ]}
+				/>
+				<LabeledTextField
+					label='Starting Interest'
+					content={negotiation.interest}
+					additionalClasses={[ 'box-both', 'label-above' ]}
+				/>
+				<LabeledTextField
+					label='Starting Patience'
+					content={negotiation.patience}
+					additionalClasses={[ 'box-both', 'label-above' ]}
+				/>
+				<LabeledTextField
+					label='Impression'
+					content={negotiation.impression}
+					additionalClasses={[ 'box-both', 'label-above' ]}
+				/>
+			</section>
+		</div>
+	);
+};

--- a/src/components/panels/classic-sheet/negotiation-sheet/negotiation-npc-card.scss
+++ b/src/components/panels/classic-sheet/negotiation-sheet/negotiation-npc-card.scss
@@ -1,0 +1,53 @@
+@use '../../../pages/classic-sheet/common.scss';
+
+main#classic-sheet .negotiation-npc.card {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: min-content 1fr min-content;
+    gap: 10px;
+
+    h2 {
+        grid-column-end: span 2;
+    }
+
+    .uncover-roll {
+        margin-bottom: 5px;
+        h3 {
+            margin-top: 0;
+        }
+    } 
+
+    section.bordered:not(#priority) {
+        margin-bottom: 5px;
+        position: relative;
+
+        .traits {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 15px;
+            margin-top: -5px;
+
+            h4 {
+                border-bottom: 2px solid common.$color-light;
+                font-size: round(1.3rem, 1px);
+                line-height: round(1.8rem, 1px);
+            }
+        }
+
+        p:not(.reference) strong {
+            font-size: round(1.1rem, 1px);
+        }
+
+        p.reference strong {
+            color: var(--color-text);
+        }
+
+        div:last-of-type p {
+            margin-bottom: 0;
+        }
+
+        .languages {
+            font-size: round(1.4rem, 1px);;
+        }
+    }
+}

--- a/src/components/panels/classic-sheet/negotiation-sheet/negotiation-npc-card.tsx
+++ b/src/components/panels/classic-sheet/negotiation-sheet/negotiation-npc-card.tsx
@@ -1,0 +1,95 @@
+import { Markdown } from '@/components/controls/markdown/markdown';
+import { NegotiationSheet } from '@/models/classic-sheets/negotiation-sheet';
+import { useMemo } from 'react';
+
+import rollT1Icon from '@/assets/icons/power-roll-t1.svg';
+import rollT2Icon from '@/assets/icons/power-roll-t2.svg';
+import rollT3Icon from '@/assets/icons/power-roll-t3.svg';
+
+import './negotiation-npc-card.scss';
+
+interface Props {
+	negotiation: NegotiationSheet;
+}
+
+export const NegotiationNpcCard = (props: Props) => {
+	const negotiation = useMemo(() => props.negotiation, [ props.negotiation ]);
+	return (
+		<div className='negotiation-npc card'>
+			<h2>Negotiating NPC</h2>
+			<section className='bordered'>
+				<h3>Motivations</h3>
+				<div className='traits'>
+					<h4>{negotiation.motivations[0]?.trait}</h4>
+					<h4>{negotiation.motivations[1]?.trait}</h4>
+				</div>
+				{
+					negotiation.motivations[0] ?
+						<Markdown text={`**${negotiation.motivations[0].trait}:** ` + negotiation.motivations[0]?.description} />
+						: null
+				}
+				{
+					negotiation.motivations[1] ?
+						<Markdown text={`**${negotiation.motivations[1].trait}:** ` + negotiation.motivations[1]?.description} />
+						: null
+				}
+			</section>
+
+			<section className='bordered'>
+				<h3>Pitfalls</h3>
+				<div className='traits'>
+					<h4>{negotiation.pitfalls[0]?.trait}</h4>
+					<h4>{negotiation.pitfalls[1]?.trait}</h4>
+				</div>
+				{
+					negotiation.pitfalls[0] ?
+						<Markdown text={`**${negotiation.pitfalls[0].trait}:** ` + negotiation.pitfalls[0]?.description} />
+						: null
+				}
+				{
+					negotiation.pitfalls[1] ?
+						<Markdown text={`**${negotiation.pitfalls[1].trait}:** ` + negotiation.pitfalls[1]?.description} />
+						: null
+				}
+				<p className='reference'>
+					Arguments that use a pitfall automatically fail: <br />
+					<strong>-1 Interest, -1 Patience</strong>
+				</p>
+			</section>
+
+			<div className='uncover-roll'>
+				<h3>Uncover Motivation</h3>
+				<div className='power-roll'>
+					<div className='power'>Power Roll + Reason, Intuition, or Presence:</div>
+					<div className='roll-tiers'>
+						<div className='tier t1'>
+							<img alt='≤ 11' className='range' src={rollT1Icon} />
+							<span className='effect'>
+								The NPC's patience decreases by 1.
+							</span>
+						</div>
+						<div className='tier t2'>
+							<img alt='12 - 16' className='range' src={rollT2Icon} />
+							<span className='effect'>
+								The hero learns no information regarding the NPC's motivations or pitfalls
+							</span>
+						</div>
+						<div className='tier t3'>
+							<img alt='17 +' className='range' src={rollT3Icon} />
+							<span className='effect'>
+								The hero learns one of the NPC's motivations or pitfalls (their choice).
+							</span>
+						</div>
+					</div>
+				</div>
+			</div>
+
+			<section className='bordered'>
+				<h3>Skills and Languages</h3>
+				<p className='languages'>
+					Languages: {negotiation.languages.join(', ')}
+				</p>
+			</section>
+		</div>
+	);
+};

--- a/src/components/panels/classic-sheet/negotiation-sheet/negotiation-responses-card.scss
+++ b/src/components/panels/classic-sheet/negotiation-sheet/negotiation-responses-card.scss
@@ -1,0 +1,22 @@
+@use '../../../pages/classic-sheet/common.scss';
+
+main#classic-sheet .negotiation-responses.card {
+    display: grid;
+    grid-template-rows: min-content repeat(6, 1fr);
+    gap: 5px;
+
+    h2 {
+        margin-bottom: 10px;
+    }
+
+    section.bordered {
+        position: relative;
+
+        h4 {
+            text-align: left;
+            margin-top: -10px;
+            font-size: round(1.15rem, 1px);
+        }
+    }
+
+}

--- a/src/components/panels/classic-sheet/negotiation-sheet/negotiation-responses-card.tsx
+++ b/src/components/panels/classic-sheet/negotiation-sheet/negotiation-responses-card.tsx
@@ -1,0 +1,59 @@
+import { Markdown } from '@/components/controls/markdown/markdown';
+import { NegotiationSheet } from '@/models/classic-sheets/negotiation-sheet';
+import { useMemo } from 'react';
+
+import './negotiation-responses-card.scss';
+
+interface Props {
+	negotiation: NegotiationSheet;
+}
+
+export const NegotiationResponsesCard = (props: Props) => {
+	const negotiation = useMemo(() => props.negotiation, [ props.negotiation ]);
+	return (
+		<div className='negotiation-responses card'>
+			<h2>Response and Offers</h2>
+			<section className='bordered'>
+				<h3>Interest 5</h3>
+				<h4>Yes, and...</h4>
+				<Markdown text={negotiation.outcomes[5]} />
+			</section>
+
+			<section className='bordered'>
+				<h3>Interest 4</h3>
+				<h4>Yes.</h4>
+				<Markdown text={negotiation.outcomes[4]} />
+				<p className='reference'>
+					If the NPC still has patience, they can<br />prompt the heroes to ask for a better deal.
+				</p>
+			</section>
+
+			<section className='bordered'>
+				<h3>Interest 3</h3>
+				<h4>Yes, but...</h4>
+				<Markdown text={negotiation.outcomes[3]} />
+			</section>
+
+			<section className='bordered'>
+				<h3>Interest 2</h3>
+				<h4>No, but...</h4>
+				<Markdown text={negotiation.outcomes[2]} />
+			</section>
+
+			<section className='bordered'>
+				<h3>Interest 1</h3>
+				<h4>No.</h4>
+				<Markdown text={negotiation.outcomes[1]} />
+				<p className='reference'>
+					If the NPC still has patience, they can<br />ask for a better deal.
+				</p>
+			</section>
+
+			<section className='bordered'>
+				<h3>Interest 0</h3>
+				<h4>No, and...</h4>
+				<Markdown text={negotiation.outcomes[0]} />
+			</section>
+		</div>
+	);
+};

--- a/src/components/panels/classic-sheet/negotiation-sheet/negotiation-sheet-page.scss
+++ b/src/components/panels/classic-sheet/negotiation-sheet/negotiation-sheet-page.scss
@@ -1,0 +1,59 @@
+@use '../../../pages/classic-sheet/common.scss';
+
+main#classic-sheet .negotiation-sheet {
+    table {
+        * {
+            border: 0;
+            text-align: center;
+            @include common.font-serif;
+        }
+    }
+
+    h3:has(+ .power-roll) {
+        text-align: left;
+        border-bottom: 2px solid common.$color-medium;
+        text-transform: none;
+        width: 55%;
+        margin-top: 5px;
+        margin-bottom: 5px;
+    }
+
+    h3 + .power-roll .power {
+        margin-left: 0;
+        margin-bottom: 5px;
+    }
+    
+    .card section.bordered {
+        div p {
+            margin: 0;
+            margin-bottom: 10px;
+        }
+
+        p.reference {
+            @include common.font-slab;
+            font-size: round(0.95rem, 1px);
+            font-weight: 450;
+            color: var(--color-text-lightest);
+            text-align: right;
+
+            position: absolute;
+            bottom: 0;
+            right: 0;
+        }
+    }
+
+    .page-1 {
+        display: grid;
+        grid-template-rows: min-content min-content min-content 1fr;
+        grid-template-columns: 7fr 3fr;
+
+        .negotiation-header.card,
+        .negotiation-patience-interest.card {
+            grid-column-end: span 2;
+        }
+
+        .negotiation-responses.card {
+            grid-row-end: span 2;
+        }
+    }
+}

--- a/src/components/panels/classic-sheet/negotiation-sheet/negotiation-sheet-page.tsx
+++ b/src/components/panels/classic-sheet/negotiation-sheet/negotiation-sheet-page.tsx
@@ -1,0 +1,52 @@
+import { Negotiation } from '@/models/negotiation';
+import { NegotiationArgumentsCard } from './negotiation-arguments-card';
+import { NegotiationHeaderCard } from './negotiation-header';
+import { NegotiationNpcCard } from './negotiation-npc-card';
+import { NegotiationResponsesCard } from './negotiation-responses-card';
+import { NegotiationSheetBuilder } from '@/logic/playbook-sheets/negotiation-sheet-builder';
+import { Options } from '@/models/options';
+import { PatienceInterestCard } from './patience-interest-card';
+import { SheetFormatter } from '@/logic/classic-sheet/sheet-formatter';
+import { useMemo } from 'react';
+
+import './negotiation-sheet-page.scss';
+
+interface Props {
+	negotiation: Negotiation;
+	options: Options;
+}
+
+export const NegotiationSheetPage = (props: Props) => {
+	const negotiation = useMemo(
+		() => NegotiationSheetBuilder.buildNegotiationSheet(props.negotiation),
+		[ props.negotiation ]
+	);
+
+	const sheetClasses = useMemo(
+		() => {
+			const classes = [
+				'negotiation-sheet',
+				props.options.classicSheetPageSize.toLowerCase()
+			];
+			if (props.options.colorSheet) {
+				classes.push('color');
+			}
+			return classes;
+		},
+		[ props.options.classicSheetPageSize, props.options.colorSheet ]
+	);
+
+	return (
+		<main id='classic-sheet'>
+			<div className={sheetClasses.join(' ')}>
+				<div className={`page page-1 ${props.options.pageOrientation}`} id={SheetFormatter.getPageId('negotiation', negotiation.id, 'main')}>
+					<NegotiationHeaderCard negotiation={negotiation} />
+					<PatienceInterestCard negotiation={negotiation} />
+					<NegotiationNpcCard negotiation={negotiation} />
+					<NegotiationResponsesCard negotiation={negotiation} />
+					<NegotiationArgumentsCard />
+				</div>
+			</div>
+		</main>
+	);
+};

--- a/src/components/panels/classic-sheet/negotiation-sheet/patience-interest-card.scss
+++ b/src/components/panels/classic-sheet/negotiation-sheet/patience-interest-card.scss
@@ -1,0 +1,177 @@
+@use '../../../pages/classic-sheet/common.scss';
+@use '../../../pages/classic-sheet/functions' as *;
+
+main#classic-sheet .negotiation-patience-interest.card {
+    display: grid;
+    grid-template-columns: 3.5fr 6.5fr;
+
+    .patience,
+    .interest {
+        &>label {
+            display: block;
+            font-size: round(1.8rem, 1px);
+            line-height: round(2.4rem, 1px);
+            font-weight: 500;
+            text-align: center;
+            margin: 5px 0;
+        }
+    }
+
+    .patience {
+        display: grid;
+        grid-template-columns: 4fr 6fr;
+        
+        background-image: linear-gradient(180deg, common.$color-light, common.$color-light);
+        background-size: 2px calc(100% - 30px);
+        background-position: center right;
+        background-repeat: no-repeat;
+
+        label {
+            grid-column-end: span 2;
+        }
+
+        .patience-reference {
+            padding-right: 15px;
+        }
+
+        p.reference {
+            @include common.font-slab;
+            color: var(--color-text-lightest);
+            strong {
+                color: var(--color-text);
+            }
+        }
+
+        .current-patience {
+            .field {
+                margin: 10px 30px;
+                border: 4px solid common.$color-medium;
+                aspect-ratio: 1/1;
+                border-radius: 50%;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                
+                @include common.font-slab;
+                font-size: round(2rem, 1px);
+                color: common.$color-light;
+            }
+
+            p.reference {
+                font-weight: 500;
+                text-align: center;
+            }
+        }
+    }
+
+    .interest {
+        display: grid;
+        grid-template-rows: min-content 1fr min-content;
+
+        .interest-tracker {
+            display: grid;
+            grid-template-rows: min-content min-content;
+            margin-top: 5px;
+
+            .start-point,
+            .reference {
+                display: grid;
+                grid-template-columns: repeat(6, 1fr);
+            }
+
+            .tracker,
+            .reference {
+                margin: 0 10px;
+            }
+
+            .tracker {
+                @include common.border-beveled(10px, 2px, common.$color-medium);
+                padding: 2px 0;
+
+                .start-point {
+                    padding: 0 10px;
+
+                    --start-x: 200%;
+                    --start-val: 7;
+                    &.start-1 {
+                        --start-val: 1;
+                    }
+                    &.start-2 {
+                        --start-val: 2;
+                    }
+                    &.start-3 {
+                        --start-val: 3;
+                    }
+                    &.start-4 {
+                        --start-val: 4;
+                    }
+                    --start-x: calc((var(--start-val) + 0.5) * ((100%) / 6));
+
+                    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="enable-background:new 0 0 64 64" xml:space="preserve"><path d="M62 32L32 62L2.001 32l30-30z" fill="#{encodecolor(common.$color-light)}"></path></svg>'),
+                        url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="enable-background:new 0 0 64 64" xml:space="preserve"><path d="M62 32L32 62L2.001 32l30-30z" fill="#{encodecolor(common.$color-light)}"></path></svg>');
+
+                    background-size: 32px 32px,
+                        32px 32px;
+
+                    background-position: calc(var(--start-x)) calc(100% + 22px),
+                        calc(var(--start-x)) calc(0% - 22px);
+
+                    background-repeat: no-repeat;
+
+                }
+
+                .labeled-boolean {
+                    justify-content: center;
+                    margin: 10px 0;
+
+                    &:not(:last-of-type) {
+                        border-right: 2px solid common.$color-medium;
+                    }
+
+                    label {
+                        font-size: round(2rem, 1px);
+                        font-weight: 500;
+                    }
+                    .labeled-boolean-content span {
+                        font-size: round(2rem, 1px);
+                        font-weight: 500;
+                    }
+                }
+            }
+
+            .reference * {
+                @include common.font-slab;
+                text-align: center;
+                font-size: round(0.95rem, 1px);
+                font-weight: 450;
+                color: var(--color-text-lightest);
+                margin-top: 5px;
+            }
+            .ref-5 {
+                grid-column-start: 6;
+            }
+        }
+
+        .renown {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+
+            .renown-level {
+                @include common.font-slab;
+                grid-column-end: span 2;
+                margin: 0;
+            }
+
+            p {
+                text-align: center;
+                font-size: round(0.95rem, 1px);
+                font-weight: 450;
+                color: var(--color-text-lightest);
+
+                strong {
+                    color: var(--color-text);
+                }
+            }
+        }
+    }
+}

--- a/src/components/panels/classic-sheet/negotiation-sheet/patience-interest-card.tsx
+++ b/src/components/panels/classic-sheet/negotiation-sheet/patience-interest-card.tsx
@@ -1,0 +1,69 @@
+import { LabeledBooleanField } from '../components/labeled-field';
+import { NegotiationSheet } from '@/models/classic-sheets/negotiation-sheet';
+import { useMemo } from 'react';
+
+import './patience-interest-card.scss';
+
+interface Props {
+	negotiation: NegotiationSheet;
+}
+
+export const PatienceInterestCard = (props: Props) => {
+	const negotiation = useMemo(() => props.negotiation, [ props.negotiation ]);
+
+	return (
+		<div className='negotiation-patience-interest card'>
+			<div className='patience'>
+				<label>Patience</label>
+				<div className='current-patience'>
+					<div className='field'>
+						{negotiation.patience}
+					</div>
+					<p className='reference'>
+						<strong>Patience 0:</strong>
+						<br />
+						NPC Makes Final Offer
+					</p>
+				</div>
+				<div className='patience-reference'>
+					<p className='reference'>One hero shares NPC's native language (non-Caelian): <strong>Patience +1</strong></p>
+					<p className='reference'>Three or more heroes shares NPC's native language (non-Caelian): <strong>Patience +2</strong></p>
+				</div>
+			</div>
+			<div className='interest'>
+				<label>Interest</label>
+				<div className='interest-tracker'>
+					<div className='tracker'>
+						<div className={`start-point start-${negotiation.interest}`}>
+							<LabeledBooleanField value={false} label='0' />
+							<LabeledBooleanField value={false} label='1' />
+							<LabeledBooleanField value={false} label='2' />
+							<LabeledBooleanField value={false} label='3' />
+							<LabeledBooleanField value={false} label='4' />
+							<LabeledBooleanField value={false} label='5' />
+						</div>
+					</div>
+					<div className='reference'>
+						<div className='ref-0'>NPC Ends Negotiation</div>
+						<div className='ref-5'>NPC Makes Final Offer</div>
+					</div>
+				</div>
+				<div className='renown'>
+					<p className='renown-level'>
+						<strong>Hero renown ≥ {negotiation.impression}</strong> (NPC Impression score)
+					</p>
+					<p>
+						<strong>Hero is famous to NPC:</strong>
+						<br />
+						Edge on tests using Flirt, Lead, or Persuade
+					</p>
+					<p>
+						<strong>Hero is infamous to NPC:</strong>
+						<br />
+						Edge on tests using Brag, Interrogate, or Intimidate
+					</p>
+				</div>
+			</div>
+		</div>
+	);
+};

--- a/src/logic/playbook-sheets/negotiation-sheet-builder.ts
+++ b/src/logic/playbook-sheets/negotiation-sheet-builder.ts
@@ -1,0 +1,31 @@
+import { Negotiation } from '@/models/negotiation';
+import { NegotiationSheet } from '@/models/classic-sheets/negotiation-sheet';
+
+export class NegotiationSheetBuilder {
+	static buildNegotiationSheet = (negotiation: Negotiation): NegotiationSheet => {
+		const sheet: NegotiationSheet = {
+			id: negotiation.id,
+			name: negotiation.name,
+			attitude: negotiation.attitude.toString(),
+			impression: negotiation.impression,
+			interest: negotiation.interest,
+			patience: negotiation.patience,
+			outcomes: negotiation.outcomes,
+			languages: [],
+			motivations: negotiation.motivations.map(m => ({ trait: m.trait.toString(), description: m.description })),
+			pitfalls: negotiation.pitfalls.map(m => ({ trait: m.trait.toString(), description: m.description }))
+		};
+
+		let nativeFound = false;
+		negotiation.languages.forEach(lang => {
+			if (lang !== 'Caelian' && !nativeFound) {
+				sheet.languages.push(`${lang} (Native)`);
+				nativeFound = true;
+			} else {
+				sheet.languages.push(lang);
+			}
+		});
+
+		return sheet;
+	};
+};

--- a/src/models/classic-sheets/negotiation-sheet.ts
+++ b/src/models/classic-sheets/negotiation-sheet.ts
@@ -1,0 +1,14 @@
+export interface NegotiationSheet {
+	id: string;
+	name: string;
+	attitude: string;
+	impression: number;
+	interest: number;
+	patience: number;
+
+	outcomes: string[];
+
+	languages: string[];
+	motivations: { trait: string, description: string }[];
+	pitfalls: { trait: string, description: string }[];
+};

--- a/to do.md
+++ b/to do.md
@@ -55,19 +55,14 @@
 
 ### Heroes
 
-- Add 'Made With Forge Steel' to classic sheet
-- convert 'Standard Features' view to classic sheet style + PDF export
 - Add ability to create standalone 'reference sheets' with selectable 'reference cards'
 - (possibly solved along with above) Have ability to create handout sheets with items, followers, etc without being attached to a character
-- add something like 'known projects'? or, would it be adding 'project cards' for projects that show the description, etc
 - Check hero features/abilities for certain keywords and ensure relevant reference cards get put into the character sheet?
 - Add user-selectable color scheme
 
 ### Encounter
-- Add filter/selection of Malice features
 
 ### Negotiation
 - Add Negotiation classic sheet
 
 ### Montage
-- Add Montage classic sheet


### PR DESCRIPTION
Adds a first pass at a Classic Sheet view for Negotiations:
<img width="830" height="1066" alt="image" src="https://github.com/user-attachments/assets/a235f8e2-8c6e-4835-860c-e78074ea260e" />

Differs from the official sheets in that the starting values are indicated in a much lighter fashion to make it easier to see changes in pen/pencil at the table when printed:
<img width="1151" height="223" alt="image" src="https://github.com/user-attachments/assets/31966613-a742-41aa-ac57-fb8f506458bb" />
