### PR TITLE
FIX: dark mode fix for stamina gauge text

### DIFF
--- a/src/components/panels/health-gauge/health-gauge.scss
+++ b/src/components/panels/health-gauge/health-gauge.scss
@@ -28,3 +28,9 @@
 		font-size: 13px;
 	}
 }
+
+html[data-theme="dark"] {
+	.gauge-info {
+		color: rgb(255, 255, 255);
+	}
+}


### PR DESCRIPTION
In dark mode, the stamina gauge text was black (see before screenshot). Fixed so it's white in dark mode. Tested in chrome, firefox, edge in dark and in light mode. Checked linting.

BEFORE
<img width="804" height="542" alt="image" src="https://github.com/user-attachments/assets/c45a3e62-0014-4664-9e08-289121152ba4" />

AFTER (FIXED)
<img width="783" height="539" alt="image" src="https://github.com/user-attachments/assets/f221afbb-2b0d-4a71-b4c8-7a6022608572" />
