### PR TITLE
Update workflow

### DIFF
--- a/.github/workflows/digitalocean.yml
+++ b/.github/workflows/digitalocean.yml
@@ -2,11 +2,17 @@ name: Build and deploy
 
 on:
   push:
-    branches: [ host-deployment ]
+    branches:
+      - host-deployment
+  workflow_dispatch:
+    inputs:
+      label:
+        description: 'Image label'
+        required: true
 
 env:
-  CONTAINER_REGISTRY: "registry.digitalocean.com/forgesteel"
-  IMAGE_NAME: "forgesteel-app"
+  CONTAINER_REGISTRY: ${{ vars.DOCR_REGISTRY || 'registry.digitalocean.com/forgesteel' }}
+  IMAGE_NAME: ${{ vars.DOCR_IMAGE_NAME || 'forgesteel-app' }}
 
 jobs:
   build_and_push:
@@ -23,14 +29,21 @@ jobs:
       - name: Log in to DOCR with short-lived credentials
         run: doctl registry login --expiry-seconds 600
       
-      - name: Set short hash
-        run: echo "COMMIT_SHA_SHORT=$(echo $GITHUB_SHA | head -c7)" >> $GITHUB_ENV
+      - name: Set image tag if run manually
+        if: "${{ inputs.label != '' }}"
+        run: echo "IMAGE_TAG=$INPUT_LABEL" >> $GITHUB_ENV
+        env:
+          INPUT_LABEL: ${{ inputs.label }}
+  
+      - name: Set image tag to commit hash if run from a push
+        if: "${{ inputs.label == '' }}"
+        run: echo "IMAGE_TAG=$(echo $GITHUB_SHA | head -c7)" >> $GITHUB_ENV
 
       - name: Set full image name
         run: echo "FULL_IMAGE_NAME=${CONTAINER_REGISTRY}/${IMAGE_NAME}" >> $GITHUB_ENV
 
       - name: Check image name
-        run: echo "${{ env.FULL_IMAGE_NAME }}:${{ env.COMMIT_SHA_SHORT }}"
+        run: echo "${{ env.FULL_IMAGE_NAME }}:${{ env.IMAGE_TAG }}"
 
       - name: Build and push Docker image
         id: push
@@ -38,7 +51,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ env.FULL_IMAGE_NAME }}:${{ env.COMMIT_SHA_SHORT }},${{ env.FULL_IMAGE_NAME }}:latest
+          tags: ${{ env.FULL_IMAGE_NAME }}:${{ env.IMAGE_TAG }},${{ env.FULL_IMAGE_NAME }}:latest
 
       - name: Cleanup old images
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY package.json package-lock.json .
 RUN npm ci
 
 COPY . ./
-RUN npm run predeploy
+RUN npm run build
 
 FROM nginx:latest
 


### PR DESCRIPTION
Some build and push workflow updates:
- Adds a manual option to run the workflow
- Can pull DOCR registry and image name from variables, if set (useful for me using different settings in my fork/testing repo)
    - Defaults to the 'prod' settings, though
- Doesn't run tests as part of the docker image build. I will probably create a separate workflow for running linting, unit tests, and stuff like that - but set that up to run on a wider range of branches (including PRs!)