### PR TITLE
Hotfix - Fix useNavigation error on data loader

### DIFF
--- a/src/components/modals/settings/settings-modal.tsx
+++ b/src/components/modals/settings/settings-modal.tsx
@@ -1,4 +1,4 @@
-import { Button, Drawer, Flex, Input, Segmented, Select, Space } from 'antd';
+import { Button, Divider, Drawer, Flex, Input, Segmented, Select, Space } from 'antd';
 import { CopyOutlined, FlagFilled, FlagOutlined, MoonOutlined, SettingOutlined, SunOutlined } from '@ant-design/icons';
 import { AbilityData } from '@/data/ability-data';
 import { Collections } from '@/utils/collections';
@@ -23,6 +23,7 @@ import { SheetPageSize } from '@/enums/sheet-page-size';
 import { StandardAbilitySelectModal } from '@/components/modals/select/standard-ability-select/standard-ability-select-modal';
 import { Toggle } from '@/components/controls/toggle/toggle';
 import { Utils } from '@/utils/utils';
+import { WarehouseActionsPanel } from '@/components/panels/connection-settings/warehouse-actions-panel';
 import { useState } from 'react';
 import { useTheme } from '@/hooks/use-theme';
 
@@ -639,10 +640,23 @@ export const SettingsModal = (props: Props) => {
 		if (FeatureFlags.hasFlag(FeatureFlags.warehouse.code)) {
 			return (
 				<Expander title='Forge Steel Warehouse'>
-					<ConnectionSettingsPanel
-						connectionSettings={props.connectionSettings}
-						setConnectionSettings={props.setConnectionSettings}
-					/>
+					<Space orientation='vertical' style={{ width: '100%' }}>
+						{
+							props.connectionSettings.useWarehouse ?
+								<>
+									<WarehouseActionsPanel
+										connectionSettings={props.connectionSettings}
+									/>
+									<Divider size='small' />
+								</>
+								: null
+						}
+						<ConnectionSettingsPanel
+							connectionSettings={props.connectionSettings}
+							setConnectionSettings={props.setConnectionSettings}
+							showReload={true}
+						/>
+					</Space>
 				</Expander>
 			);
 		}

--- a/src/components/panels/connection-settings/warehouse-actions-panel.tsx
+++ b/src/components/panels/connection-settings/warehouse-actions-panel.tsx
@@ -1,0 +1,30 @@
+import { Button, Space } from 'antd';
+import { ConnectionSettings } from '@/models/connection-settings';
+import { useNavigate } from 'react-router';
+
+interface Props {
+	connectionSettings: ConnectionSettings;
+}
+
+export const WarehouseActionsPanel = (props: Props) => {
+	const navigate = useNavigate();
+
+	const goToTransferPage = () => {
+		navigate('/transfer');
+	};
+
+	return (
+		<Space orientation='vertical' style={{ width: '100%' }}>
+			{
+				props.connectionSettings.useWarehouse ?
+					<Button
+						block={true}
+						onClick={goToTransferPage}
+					>
+						Transfer Data
+					</Button>
+					: null
+			}
+		</Space>
+	);
+};


### PR DESCRIPTION
- Fixes the Warehouse settings panel not working on the Data Loader screen if there is an error connecting, due to the addition of `useNavigation()` for the *normal* settings panel to navigate to the data transfer page. 
- Fixes the 'Test Connection' button on the Warehouse settings panel not working with v1.0.0 of the warehouse.

Also adds a notification and a quick way to reload the app when the connection settings change.

<img width="468" height="124" alt="image" src="https://github.com/user-attachments/assets/86c1caca-ae7b-491d-b45a-06cb85855962" />

