### PR TITLE
Fix montage challenge reset button

### DIFF
--- a/src/components/panels/run/montage-run/montage-run-panel.tsx
+++ b/src/components/panels/run/montage-run/montage-run-panel.tsx
@@ -74,7 +74,7 @@ export const MontageRunPanel = (props: Props) => {
 			}
 
 			while (icons.length < challenge.uses) {
-				icons.push(<CheckIcon key={`x${icons.length}`} />);
+				icons.push(<CheckIcon key={`${icons.length}`} />);
 			}
 
 			return icons;


### PR DESCRIPTION
Remove typo from montage run panel logic so that the reset button correctly removes all icons.