### PR TITLE
Improve the hash code algorithm to greatly reduce collisions

### DIFF
--- a/src/utils/feature-flags.ts
+++ b/src/utils/feature-flags.ts
@@ -9,7 +9,7 @@ export class FeatureFlags {
 	// #region List of all the recognised flags
 
 	static warehouse: FeatureFlag = {
-		code: -1310338776,
+		code: 1551245932421255,
 		description: 'Access to the Warehouse beta'
 	};
 

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -57,4 +57,13 @@ describe('Utils', () => {
 			expect(Utils.getErrorMessage(err)).toBe(expected);
 		});
 	});
+
+	describe('hashCode', () => {
+		test.each([
+			[ 'some medium string', 'another medium string' ],
+			[ '01234567890123456', 'another medium string' ]
+		])('does not collide on medium-length strings', (a, b) => {
+			expect(Utils.hashCode(a)).not.toEqual(Utils.hashCode(b));
+		});
+	});
 });

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -22,12 +22,19 @@ export class Utils {
 		return id;
 	};
 
-	static hashCode = (str: string): number => {
-		let h = 0;
-		for (let i = 0; i < str.length; ++i) {
-			h = (31 * h) + str.charCodeAt(i);
+	// From: https://github.com/bryc/code/blob/master/jshash/experimental/cyrb53.js
+	static hashCode = (str: string, seed: number = 0): number => {
+		let h1 = 0xdeadbeef ^ seed, h2 = 0x41c6ce57 ^ seed;
+		for (let i = 0, ch; i < str.length; i++) {
+			ch = str.charCodeAt(i);
+			h1 = Math.imul(h1 ^ ch, 2654435761);
+			h2 = Math.imul(h2 ^ ch, 1597334677);
 		}
-		return h & 0xFFFFFFFF;
+		h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507);
+		h1 ^= Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+		h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507);
+		h2 ^= Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+		return 4294967296 * (2097151 & h2) + (h1 >>> 0);
 	};
 
 	static copy = <T>(object: T) => {


### PR DESCRIPTION
Switches the `Utils.hashCode` implementation from a 32-bit algorithm to a 53-bit one from [here](https://github.com/bryc/code/blob/master/jshash/experimental/cyrb53.js) (public domain)

This greatly reduces collisions, and will allow for longer codes (useful for multi-word but still easy to remember/convey codes)

**NOTE** I didn't update the `playtest` feature flag value, since I don't know the code - @andyaiken you'll need to make that change when merging.

Also, users might have to re-enter the codes to see them in the feature flags section, but as long as the reference values in `FeatureFlags` are also updated, the actual flag code word shouldn't need to change at all.
