### PR TITLE
Improve Negotiation sheet layout in classic view

### DIFF
--- a/src/components/panels/classic-sheet/negotiation-sheet/negotiation-npc-card.scss
+++ b/src/components/panels/classic-sheet/negotiation-sheet/negotiation-npc-card.scss
@@ -42,10 +42,6 @@ main#classic-sheet .negotiation-npc.card {
             color: var(--color-text);
         }
 
-        div:last-of-type p {
-            margin-bottom: 0;
-        }
-
         .languages {
             font-size: round(1.4rem, 1px);;
         }

--- a/src/components/panels/classic-sheet/negotiation-sheet/negotiation-sheet-page.scss
+++ b/src/components/panels/classic-sheet/negotiation-sheet/negotiation-sheet-page.scss
@@ -55,5 +55,15 @@ main#classic-sheet .negotiation-sheet {
         .negotiation-responses.card {
             grid-row-end: span 2;
         }
+
+        section.bordered {
+            &:has(.reference) div:last-of-type {
+                padding-bottom: 41px;
+            }
+            
+            div:last-of-type p {
+                margin-bottom: 0;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Changes
- Fixes an issue where text would overlap in the Negotiation classic view when there was a lot of text:

| Before | After |
|---|---|
|<img width="412" height="265" alt="image" src="https://github.com/user-attachments/assets/b95d23ee-682c-4e16-813c-5a7b4804f040" />|<img width="433" height="294" alt="image" src="https://github.com/user-attachments/assets/516dc23a-9959-45b7-9821-21c29fbe0538" />|

Also handles the **Responses and Offers** card with the same fix