### PR TITLE
Fix oauth redirect double request in dev

### DIFF
--- a/src/components/main/main.tsx
+++ b/src/components/main/main.tsx
@@ -1325,7 +1325,6 @@ export const Main = (props: Props) => {
 				heroes={heroes}
 				setOptions={persistOptions}
 				connectionSettings={connectionSettings}
-				// patreonConnections={props.patreonConnections}
 				dataService={props.dataService}
 				setConnectionSettings={persistConnectionSettings}
 				clearErrors={() => setErrors([])}

--- a/src/components/pages/auth/oauth-redirect.tsx
+++ b/src/components/pages/auth/oauth-redirect.tsx
@@ -62,13 +62,15 @@ export const OAuthRedirectPage = (props: Props) => {
 	};
 
 	// Do ONCE
-	useEffect(
-		checkPatreonStatus,
-		// dependencies here needs to be an empty array so that it only runs once
-		// otherwise, it runs several times as things change.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-		[]
-	);
+	useEffect(() => {
+		const check = setTimeout(checkPatreonStatus, 200);
+
+		return () => clearTimeout(check);
+	},
+	// dependencies here needs to be an empty array so that it only runs once
+	// otherwise, it runs several times as things change.
+	// eslint-disable-next-line react-hooks/exhaustive-deps
+	[]);
 
 	return (
 		<ErrorBoundary>

--- a/src/utils/data-service.ts
+++ b/src/utils/data-service.ts
@@ -21,7 +21,8 @@ export class DataService {
 		this.apiToken = settings.warehouseToken;
 		this.jwt = null;
 
-		this.tokenHandlerHost = 'https://forgesteel-warehouse-b7wsk.ondigitalocean.app/';
+		// this.tokenHandlerHost = 'http://localhost:5000';
+		this.tokenHandlerHost = 'https://forgesteel-warehouse-b7wsk.ondigitalocean.app';
 	};
 
 	private getErrorMessage = (error: unknown) => {


### PR DESCRIPTION
Fixes the double-request for OAuth endpoints when running in the dev server (due to `StrictMode`). 

Also adds a 'loading' spinner to the Connections panel to indicate that Patreon status is being retrieved.

*Note* The patron membership logic has to be updated on the backend, a fix for that is ~~getting ready to deploy~~ is live and ready to test