### PR TITLE
Fix saving throw logic

### DIFF
--- a/src/components/modals/roll/roll-modal.tsx
+++ b/src/components/modals/roll/roll-modal.tsx
@@ -119,7 +119,7 @@ export const RollModal = (props: Props) => {
 			case 'Saving Throw':
 				return (
 					<>
-						<DieRollPanel type='Saving Throw' modifiers={[ saveBonus, modifier ]} rollState={rollState} hero={props.hero} onRollStateChange={setRollState} />
+						<DieRollPanel type='Saving Throw' modifiers={[ saveBonus ]} rollState={rollState} hero={props.hero} onRollStateChange={setRollState} />
 					</>
 				);
 		}

--- a/src/components/panels/die-roll/die-roll-panel.tsx
+++ b/src/components/panels/die-roll/die-roll-panel.tsx
@@ -69,7 +69,11 @@ export const DieRollPanel = (props: Props) => {
 		}
 	};
 
-	const getTierMessage = (rollState: RollState) => {
+	const getTierMessage = (rollState: RollState, type: string = 'Power Roll') => {
+		if (type == 'Saving Throw') {
+			return null;
+		}
+
 		switch (rollState) {
 			case RollState.DoubleEdge:
 				return 'Move the result up one tier.';
@@ -80,8 +84,8 @@ export const DieRollPanel = (props: Props) => {
 		return null;
 	};
 
-	const bonus = RollLogic.getBonus(props.rollState);
-	const tierMessage = getTierMessage(props.rollState);
+	const bonus = RollLogic.getBonus(props.rollState, props.type);
+	const tierMessage = getTierMessage(props.rollState, props.type);
 
 	const total = Collections.sum([ ...results, ...props.modifiers, bonus ], r => r);
 
@@ -206,7 +210,7 @@ export const DieRollPanel = (props: Props) => {
 							</div>
 							<HistogramPanel
 								min={1}
-								values={RollLogic.getOdds(props.modifiers, props.rollState)}
+								values={RollLogic.getOdds(props.modifiers, props.rollState, props.type)}
 								showPercentages={true}
 								getLabel={x => {
 									switch (x) {

--- a/src/logic/roll-logic.ts
+++ b/src/logic/roll-logic.ts
@@ -2,7 +2,7 @@ import { Collections } from '@/utils/collections';
 import { RollState } from '@/enums/roll-state';
 
 export class RollLogic {
-	static getOdds = (modifiers: number[], rollState: RollState) => {
+	static getOdds = (modifiers: number[], rollState: RollState, rollType: string = 'Power Roll') => {
 		const results = [];
 
 		for (let a = 1; a <= 10; ++a) {
@@ -10,7 +10,7 @@ export class RollLogic {
 				if (a + b >= 19) {
 					results.push(4);
 				} else {
-					const total = Collections.sum([ a, b, ...modifiers, RollLogic.getBonus(rollState) ], r => r);
+					const total = Collections.sum([ a, b, ...modifiers, RollLogic.getBonus(rollState, rollType) ], r => r);
 					if (total >= 17) {
 						// Tier 3
 						switch (rollState) {
@@ -52,7 +52,11 @@ export class RollLogic {
 		return results;
 	};
 
-	static getBonus = (rollState: RollState) => {
+	static getBonus = (rollState: RollState, type: string = 'Power Roll') => {
+		if (type == 'Saving Throw') {
+			return 0;
+		}
+
 		switch (rollState) {
 			case RollState.Edge:
 				return 2;


### PR DESCRIPTION
Update saving throw logic to not add edges, banes, or modifiers besides save bonuses to the saving throw.