### PR TITLE
Fix text wrapping in classic sheet immunities/weaknesses

### DIFF
--- a/src/components/panels/classic-sheet/immunities-weaknesses-card/immunities-weaknesses-card.scss
+++ b/src/components/panels/classic-sheet/immunities-weaknesses-card/immunities-weaknesses-card.scss
@@ -34,6 +34,7 @@
             border-radius: 3px;
             padding: 1px 3px;
             opacity: 0.9;
+            text-wrap: nowrap;
         }
     }
 }


### PR DESCRIPTION
Fixes [text](https://discord.com/channels/332362513368875008/1284267513084903485/1455288465343381765)

In some cases (high dpi displays, or Windows when display scaling is > 100%), the Immunities/Weaknesses would wrap outside the box when creating the PDF.