### PR TITLE
[#754] Fix multiplier detection logic

### DIFF
--- a/src/logic/ability-logic.test.ts
+++ b/src/logic/ability-logic.test.ts
@@ -117,4 +117,14 @@ describe('getTextEffect', () => {
 
 		expect(AbilityLogic.getTextEffect(text, hero)).toBe(expected);
 	});
+
+	test.each([
+		[ 'equal to three times your Agility score', 1, 'equal to 3' ],
+		[ 'equal to 3 times your Agility score', 1, 'equal to 3' ]
+	])('should properly calculate multiplier references to characteristics', (text, characteristic, expected) => {
+		HeroLogic.getCharacteristic = vi.fn().mockReturnValue(characteristic);
+		const hero = {} as Hero;
+
+		expect(AbilityLogic.getTextEffect(text, hero)).toBe(expected);
+	});
 });

--- a/src/logic/format-logic.test.ts
+++ b/src/logic/format-logic.test.ts
@@ -41,3 +41,25 @@ describe('getConstant', () => {
 		expect(FormatLogic.getConstant(text)).toBe(expected);
 	});
 });
+
+describe('getMultiplier', () => {
+	test.each([
+		[ 'no number' ],
+		[ 'equal to 1d6' ],
+		[ '1' ],
+		[ '1 + your level' ],
+		[ '2 plus your might score' ]
+	])('should return 1 when there is no multiplier in the text', (text: string) => {
+		expect(FormatLogic.getMultiplier(text)).toBe(1);
+	});
+
+	test.each([
+		[ 'equal to twice your Might', 2 ],
+		[ '3x your level', 3 ],
+		[ 'three times your might', 3 ],
+		[ '3 times might', 3 ],
+		[ '4 times agility', 4 ]
+	])('should return the correct multiplier in the formula', (text: string, expected: number) => {
+		expect(FormatLogic.getMultiplier(text)).toBe(expected);
+	});
+});

--- a/src/logic/format-logic.ts
+++ b/src/logic/format-logic.ts
@@ -144,7 +144,8 @@ export class FormatLogic {
 					'3x',
 					'3 x',
 					'3×',
-					'3 ×'
+					'3 ×',
+					'3 times'
 				]
 			},
 			{
@@ -154,7 +155,8 @@ export class FormatLogic {
 					'4x',
 					'4 x',
 					'4×',
-					'4 ×'
+					'4 ×',
+					'4 times'
 				]
 			},
 			{
@@ -175,7 +177,8 @@ export class FormatLogic {
 					'6x',
 					'6 x',
 					'6×',
-					'6 ×'
+					'6 ×',
+					'6 times'
 				]
 			},
 			{
@@ -185,7 +188,8 @@ export class FormatLogic {
 					'7x',
 					'7 x',
 					'7×',
-					'7 ×'
+					'7 ×',
+					'7 times'
 				]
 			},
 			{
@@ -195,7 +199,8 @@ export class FormatLogic {
 					'8x',
 					'8 x',
 					'8×',
-					'8 ×'
+					'8 ×',
+					'8 times'
 				]
 			},
 			{
@@ -205,7 +210,8 @@ export class FormatLogic {
 					'9x',
 					'9 x',
 					'9×',
-					'9 ×'
+					'9 ×',
+					'9 times'
 				]
 			},
 			{
@@ -215,7 +221,8 @@ export class FormatLogic {
 					'10x',
 					'10 x',
 					'10×',
-					'10 ×'
+					'10 ×',
+					'10 times'
 				]
 			}
 		];


### PR DESCRIPTION
Add some missing combinations of multiplier possibilities to the detection logic (oddly enough, 2 and 5 were already there!)

Fixes #754 