### PR TITLE
fix: Issue #810 ensure component state is updated for xp per level

### DIFF
--- a/src/components/modals/settings/settings-modal.tsx
+++ b/src/components/modals/settings/settings-modal.tsx
@@ -92,12 +92,14 @@ export const SettingsModal = (props: Props) => {
 		const setXPPerLevel = (value: number) => {
 			const copy = Utils.copy(options);
 			copy.xpPerLevel = value;
+			setOptions(copy);
 			props.setOptions(copy);
 		};
 
 		const setShownStandardAbilities = (value: string | string[]) => {
 			const copy = Utils.copy(options);
 			copy.shownStandardAbilities = [ value ].flat(1);
+			setOptions(copy);
 			props.setOptions(copy);
 		};
 


### PR DESCRIPTION
saw this issue pop up and figured out what was going on. Only parent state was being updated, internal component state was not being updated. Curiously enough the other option in Heroes General was updating both parent and component state; i still had it update internal component state as well for good measure.

New to this codebase (and open-source... and github lol) so lmk if I'm missing something here!

Issue Link: https://github.com/andyaiken/forgesteel/issues/810