### PR TITLE
Bugfix - power roll markdown in notes

### DIFF
--- a/src/components/panels/classic-sheet/notes-card/notes-card.scss
+++ b/src/components/panels/classic-sheet/notes-card/notes-card.scss
@@ -19,12 +19,14 @@
 
     ul:has(img) {
         list-style: none;
-        img {
-            width: 50px;
-            height: 26px;
-            margin-top: 2px;
-            margin-bottom: -9px;
-        }
+    }
+    
+    li img,
+    p img {
+        width: 50px;
+        height: 26px;
+        margin-top: 2px;
+        margin-bottom: -9px;
     }
     
     table {

--- a/src/logic/classic-sheet/sheet-formatter.test.ts
+++ b/src/logic/classic-sheet/sheet-formatter.test.ts
@@ -72,6 +72,8 @@ describe.concurrent('Test markdown enhancement', () => {
 		[ '|11 or less		|', '|![11 or less](<img>)|' ],
 		[ '* 11 or lower:', '* ![11 or less](<img>)' ],
 		[ '* ≤11:', '* ![11 or less](<img>)' ],
+		[ '<=11', '![11 or less](<img>)' ],
+		[ '\\<\\=11', '![11 or less](<img>)' ],
 		[ '* <= 11:', '* ![11 or less](<img>)' ],
 		[ '| 12-16 |', '|![12 to 16](<img>)|' ],
 		[ '* 12 - 16:', '* ![12 to 16](<img>)' ],

--- a/src/logic/classic-sheet/sheet-formatter.ts
+++ b/src/logic/classic-sheet/sheet-formatter.ts
@@ -117,7 +117,7 @@ export class SheetFormatter {
 			.replace(/I<([svw\d])\]/g, 'i<$1]')
 			.replace(/P<([svw\d])\]/g, 'p<$1]')
 			.replace(/([marip])<([svw\d]\])/g, '<span class="potency">$1&lt;$2</span>')
-			.replace(/((≤|<=)\s*11|11 or (less|lower)):?/g, `![11 or less](${rollT1Icon})`)
+			.replace(/((≤|\\?<\\?=)\s*11|11 or (less|lower)):?/g, `![11 or less](${rollT1Icon})`)
 			.replace(/12\s*[-–]\s*16:?/g, `![12 to 16](${rollT2Icon})`)
 			.replace(/((≥|>=)\s*17|17(\+| or (more|greater))):?/g, `![17 or greater](${rollT3Icon})`)
 			.replace(/[`]/g, '')


### PR DESCRIPTION
Improves the detection of power roll tables in markdown, and improves rendering of the power roll tier glyphs outside lists in the notes cards.