### PR TITLE
Fix for Bug: Shallow Copy of Monsters Causing Unintended Linkage

### DIFF
--- a/src/components/panels/edit/encounter-edit/encounter-edit-panel.tsx
+++ b/src/components/panels/edit/encounter-edit/encounter-edit-panel.tsx
@@ -146,8 +146,9 @@ export const EncounterEditPanel = (props: Props) => {
 						if (remove) {
 							fromGroup.slots = fromGroup.slots.filter(s => s.id !== slotID);
 						}
-						slot.id = Utils.guid();
-						toGroup.slots.push(slot);
+						const slotCopy = Utils.copy(slot);
+						slotCopy.id = Utils.guid();
+						toGroup.slots.push(slotCopy);
 					}
 				}
 				setEncounter(copy);


### PR DESCRIPTION
# Fix for Bug: Shallow Copy of Monsters Causing Unintended Linkage

## Bug Description

Copying a minion/monster to a new or existing group results in shallow copy behavior, linking their health and several other bugs. This seems to be due to the fact that the copy and original share a `Slot.id` value.

### Reproduction steps

* Create a new encounter and add a monster
* Copy the monster to a new or existing group
* Save and run the encounter
* Apply damage to one of the monsters
* Note that both monsters are damaged

## Cause

`moveSlot()` doesn't create a copy of the `slot` object before assigning a new id, and pushing it to the `toGroup`, leaving both `slot` objects with the same `id` value.

## Remediation

Create a copy of the `slot` object and assign it a new GUID before pushing to `toGroup`.

Co-authored-by: Javan Fogle < javanfogledev@gmail.com >
Co-authored-by: Landon Adrian < landon.s.adrian@gmail.com > 