### PR TITLE
Add Forge Steel patreon status

### DIFF
--- a/src/components/panels/connection-settings/patreon-connect-panel.tsx
+++ b/src/components/panels/connection-settings/patreon-connect-panel.tsx
@@ -1,4 +1,4 @@
-import { Alert, Button, Flex, Space, Spin } from 'antd';
+import { Alert, Button, Flex, Space, Spin, notification } from 'antd';
 import { useEffect, useState } from 'react';
 import { Browser } from '@/utils/browser';
 import { ConnectionSettings } from '@/models/connection-settings';
@@ -20,6 +20,7 @@ interface Props {
 export const PatreonConnectPanel = (props: Props) => {
 	const [ loadingSession, setLoadingSession ] = useState<boolean>(true);
 	const [ patreonSession, setPatreonSession ] = useState<PatreonSession | null>(null);
+	const [ notify, notifyContext ] = notification.useNotification();
 
 	const connectOAuth = () => {
 		props.dataService.getPatreonAuthUrl()
@@ -42,12 +43,20 @@ export const PatreonConnectPanel = (props: Props) => {
 		setLoadingSession(true);
 		props.dataService.getPatreonSession()
 			.then(setPatreonSession)
+			.catch(err => {
+				console.error(err);
+				notify.error({
+					title: 'Error connecting with Patreon',
+					description: Utils.getErrorMessage(err),
+					placement: 'top'
+				});
+			})
 			.finally(() => {
 				setLoadingSession(false);
 			});
 	};
 
-	useEffect(updateSession, [ props.dataService ]);
+	useEffect(updateSession, [ props.dataService, notify ]);
 
 	if (loadingSession) {
 		return (
@@ -102,6 +111,7 @@ export const PatreonConnectPanel = (props: Props) => {
 					/>
 					: null
 			}
+			{notifyContext}
 		</Space>
 	);
 };

--- a/src/components/panels/connection-settings/patreon-status-panel.tsx
+++ b/src/components/panels/connection-settings/patreon-status-panel.tsx
@@ -23,20 +23,27 @@ export const PatreonStatusPanel = (props: Props) => {
 		);
 	};
 
-	const getTier = () => {
-		if (!props.status || !props.status.patron || !props.status.tier_cents) {
+	const getTiers = () => {
+		if (!props.status || !props.status.patron || !props.status.tiers) {
 			return null;
 		}
 
-		const dollars = Math.round(props.status.tier_cents / 100);
-
 		return (
-			<Tag
-				color='blue'
-				variant='outlined'
-			>
-				${dollars} Tier
-			</Tag>
+			<>
+				{
+					props.status.tiers.map(tier => {
+						return (
+							<Tag
+								key={tier.id}
+								color='blue'
+								variant='outlined'
+							>
+								{tier.title}
+							</Tag>
+						);
+					})
+				}
+			</>
 		);
 	};
 
@@ -68,7 +75,7 @@ export const PatreonStatusPanel = (props: Props) => {
 			</HeaderText>
 			<Flex gap={5}>
 				{getIsPatron()}
-				{getTier()}
+				{getTiers()}
 				{getSubscribedDate()}
 			</Flex>
 		</div>

--- a/src/models/patreon-connection.ts
+++ b/src/models/patreon-connection.ts
@@ -8,8 +8,14 @@ export interface PatreonConnection {
 	status: PatronStatus | null;
 }
 
+export interface PatronTier {
+	id: string;
+	title: string;
+}
+
 export interface PatronStatus {
 	patron: boolean;
+	tiers: PatronTier[];
 	tier_cents: number;
 	start: string;
 }

--- a/src/utils/data-service.ts
+++ b/src/utils/data-service.ts
@@ -146,6 +146,11 @@ export class DataService {
 
 				if (response.data.authenticated_with_patreon && response.data.user) {
 					result.connections.push({
+						name: 'Forge Steel Patreon',
+						status: response.data.user.forgesteel
+					});
+
+					result.connections.push({
 						name: 'MCDM Patreon',
 						status: response.data.user.mcdm
 					});
@@ -174,6 +179,11 @@ export class DataService {
 				result.authenticated = response.data.authenticated_with_patreon;
 
 				if (response.data.authenticated_with_patreon && response.data.user) {
+					result.connections.push({
+						name: 'Forge Steel Patreon',
+						status: response.data.user.forgesteel
+					});
+
 					result.connections.push({
 						name: 'MCDM Patreon',
 						status: response.data.user.mcdm


### PR DESCRIPTION
- Adds a membership indicator for the Forge Steel Patreon when connecting with Patreon:

<img width="434" height="258" alt="image" src="https://github.com/user-attachments/assets/56559ab8-2afe-4ceb-ad32-7953ae5503b4" />

- Also, the membership tier dollar tag has been replaced with a list of tiers (by name) that the user is entitled to for each campaign. E.g. the $8 (USD) MCDM tier is called 'MCDM+'. This name is pulled *from* the patreon api, so it will update correspondingly if/when the campaigns are modified.

- Adds some better error handling to the patreon connect panel

Currently has no additional functionality beyond showing membership and tier(s)