### PR TITLE
Always apply font scale fix for pdf

### DIFF
--- a/src/components/panels/classic-sheet/encounter-sheet/encounter-sheet-page.tsx
+++ b/src/components/panels/classic-sheet/encounter-sheet/encounter-sheet-page.tsx
@@ -1,4 +1,5 @@
 import { FillerCard, SheetLayout } from '@/logic/classic-sheet/sheet-layout';
+import { DebugCard } from '../reference/debug-card';
 import { Encounter } from '@/models/encounter';
 import { EncounterHeaderCard } from '@/components/panels/classic-sheet/encounter-header/encounter-header';
 import { EncounterRosterCard } from '@/components/panels/classic-sheet/encounter-roster/encounter-roster';
@@ -39,6 +40,15 @@ export const EncounterSheetPage = (props: Props) => {
 				element: <NotesCard notes={encounter.notes} key='notes' />,
 				width: 1,
 				height: nH,
+				shown: false
+			});
+		}
+
+		if (props.options.debugClassicSheet) {
+			requiredCards.push({
+				element: <DebugCard options={props.options} key='debug' />,
+				width: 1,
+				height: 15,
 				shown: false
 			});
 		}

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,4 +1,3 @@
-import { Browser } from '@/utils/browser';
 import { Converter } from 'showdown';
 import { Random } from '@/utils/random';
 import { SheetPageSize } from '@/enums/sheet-page-size';
@@ -109,7 +108,7 @@ export class Utils {
 		const height = element.clientHeight;
 
 		// see: https://github.com/qq15725/modern-screenshot/issues/104
-		const mobileFix = (node: Node) => {
+		const fontScaleFix = (node: Node) => {
 			if (node instanceof HTMLElement) {
 				node.style.fontSize = node.style.fontSize.replace(/(\d+(\.\d+)?(e[+-]?\d+)?)/g, (match, number) => {
 					const parsedNumber = parseFloat(number);
@@ -122,7 +121,7 @@ export class Utils {
 			width: width,
 			height: height,
 			scale: scale,
-			onCloneEachNode: Browser.isMobile() ? mobileFix : null
+			onCloneEachNode: fontScaleFix
 		});
 	};
 


### PR DESCRIPTION
Always apply font scaling fix for classic sheet PDFs, instead of only for mobile. At least one user was still seeing the text wrapping issue on non-mobile browsers, though I could not reproduce.

Also add a debug card to the encounter sheet if enabled