### PR TITLE
Improve rendering of encounter notes

### DIFF
--- a/src/components/pages/classic-sheet/common.scss
+++ b/src/components/pages/classic-sheet/common.scss
@@ -117,7 +117,7 @@ main#classic-sheet {
         }
 
         .card {
-            background: #fff;
+            background-color: #fff;
             border: 2px solid colors.$light;
             border-radius: 2px;
             margin: 5px;

--- a/src/components/panels/classic-sheet/encounter-sheet/encounter-sheet-page.tsx
+++ b/src/components/panels/classic-sheet/encounter-sheet/encounter-sheet-page.tsx
@@ -33,10 +33,12 @@ export const EncounterSheetPage = (props: Props) => {
 		const requiredCards: FillerCard[] = [];
 
 		if (encounter.notes?.length) {
+			let nH = Math.max(20, SheetFormatter.calculateNotesCardSize(encounter.notes, layout.cardLineLen));
+			nH = Math.min(layout.linesY, nH);
 			requiredCards.push({
 				element: <NotesCard notes={encounter.notes} key='notes' />,
 				width: 1,
-				height: Math.max(20, SheetFormatter.countLines(encounter.notes, layout.cardLineLen)),
+				height: nH,
 				shown: false
 			});
 		}

--- a/src/components/panels/classic-sheet/notes-card/notes-card.scss
+++ b/src/components/panels/classic-sheet/notes-card/notes-card.scss
@@ -1,4 +1,9 @@
 @use '../../../pages/classic-sheet/common.scss';
+
+// #classic-sheet .notes.card {
+//     @include common.striped-card;
+// }
+
 #classic-sheet .notes.card .content {
     p {
         font-size: round(1.1rem, 1px);
@@ -6,5 +11,38 @@
 
     h1, h2 {
         @include common.divider-plain(common.$color-medium, 1px);
+    }
+
+    h3 {
+        @include common.divider-gradient-line-center;
+    }
+
+    ul:has(img) {
+        list-style: none;
+        img {
+            width: 50px;
+            height: 26px;
+            margin-top: 2px;
+            margin-bottom: -9px;
+        }
+    }
+    
+    table {
+        th, td {
+            @include common.font-slab();
+            border: 0;
+            padding: 0;
+            height: 26px;
+        }
+        th {
+            font-weight: 500;
+        }
+
+        img {
+            width: 50px;
+            height: 26px;
+            margin-top: 2px;
+            margin-bottom: -5px;
+        }
     }
 }

--- a/src/logic/classic-sheet/sheet-formatter.test.ts
+++ b/src/logic/classic-sheet/sheet-formatter.test.ts
@@ -65,6 +65,22 @@ describe.concurrent('Test markdown enhancement', () => {
 	])('Removes extra/bad markdown stuff', (inStr, expected) => {
 		expect(SheetFormatter.enhanceMarkdown(inStr)).toBe(expected);
 	});
+
+	test.each([
+		[ '| ≤ 11 |', '|![11 or less](<img>)|' ],
+		[ '| 12-16 |', '|![12 to 16](<img>)|' ],
+		[ '| 17+ |', '|![17 or greater](<img>)|' ],
+		[ '* 11 or lower:', '* ![11 or less](<img>)' ],
+		[ '* 12 - 16:', '* ![12 to 16](<img>)' ],
+		[ '* ≥ 17:', '* ![17 or greater](<img>)' ],
+		[ '* 17+:', '* ![17 or greater](<img>)' ],
+		[ '* ≤11:', '* ![11 or less](<img>)' ]
+	])('Converts power roll text to glyphs', (inStr, expected) => {
+		const markdown = SheetFormatter.enhanceMarkdown(inStr);
+		// switch out the image svg details
+		const check = markdown.replace(/(!\[.+\])\(data:image.+\)/, '$1(<img>)');
+		expect(check).toBe(expected);
+	});
 });
 
 describe.concurrent('cleanupText', () => {

--- a/src/logic/classic-sheet/sheet-formatter.ts
+++ b/src/logic/classic-sheet/sheet-formatter.ts
@@ -120,9 +120,9 @@ export class SheetFormatter {
 			.replace(/\|\s+≤\s*11\s+\|/g, `|![11 or less](${rollT1Icon})|`)
 			.replace(/\|\s+12\s*[-–]\s*16\s+\|/g, `|![12 to 16](${rollT2Icon})|`)
 			.replace(/\|\s+≥?\s*17\s*\+?\s+\|/g, `|![17 or greater](${rollT3Icon})|`)
-			.replace(/11 or lower:?/g, `![11 or less](${rollT1Icon})`)
+			.replace(/(11 or lower|≤\s*11):?/g, `![11 or less](${rollT1Icon})`)
 			.replace(/12\s*[-–]\s*16:?/g, `![12 to 16](${rollT2Icon})`)
-			.replace(/17\s*\+:?/g, `![17 or greater](${rollT3Icon})`)
+			.replace(/(17\s*\+|≥\s*17):?/g, `![17 or greater](${rollT3Icon})`)
 			.replace(/[`]/g, '')
 			.replace(/<\/?code>/g, '');
 		return text;
@@ -757,6 +757,16 @@ export class SheetFormatter {
 		return size;
 	};
 
+	static calculateNotesCardSize = (notes: string, lineWidth: number): number => {
+		let size = 2.7;
+		size += Math.max(20, this.countLines(notes, lineWidth));
+		const numHeadings = (notes.match(/###/g) || []).length;
+		size += numHeadings * 0.8; // extra spage per heading
+		const numParagraphs = (notes.match(/\n\n/g) || []).length;
+		size += numParagraphs * 0.3; // extra space per paragraph
+		return size;
+	};
+
 	static calculateAbilitySize = (ability: AbilitySheet | undefined, lineWidth: number): number => {
 		let size = 0;
 		const rollLineLen = Math.ceil(0.8 * lineWidth) - 10;
@@ -785,7 +795,7 @@ export class SheetFormatter {
 
 	static countLines = (text: string | undefined, lineWidth: number, emptyLineSize = 0, lineFactor: number = 1) => {
 		let tableSpace = 0;
-		const result = text?.trim().split('\n').reduce((n, l) => {
+		const result = text?.trim().replaceAll(/(!\[.+\])\(data:image.+\)/g, '$1(<img>)').split('\n').reduce((n, l) => {
 			let len = emptyLineSize;
 			if (l.length) {
 				len = Math.ceil(l.length / lineWidth) * lineFactor;

--- a/src/logic/playbook-sheets/encounter-sheet-builder.ts
+++ b/src/logic/playbook-sheets/encounter-sheet-builder.ts
@@ -9,6 +9,7 @@ import { Hero } from '@/models/hero';
 import { MonsterLogic } from '@/logic/monster-logic';
 import { MonsterOrganizationType } from '@/enums/monster-organization-type';
 import { Options } from '@/models/options';
+import { SheetFormatter } from '../classic-sheet/sheet-formatter';
 import { Sourcebook } from '@/models/sourcebook';
 import { SourcebookLogic } from '@/logic/sourcebook-logic';
 import { Utils } from '@/utils/utils';
@@ -31,7 +32,10 @@ export class EncounterSheetBuilder {
 			encounterEv: strength
 		};
 
-		sheet.notes = encounter.notes.map(note => `# ${note.name}\n${note.description}`).join('\n\n');
+		sheet.notes = encounter.notes.map(note => {
+			const description = SheetFormatter.enhanceMarkdown(note.description);
+			return `### ${note.name}\n${description}`;
+		}).join('\n\n');
 
 		sheet.objective = encounter.objective?.name;
 		sheet.successCondition = encounter.objective?.successCondition;


### PR DESCRIPTION
Improves the rendering and layout of Encounter notes.

Now renders power rolls with glyphs when entered as a list:

| Editor | Classic sheet |
|---|---|
| <img width="385" height="137" alt="image" src="https://github.com/user-attachments/assets/93ed7c17-7220-4334-90a5-1dc426529fbc" /> | <img width="317" height="115" alt="image" src="https://github.com/user-attachments/assets/34eada86-9b9f-4d3f-bb61-9549c2934bce" /> |