### PR TITLE
Add GitHub Actions workflow to build and push app container

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,3 @@
+## Production env vars - these are just prefixed tokens to be replaced
+## at runtime as part of the docker startup
+VITE_PATREON_TOKEN_HANDLER_HOST=FORGESTEEL_PATREON_TOKEN_HANDLER_HOST

--- a/.env.production
+++ b/.env.production
@@ -1,3 +1,17 @@
 ## Production env vars - these are just prefixed tokens to be replaced
 ## at runtime as part of the docker startup
+##
+## To declare a new env var, in addition to any app setup (e.g. in vite-env.d.ts)
+## add an entry in this file in the form:
+##
+## VITE_ENV_NAME=FORGESTEEL_ENV_NAME
+##
+## The VITE_ENV_NAME part is how the var will be referenced in the app, and 
+## FORGESTEEL_ENV_NAME will be the token used to inject the runtime value in
+## the production container. The token MUST start with 'FORGESTEEL_', and the
+## FULL token (e.g. 'FORGESTEEL_ENV_NAME') will be the env var referenced in
+## the container.
+##
+## See nginx/env.sh for more
+##
 VITE_PATREON_TOKEN_HANDLER_HOST=FORGESTEEL_PATREON_TOKEN_HANDLER_HOST

--- a/.github/workflows/digitalocean.yml
+++ b/.github/workflows/digitalocean.yml
@@ -2,11 +2,11 @@ name: Build and deploy
 
 on:
   push:
-    branches: [ feature/gh-action-deploy ]
+    branches: [ host-deployment ]
 
 env:
-  CONTAINER_REGISTRY: "registry.digitalocean.com/forgesteel-fork-test"
-  IMAGE_NAME: "forgesteel"
+  CONTAINER_REGISTRY: "registry.digitalocean.com/forgesteel"
+  IMAGE_NAME: "forgesteel-app"
 
 jobs:
   build_and_push:

--- a/.github/workflows/digitalocean.yml
+++ b/.github/workflows/digitalocean.yml
@@ -1,0 +1,125 @@
+name: Build and deploy
+
+on:
+  push:
+    branches: [ feature/gh-action-deploy ]
+
+env:
+  CONTAINER_REGISTRY: "registry.digitalocean.com/forgesteel-fork-test"
+  IMAGE_NAME: "forgesteel"
+
+jobs:
+  build_and_push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+    
+      - name: Log in to DOCR with short-lived credentials
+        run: doctl registry login --expiry-seconds 600
+      
+      - name: Set short hash
+        run: echo "COMMIT_SHA_SHORT=$(echo $GITHUB_SHA | head -c7)" >> $GITHUB_ENV
+
+      - name: Set full image name
+        run: echo "FULL_IMAGE_NAME=${CONTAINER_REGISTRY}/${IMAGE_NAME}" >> $GITHUB_ENV
+
+      - name: Check image name
+        run: echo "${{ env.FULL_IMAGE_NAME }}:${{ env.COMMIT_SHA_SHORT }}"
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6.5.0
+        with:
+          context: .
+          push: true
+          tags: ${{ env.FULL_IMAGE_NAME }}:${{ env.COMMIT_SHA_SHORT }},${{ env.FULL_IMAGE_NAME }}:latest
+
+      - name: Cleanup old images
+        run: |
+          #!/bin/bash -e
+
+          ## Adapted slightly from https://github.com/rehab834/Automatic-cleaning-up-of-DOCR-/blob/main/DOCR-clean-up.yaml
+          set -o pipefail
+          echo "=== Starting DOCR Cleanup ==="
+          trap 'echo "ERROR: Cleanup failed at $(date)"; exit 1' ERR
+
+          ##
+          ## Build keeplist from running apps
+          ##
+          echo "Building list of digests to keep from running apps..."
+          KEEP_DIGESTS=""
+          echo "Fetching in-use image digests..."
+          IN_USE_DIGESTS=$(doctl apps list --output json | \
+              jq -r '.[] | .active_deployment.cause_details.docr_push.image_digest | select( . != null )')
+          if [ -z "$IN_USE_DIGESTS" ]; then
+              echo "No running images found in apps."
+          else
+              KEEP_DIGESTS=$(echo "$IN_USE_DIGESTS")
+              echo "Successfully marked running image digests to keep."
+          fi
+          echo "Keep list build complete."
+
+          ##
+          ## Loop through each repository
+          ##
+          doctl registry repository list | tail -n +2 | awk '{print $1}' | while read -r repo; do
+              echo "--- Processing repository: $repo ---"
+              ## List all manifests and separate into two lists
+              all_manifests=$(doctl registry repository list-manifests $repo --format Digest,UpdatedAt,Tags | tail -n +2)
+              untagged_list=""
+              tagged_list=""
+              while read -r line; do
+                  [ -z "$line" ] && continue
+                  digest=$(echo $line | awk '{print $1}')
+                  updated_at=$(echo $line | awk '{print $6, $7, $8}')
+                  tags=$(echo $line | awk '{print $10}')
+                  timestamp=$(date -d "$updated_at" +%s)
+                  output_line="$timestamp|$digest|$updated_at"
+                  if [ "$tags" == "[]" ]; then
+                      untagged_list+="$output_line\n"
+                  else
+                      tagged_list+="$output_line\n"
+                  fi
+              done <<< "$all_manifests"
+              ## Process UNTAGGED images (Delete all, no checks)
+              echo "Processing untagged images..."
+              while read -r line; do
+                  [ -z "$line" ] && continue
+                  digest=$(echo $line | cut -d'|' -f2)
+                  updated_at=$(echo $line | cut -d'|' -f3)
+                  printf "Deleting (untagged): %s (updated at %s)\n" "$digest" "$updated_at"
+                  doctl registry repository delete-manifest $repo $digest --force
+              done <<< "$(echo -e "$untagged_list")"
+              ## Process TAGGED images
+              echo "Processing tagged images..."
+              keep_count=0
+              while read -r line; do
+                  [ -z "$line" ] && continue
+                  keep_count=$((keep_count + 1))
+                  timestamp=$(echo $line | cut -d'|' -f1)
+                  digest=$(echo $line | cut -d'|' -f2)
+                  updated_at=$(echo $line | cut -d'|' -f3)
+                  ## Skip images currently running in cluster
+                  if [[ "$KEEP_DIGESTS" == *"$digest"* ]]; then
+                      printf "Keeping (in use): %s (updated at %s)\n" "$digest" "$updated_at"
+                      continue
+                  fi
+                  ## Always keep the 5 latest tagged images
+                  if [[ $keep_count -le 5 ]]; then
+                      printf "Keeping (newest %d/5): %s (updated at %s)\n" "$keep_count" "$digest" "$updated_at"
+                      continue
+                  fi
+                  ## Delete others
+                  printf "Deleting (tagged, older): %s (updated at %s)\n" "$digest" "$updated_at"
+                  doctl registry repository delete-manifest $repo $digest --force
+
+              done <<< "$(echo -e "$tagged_list" | sort -rn)" # Sort tagged list newest first
+              echo "Completed cleanup for repository: $repo"
+          done
+          echo "=== Registry cleanup finished successfully ==="

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ coverage
 dist
 node_modules
 .DS_Store
-.github
 .vscode/
 .vscode/*
 .env
+.env.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM node:latest AS builder
-
 WORKDIR /app
 
 COPY package.json package-lock.json .
@@ -15,6 +14,10 @@ COPY ./nginx/default.conf /etc/nginx/conf.d/default.conf
 
 COPY --from=builder /app/dist /usr/share/nginx/html
 
+COPY ./nginx/env.sh /docker-entrypoint.d/40-env.sh
+RUN chmod +x /docker-entrypoint.d/40-env.sh
+
 WORKDIR /usr/share/nginx/html
 
-CMD ["/bin/bash", "-c", "nginx -g \"daemon off;\""]
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,8 +1,6 @@
 types {
     font/otf otf;
     font/ttf ttf;
-    font/woff woff;
-    font/woff2 woff2;
 }
 
 gzip on;
@@ -15,7 +13,6 @@ gzip_types
     application/xml
     font/otf
     font/ttf
-    font/woff
     font/woff2
     text/css
     text/javascript
@@ -36,5 +33,11 @@ server {
   error_page   500 502 503 504  /50x.html;
   location = /50x.html {
     root   /usr/share/nginx/html;
+  }
+
+  location /healthz {
+    access_log off;
+    return 200 'healthy';
+    add_header Content-Type text/plain;
   }
 }

--- a/nginx/env.sh
+++ b/nginx/env.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -e
+
+APP_PREFIX="FORGESTEEL_"
+ASSET_DIR=/usr/share/nginx/html
+
+# # Check if APP_PREFIX is set
+# : "${APP_PREFIX:?APP_PREFIX must be set (e.g. APP_PREFIX='APP_PREFIX_')}"
+
+# # Check if ASSET_DIRS is set
+# : "${ASSET_DIR:?Must set ASSET_DIR to one path}"
+
+# Check if the directory exists
+if [ ! -d "$ASSET_DIR" ]; then
+    # If not, display a warning message and skip to the next iteration
+    echo "Warning: directory '$ASSET_DIR' not found, skipping."
+    continue
+fi
+
+# Display the current directory being scanned
+echo "Scanning directory: $ASSET_DIR"
+
+# Iterate through each environment variable that starts with APP_PREFIX
+env | grep "^${APP_PREFIX}" | while IFS='=' read -r key value; do
+    # Display the variable being replaced
+    echo "  • Replacing ${key} → ${value}"
+
+    # Use find and sed to replace the variable in all files within the directory
+    find "$ASSET_DIR" -type f \
+        -exec sed -i "s|${key}|${value}|g" {} +
+done

--- a/src/utils/data-service.ts
+++ b/src/utils/data-service.ts
@@ -22,7 +22,7 @@ export class DataService {
 		this.storageService = StorageServiceFactory.fromConnectionSettings(settings);
 
 		const envVal = import.meta.env.VITE_PATREON_TOKEN_HANDLER_HOST;
-		this.tokenHandlerHost = Utils.valueOrDefault(envVal, 'https://forgesteel-warehouse-b7wsk.ondigitalocean.app');
+		this.tokenHandlerHost = Utils.valueOrDefault(envVal, 'https://warehouse.forgesteel.net');
 	};
 
 	private async getLocalOrWarehouse<T>(key: string): Promise<T | null> {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+	// API Configuration
+	readonly VITE_PATREON_TOKEN_HANDLER_HOST: string;
+}
+
+interface ImportMeta {
+	readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Changes

- Adds a new workflow (initially set to auto-run on the `host-deployment` branch) that:
   - Builds the app container
   - Logs in to the Digital Ocean Container Registry (DOCR) using an API token
   - Pushes the built container to the registry
   - Cleans up the registry, deleting any unused images older than the most recent 5
- Adds a `/healthz` endpoint to the app container for nginx liveliness probes
- Adds a way to inject runtime environment variables to the container, piggybacking on the built-in vite process
    - Currently there's only one variable like this: `VITE_PATREON_TOKEN_HANDLER_HOST` but the process is easily extendable in the future for other config things