### PR TITLE
fix summons missing from sheet

### DIFF
--- a/src/logic/hero-sheet/hero-sheet-builder.test.ts
+++ b/src/logic/hero-sheet/hero-sheet-builder.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import { FeatureCompanion, FeatureFollower, FeatureRetainer, FeatureSummonChoice, FeatureSummonChoiceData } from '@/models/feature';
+import { FeatureCompanion, FeatureFollower, FeatureRetainer, FeatureSummon, FeatureSummonChoice, FeatureSummonChoiceData } from '@/models/feature';
 import { afterEach, describe, expect, expectTypeOf, test, vi } from 'vitest';
 import { FactoryLogic } from '@/logic/factory-logic';
 import { FeatureType } from '@/enums/feature-type';
@@ -107,13 +107,22 @@ const beastheartCompanionChoices = beastheart.featuresByLevel.find(fbl => fbl.le
 const companion1 = beastheartCompanionChoices.options.find(o => o.monster.id === 'beastheart-1-2a-1') as Summon;
 
 const mockSummonChoiceFeature = {
-	id: 'mock-summon-chouice',
+	id: 'mock-summon-choice',
 	name: 'Mock Summon Choice',
 	type: FeatureType.SummonChoice,
 	data: {
 		selected: [ companion1, minionSummon1 ]
 	}
 } as FeatureSummonChoice;
+
+const mockSummonFeature = {
+	id: 'mock-summon',
+	name: 'Mock Summon',
+	type: FeatureType.Summon,
+	data: {
+		summons: [ minionSummon1 ]
+	}
+} as FeatureSummon;
 // #endregion
 
 describe('buildFollowerCompanionSheet()', () => {
@@ -194,7 +203,8 @@ describe('buildHeroSheet', () => {
 			{ feature: mockFeatureRetainer, source: 'test' },
 			{ feature: mockFeatureFollower, source: 'test' },
 			{ feature: mockFeatureCompanion, source: 'test' },
-			{ feature: mockSummonChoiceFeature, source: 'test' }
+			{ feature: mockSummonChoiceFeature, source: 'test' },
+			{ feature: mockSummonFeature, source: 'test' }
 		]);
 
 		const result = HeroSheetBuilder.buildHeroSheet(hero, sourcebooks, options);
@@ -202,5 +212,6 @@ describe('buildHeroSheet', () => {
 		expect(result).toBeDefined();
 		expect(result).not.toBeNullable();
 		expect(result.followers.length).toBe(4);
+		expect(result.summons.length).toBe(2);
 	});
 });

--- a/src/logic/hero-sheet/hero-sheet-builder.ts
+++ b/src/logic/hero-sheet/hero-sheet-builder.ts
@@ -398,8 +398,11 @@ export class HeroSheetBuilder {
 		const retinue = allFeatures.filter(f => [ FeatureType.Follower, FeatureType.Retainer, FeatureType.Companion, FeatureType.Summon, FeatureType.SummonChoice ].includes(f.feature.type))
 			.map(f => f.feature);
 		sheet.followers = retinue.flatMap(f => this.buildFollowerCompanionSheet(f, hero)).filter(s => !!s);
-		sheet.summons = retinue.filter(f => f.type === FeatureType.SummonChoice).flatMap(f => f.data.selected)
-			.filter(f => CreatureLogic.isSummon(f)).map(f => this.buildSummonSheet(f, hero)).filter(s => !!s);
+
+		const summons = retinue.filter(f => f.type === FeatureType.SummonChoice).flatMap(f => f.data.selected)
+			.concat(retinue.filter(f => f.type === FeatureType.Summon).flatMap(f => f.data.summons));
+		sheet.summons = summons.filter(f => CreatureLogic.isSummon(f))
+			.map(f => this.buildSummonSheet(f, hero)).filter(s => !!s);
 
 		coveredFeatureIds.push(...retinue.map(f => f.id));
 


### PR DESCRIPTION
Fixes the (new?) Summons missing from the Classic sheet when they are of type `FeatureSummon` instead of `FeatureSummonChoice`