### PR TITLE
Revert cookie auth for forgesteel-warehouse

### DIFF
--- a/src/components/pages/transfer/transfer-page.tsx
+++ b/src/components/pages/transfer/transfer-page.tsx
@@ -17,7 +17,7 @@ import { SourcebookLogic } from '@/logic/sourcebook-logic';
 import { SourcebookMergeLogic } from '@/logic/merge/sourcebook-merge-logic';
 import { SourcebookPanel } from '@/components/panels/elements/sourcebook-panel/sourcebook-panel';
 import { Utils } from '@/utils/utils';
-import { generatePath } from 'react-router';
+import { useNavigation } from '@/hooks/use-navigation';
 
 import './transfer-page.scss';
 
@@ -256,10 +256,17 @@ export const TransferPage = (props: Props) => {
 		}
 	};
 
+	const nav = useNavigation();
 	const navHome = () => {
 		// set the url directly so the app reloads
-		const home = generatePath('/');
-		window.location.href = home;
+		const url = window.location.toString();
+		const match = url.match(/^([^#]+)(#.*)/);
+		if (match) {
+			const base = match[1];
+			window.location.href = base;
+		} else {
+			nav.goToWelcome();
+		}
 	};
 
 	return (

--- a/src/utils/data-service.test.ts
+++ b/src/utils/data-service.test.ts
@@ -95,14 +95,12 @@ describe('DataService', () => {
 			const catchFn = vi.fn();
 			const thenFn = vi.fn();
 
-			const healthResponse = { data: { version: '0.1.6' } };
 			const jwtResponse = { data: { access_token: 'fake_token' } };
 
 			const mockHero = { id: 'test-hero' } as Hero;
 			const mockData = [ mockHero ];
 			const responseObj = { data: { data: mockData } };
 			axios.get = vi.fn()
-				.mockImplementationOnce(() => Promise.resolve(healthResponse))
 				.mockImplementationOnce(() => Promise.resolve(jwtResponse))
 				.mockImplementationOnce(() => Promise.resolve(responseObj));
 
@@ -114,61 +112,12 @@ describe('DataService', () => {
 				.then(thenFn)
 				.catch(catchFn);
 
-			expect(axios.get).toHaveBeenNthCalledWith(1, 'http://test-fake-host/healthz');
-
-			expect(axios.get).toHaveBeenNthCalledWith(2, 'http://test-fake-host/connect', {
+			expect(axios.get).toHaveBeenNthCalledWith(1, 'http://test-fake-host/connect', {
 				headers: { Authorization: 'Bearer abcd123' }
 			});
 
-			expect(axios.get).toHaveBeenNthCalledWith(3, 'http://test-fake-host/data/forgesteel-heroes', {
-				headers: { Authorization: 'Bearer fake_token' }
-			});
-
-			expect(thenFn).toHaveBeenCalledWith(mockData);
-		});
-
-		test('Uses cookie auth for new versions of Warehouse', async () => {
-			const connSettings = { ...defaultSettings,
-				useWarehouse: true,
-				warehouseHost: 'http://test-fake-host',
-				warehouseToken: 'abcd123'
-			};
-
-			const catchFn = vi.fn();
-			const thenFn = vi.fn();
-
-			const healthResponse = { data: { version: '1.0.0' } };
-			const connectResponse = { data: {} };
-
-			const mockHero = { id: 'test-hero' } as Hero;
-			const mockData = [ mockHero ];
-			const responseObj = { data: { data: mockData } };
-			axios.get = vi.fn()
-				.mockImplementationOnce(() => Promise.resolve(healthResponse))
-				.mockImplementationOnce(() => Promise.resolve(responseObj));
-
-			axios.post = vi.fn()
-				.mockImplementationOnce(() => Promise.resolve(connectResponse));
-
-			const ds = new DataService(connSettings);
-			const connected = await ds.initialize();
-			expect(connected).toBe(true);
-
-			await ds.getHeroes()
-				.then(thenFn)
-				.catch(catchFn);
-
-			expect(axios.get).toHaveBeenNthCalledWith(1, 'http://test-fake-host/healthz');
-
-			expect(axios.post).toHaveBeenNthCalledWith(1, 'http://test-fake-host/connect', { }, {
-				headers: { Authorization: 'Bearer abcd123' },
-				withCredentials: true,
-				withXSRFToken: true
-			});
-
 			expect(axios.get).toHaveBeenNthCalledWith(2, 'http://test-fake-host/data/forgesteel-heroes', {
-				withCredentials: true,
-				withXSRFToken: true
+				headers: { Authorization: 'Bearer fake_token' }
 			});
 
 			expect(thenFn).toHaveBeenCalledWith(mockData);
@@ -200,11 +149,9 @@ describe('DataService', () => {
 			const catchFn = vi.fn();
 			const thenFn = vi.fn();
 
-			const healthResponse = { data: { version: '0.1.6' } };
 			const jwtResponse = { data: { access_token: 'fake_token' } };
 
 			axios.get = vi.fn()
-				.mockImplementationOnce(() => Promise.resolve(healthResponse))
 				.mockImplementationOnce(() => Promise.resolve(jwtResponse));
 
 			axios.put = vi.fn();
@@ -220,62 +167,12 @@ describe('DataService', () => {
 				.then(thenFn)
 				.catch(catchFn);
 
-			expect(axios.get).toHaveBeenNthCalledWith(1, 'fake-host/healthz');
-
-			expect(axios.get).toHaveBeenNthCalledWith(2, 'fake-host/connect', {
+			expect(axios.get).toHaveBeenNthCalledWith(1, 'fake-host/connect', {
 				headers: { Authorization: 'Bearer abcd123' }
 			});
 
 			expect(axios.put).toHaveBeenCalledWith('fake-host/data/forgesteel-heroes', mockData, {
 				headers: { Authorization: 'Bearer fake_token' }
-			});
-
-			expect(thenFn).toHaveBeenCalledWith(mockData);
-		});
-
-		test('Uses cookie auth for new versions of warehouse', async () => {
-			const connSettings = { ...defaultSettings,
-				warehouseHost: 'fake-host',
-				useWarehouse: true,
-				warehouseToken: 'abcd123'
-			};
-
-			const catchFn = vi.fn();
-			const thenFn = vi.fn();
-
-			const healthResponse = { data: { version: '1.0.0' } };
-			const connectResponse = { data: { } };
-
-			axios.get = vi.fn()
-				.mockImplementationOnce(() => Promise.resolve(healthResponse));
-
-			axios.post = vi.fn()
-				.mockImplementationOnce(() => Promise.resolve(connectResponse));
-
-			axios.put = vi.fn();
-
-			const ds = new DataService(connSettings);
-			const connected = await ds.initialize();
-			expect(connected).toBe(true);
-
-			const mockHero = { id: 'test-hero' } as Hero;
-			const mockData = [ mockHero ];
-			// const responseObj = { data: mockData };
-			await ds.saveHeroes(mockData)
-				.then(thenFn)
-				.catch(catchFn);
-
-			expect(axios.get).toHaveBeenNthCalledWith(1, 'fake-host/healthz');
-
-			expect(axios.post).toHaveBeenNthCalledWith(1, 'fake-host/connect', { }, {
-				headers: { Authorization: 'Bearer abcd123' },
-				withCredentials: true,
-				withXSRFToken: true
-			});
-
-			expect(axios.put).toHaveBeenCalledWith('fake-host/data/forgesteel-heroes', mockData, {
-				withCredentials: true,
-				withXSRFToken: true
 			});
 
 			expect(thenFn).toHaveBeenCalledWith(mockData);

--- a/src/utils/data-service.ts
+++ b/src/utils/data-service.ts
@@ -49,16 +49,10 @@ export class DataService {
 		return msg;
 	};
 
-	private async checkUseNewAuth(): Promise<boolean> {
-		try {
-			const status = await axios.get(`${this.host}/healthz`);
-			const version = status.data.version;
-			const maj = parseInt(version.split('.')[0]);
-			return maj > 0;
-		} catch (error) {
-			console.error('Error communicating with FS Warehouse', error);
-			throw new Error(this.getErrorMessage(error), { cause: error });
-		}
+	private async checkUseCookieAuth(): Promise<boolean> {
+		// Future work - once Patreon is integrated and backend is on same domain,
+		// use new auth for patreon. Otherwise, use header auth
+		return false;
 	}
 
 	private async ensureJwt() {
@@ -145,7 +139,7 @@ export class DataService {
 
 	async initialize(): Promise<boolean> {
 		if (this.settings.useWarehouse) {
-			this.useNewAuth = await this.checkUseNewAuth();
+			this.useNewAuth = await this.checkUseCookieAuth();
 			if (this.useNewAuth) {
 				const connected = await this.ensureCsrf();
 				return connected;


### PR DESCRIPTION
In a turn of events I should have completely seen coming after the Patreon cookie/Safari/SameSite issue, the self-hosted Warehouse connection auth with cookies doesn't work in prod. 

This reverts the warehouse data service auth handling back to the header form, which doesn't suffer from the SameSite cookie issue.

Also fixes the transfer page 'Return' button for prod - it currently sends the user to a non-existent page.