### PR TITLE
[#705] Fix feature reference size calculations

### DIFF
--- a/src/components/pages/classic-sheet/common.scss
+++ b/src/components/pages/classic-sheet/common.scss
@@ -339,6 +339,7 @@ main#classic-sheet {
             }
 
             .feature-reference.wide,
+            .feature-reference.extra-wide,
             .card.slots-3-wide,
             .table-reference.card {
                 flex-basis: 100%;

--- a/src/components/pages/heroes/hero-sheet/hero-sheet-page.tsx
+++ b/src/components/pages/heroes/hero-sheet/hero-sheet-page.tsx
@@ -235,13 +235,27 @@ export const HeroSheetPage = (props: Props) => {
 					break;
 				case 'feature-reference': {
 					const minW = layoutEnd.orientation === 'portrait' ? 1 : 2;
-					card.width = Math.min(minW, card.width);
-					if (card.width === 1) {
-						card.height = SheetFormatter.calculateFeatureReferenceSize(character.featuresReferenceOther, hero, layoutEnd.cardLineLen, 1);
-					} else {
-						card.height = SheetFormatter.calculateFeatureReferenceSize(character.featuresReferenceOther, hero, layoutEnd.cardLineLen, 2);
+					let lineWidth = layoutEnd.cardLineLen;
+					let refW = Math.min(minW, card.width);
+					let refH = SheetFormatter.calculateFeatureReferenceSize(character.featuresReferenceOther, hero, lineWidth, 1);
+					if (refH > 60) {
+						refW += 1;
+						lineWidth = ((refW - 1) * layoutEnd.cardGap) + (refW * layoutEnd.cardLineLen) * 0.49;
+						refH = SheetFormatter.calculateFeatureReferenceSize(character.featuresReferenceOther, hero, lineWidth, 2);
+						if (refH > layoutEnd.linesY && layoutEnd.perRow === 4) {
+							refW = 4;
+							lineWidth = (3 * layoutEnd.cardGap) + (4 * layoutEnd.cardLineLen) * 0.33;
+							refH = SheetFormatter.calculateFeatureReferenceSize(character.featuresReferenceOther, hero, lineWidth, 3);
+						}
+						if (refH > layoutEnd.linesY) {
+							console.warn('Features reference is still too long!', refH, layoutEnd.linesY);
+							refH = Math.min(layoutEnd.linesY, refH);// Will need a better solution at some point
+						}
 					}
-					// console.log('###### RECALC Reference size: ', card.height);
+					// console.log('###### RECALC Reference size: ', refH, refW);
+					card.width = refW;
+					card.height = refH;
+
 					break;
 				}
 				default:

--- a/src/components/panels/classic-sheet/components/feature-component.scss
+++ b/src/components/panels/classic-sheet/components/feature-component.scss
@@ -173,6 +173,30 @@
         font-weight: 450;
         border-bottom: 1px solid common.$color-light;
     }
+
+    .feature-description table tr:has(td img) {
+        border-bottom: 0;
+
+        td {
+            vertical-align:top;
+            padding-bottom: 0;
+
+            &:not(:first-child) {
+                padding-top: 8px;
+            }
+        }
+        
+        td:first-child {
+            text-wrap: nowrap;
+            vertical-align: text-top;
+
+            img {
+                width: 50px;
+                height: 26px;
+                margin: 1px 0;
+            }
+        }
+    }
 }
 
 #classic-sheet .feature-malice {
@@ -232,17 +256,6 @@
 
 li .feature ul.feature-description {
     margin-left: 5px;
-}
-
-.feature-reference .feature .feature-description table td:first-child {
-    text-wrap: nowrap;
-    vertical-align: text-top;
-
-    img {
-        width: 50px;
-        height: 18px;
-        margin: 1px 0;
-    }
 }
 
 #classic-sheet .color .feature {

--- a/src/data/classes/troubadour/troubadour.ts
+++ b/src/data/classes/troubadour/troubadour.ts
@@ -151,8 +151,7 @@ You can have a number of bonds active equal to your level. When you form a bond 
 					name: 'Appeal to the Muses',
 					description: `You can give a rousing speech, invoke your inspirations, or lift your fellows’ spirits, appealing to the muses to heighten a battle’s drama. However, irony is eager to hand your fortune to the villain to achieve the same end.
 
-Before you roll to gain drama at the start of your turn, you can make your appeal (no action required). If you do, your roll gains the following
-additional effects:
+Before you roll to gain drama at the start of your turn, you can make your appeal (no action required). If you do, your roll gains the following additional effects:
 * If the roll is a 1, you gain 1 additional drama. The Director gains 1d3 Malice.
 * If the roll is a 2, you gain 1 Heroic Resource, which you can keep or give to an ally within the distance of your active performance. The Director gains 1 Malice.
 * If the roll is a 3, you gain 2 of a Heroic Resource, which you can distribute among yourself and any allies within the distance of your active performance.`


### PR DESCRIPTION
Fixes size calculations for the Features Reference card in the classic sheet when it is really long, and will always at least display it