### PR TITLE
Configure app for external deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:latest AS builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json .
+RUN npm ci
+
+COPY . ./
+RUN npm run predeploy
+
+FROM nginx:latest
+
+RUN rm -rf /etc/nginx/conf.d/default.conf
+COPY ./nginx/default.conf /etc/nginx/conf.d/default.conf
+
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+WORKDIR /usr/share/nginx/html
+
+CMD ["/bin/bash", "-c", "nginx -g \"daemon off;\""]

--- a/index.html
+++ b/index.html
@@ -14,13 +14,13 @@
 	<meta property="og:title" content="Forge Steel" />
 	<meta property="og:type" content="website" />
 	<meta property="og:image" content="/src/assets/shield.png" />
-	<meta property="og:url" content="https://andyaiken.github.io/forgesteel/" />
+	<meta property="og:url" content="https://forgesteel.net/" />
 	<meta http-equiv="Cache-Control" content="no-store, no-cache" />
 	<meta http-equiv="Pragma" content="no-cache" />
 	<meta http-equiv="Expires" content="0" />
 	
 	<!-- PWA Manifest -->
-	<link rel="manifest" href="/forgesteel/manifest.json" />
+	<link rel="manifest" href="/manifest.json" />
 	
 	<!-- PWA Meta Tags -->
 	<meta name="theme-color" content="#1890ff" />

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,40 @@
+types {
+    font/otf otf;
+    font/ttf ttf;
+    font/woff woff;
+    font/woff2 woff2;
+}
+
+gzip on;
+gzip_comp_level 5;
+gzip_min_length 256;
+gzip_types
+    application/javascript
+    application/json
+    application/manifest+json
+    application/xml
+    font/otf
+    font/ttf
+    font/woff
+    font/woff2
+    text/css
+    text/javascript
+    text/plain
+    text/xml
+    image/svg+xml;
+
+server {
+  listen 80;
+  add_header Cache-Control no-cache;
+  location / {
+    root   /usr/share/nginx/html;
+    index  index.html index.htm;
+    try_files $uri $uri/ /index.html;
+    expires -1;
+  }
+
+  error_page   500 502 503 504  /50x.html;
+  location = /50x.html {
+    root   /usr/share/nginx/html;
+  }
+}

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ npm install
 npm run start
 ```
 
-Once built, the app should then be available at `http://localhost:5173/forgesteel/`.
+Once built, the app should then be available at `http://localhost:5173/`.
 
 When you've finished with your changes, make sure to appease the linter and run the unit tests:
 

--- a/src/hooks/use-sync-status.ts
+++ b/src/hooks/use-sync-status.ts
@@ -91,9 +91,9 @@ export const useSyncStatus = () => {
 
 				// Cache essential files
 				const urlsToCache = [
-					'/forgesteel/',
-					'/forgesteel/index.html',
-					'/forgesteel/manifest.json'
+					'/',
+					'/index.html',
+					'/manifest.json'
 				];
 
 				await cache.addAll(urlsToCache);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,7 +13,7 @@ initializeTheme();
 // Register Service Worker for PWA functionality
 if ('serviceWorker' in navigator) {
 	window.addEventListener('load', () => {
-		navigator.serviceWorker.register('/forgesteel/sw.js')
+		navigator.serviceWorker.register('/sw.js')
 			.catch(registrationError => {
 				console.error('SW registration failed: ', registrationError);
 			});

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -24,9 +24,9 @@ const swSelf = self as unknown as ServiceWorkerGlobalScope;
 const CACHE_VERSION = new Date().toISOString().replace(/[:.]/g, '-');
 const CACHE_NAME = `forgesteel-${CACHE_VERSION}`;
 const STATIC_CACHE_URLS = [
-	'/forgesteel/',
-	'/forgesteel/index.html',
-	'/forgesteel/manifest.json'
+	'/',
+	'/index.html',
+	'/manifest.json'
 ];
 
 // Install event - cache static assets
@@ -89,7 +89,7 @@ self.addEventListener('fetch', (event: Event) => {
 				const response = await fetch(fetchEvent.request);
 
 				// Cache for offline use only
-				if (response && response.status === 200 && fetchEvent.request.url.includes('/forgesteel/')) {
+				if (response && response.status === 200 && fetchEvent.request.url.includes('/')) {
 					const cache = await caches.open(CACHE_NAME);
 					await cache.put(fetchEvent.request, response.clone());
 				}
@@ -104,7 +104,7 @@ self.addEventListener('fetch', (event: Event) => {
 
 				// Fallback to main page for navigation
 				if (fetchEvent.request.destination === 'document') {
-					const fallback = await caches.match('/forgesteel/index.html');
+					const fallback = await caches.match('/index.html');
 					if (fallback) {
 						return fallback;
 					}
@@ -132,8 +132,8 @@ self.addEventListener('push', (event: Event) => {
 		const data = pushEvent.data.json() as { title: string; body: string };
 		const options: NotificationOptions = {
 			body: data.body,
-			icon: '/forgesteel/src/assets/shield.png',
-			badge: '/forgesteel/src/assets/shield.png',
+			icon: '/src/assets/shield.png',
+			badge: '/src/assets/shield.png',
 			data: {
 				dateOfArrival: Date.now(),
 				primaryKey: 1

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,12 +7,12 @@ const BASE_MANIFEST = {
 	name: 'Forge Steel',
 	short_name: 'Forge Steel',
 	description: 'Heroes, monsters, encounters ... everything you need for Draw Steel.',
-	start_url: '/forgesteel/',
+	start_url: '/',
 	display: 'standalone',
 	background_color: '#ffffff',
 	theme_color: '#1890ff',
 	orientation: 'any',
-	scope: '/forgesteel/',
+	scope: '/',
 	categories: [ 'games', 'entertainment', 'utilities' ],
 	lang: 'en',
 	dir: 'ltr'
@@ -20,7 +20,7 @@ const BASE_MANIFEST = {
 
 // Generate manifest with icon paths
 const generateManifest = (shieldIconPath?: string) => {
-	const iconPath = shieldIconPath || '/forgesteel/src/assets/shield.png';
+	const iconPath = shieldIconPath || '/src/assets/shield.png';
 
 	return {
 		...BASE_MANIFEST,
@@ -51,7 +51,7 @@ const manifestPlugin = (): Plugin => {
 			);
 
 			if (shieldIcon) {
-				const manifest = generateManifest(`/forgesteel/${shieldIcon}`);
+				const manifest = generateManifest(`/${shieldIcon}`);
 
 				// Write the manifest to the dist folder
 				this.emitFile({
@@ -66,7 +66,7 @@ const manifestPlugin = (): Plugin => {
 
 // https://vitejs.dev/config/
 export default defineConfig({
-	base: '/forgesteel/',
+	base: '/',
 	build: {
 		chunkSizeWarningLimit: 10000,
 		rollupOptions: {
@@ -77,6 +77,12 @@ export default defineConfig({
 			output: {
 				entryFileNames: chunkInfo => {
 					return chunkInfo.name === 'sw' ? 'sw.js' : '[name]-[hash].js';
+				},
+				assetFileNames: chunkInfo => {
+					if (chunkInfo.names && chunkInfo.names[0].match(/\.(ttf|otf)$/)) {
+						return 'assets/[name][extname]';
+					}
+					return 'assets/[name]-[hash][extname]';
 				}
 			}
 		}
@@ -90,20 +96,14 @@ export default defineConfig({
 			name: 'dev-pwa-files',
 			configureServer(server) {
 				// Serve manifest.json during development
-				// Handle both possible paths due to Vite's base path resolution
-				server.middlewares.use('/forgesteel/forgesteel/manifest.json', (_, res) => {
-					const manifest = generateManifest();
-					res.setHeader('Content-Type', 'application/json');
-					res.end(JSON.stringify(manifest, null, 2));
-				});
-				server.middlewares.use('/forgesteel/manifest.json', (_, res) => {
+				server.middlewares.use('/manifest.json', (_, res) => {
 					const manifest = generateManifest();
 					res.setHeader('Content-Type', 'application/json');
 					res.end(JSON.stringify(manifest, null, 2));
 				});
 
 				// Serve sw.js during development (compiled on-the-fly)
-				server.middlewares.use('/forgesteel/sw.js', async (_, res) => {
+				server.middlewares.use('/sw.js', async (_, res) => {
 					try {
 						// Import and compile the service worker
 						const { build } = await import('esbuild');
@@ -131,7 +131,7 @@ export default defineConfig({
 	publicDir: 'public',
 	server: {
 		headers: {
-			'Service-Worker-Allowed': '/forgesteel/'
+			'Service-Worker-Allowed': '/'
 		}
 	}
 });


### PR DESCRIPTION
Prepares the app for external deployment via container to non-GitHub Pages hosting

## Changes
- Adds a Dockerfile to wrap the app in a container (served by nginx)
- updates app references (not any backend just yet) to the new url
- updates the serviceworker and dev server to expect/run the app at the root path instead of  `/forgesteel`
- Updates the vite bundler to not hash font files - I am pretty sure these don't change much if ever, so busting caching on them (especially since they can be rather large) is counterproductive