### PR TITLE
Add Patron Warehouse

### DIFF
--- a/src/components/main/main.tsx
+++ b/src/components/main/main.tsx
@@ -76,6 +76,7 @@ import { SourcebookData } from '@/data/sourcebook-data';
 import { SourcebookLogic } from '@/logic/sourcebook-logic';
 import { SourcebookUpdateLogic } from '@/logic/update/sourcebook-update-logic';
 import { SourcebooksModal } from '@/components/modals/sourcebooks/sourcebooks-modal';
+import { StorageServiceFactory } from '@/service/storage/storage-service-factory';
 import { SubClass } from '@/models/subclass';
 import { SummoningInfo } from '@/models/summon';
 import { TacticalMap } from '@/models/tactical-map';
@@ -120,6 +121,8 @@ export const Main = (props: Props) => {
 		return opts;
 	});
 	const [ connectionSettings, setConnectionSettings ] = useState<ConnectionSettings>(props.connectionSettings);
+	const [ dataService, setDataService ] = useState<DataService>(props.dataService);
+
 	const [ errors, setErrors ] = useState<Event[]>([]);
 	const [ drawer, setDrawer ] = useState<ReactNode>(null);
 	const [ playerView, setPlayerView ] = useState<Window | null>(null);
@@ -150,7 +153,7 @@ export const Main = (props: Props) => {
 	};
 
 	const persistHeroes = (heroes: Hero[]) => {
-		return props.dataService
+		return dataService
 			.saveHeroes(Collections.sort(heroes, h => h.name))
 			.then(
 				setHeroes,
@@ -178,7 +181,7 @@ export const Main = (props: Props) => {
 	};
 
 	const persistSession = (session: Session) => {
-		return props.dataService
+		return dataService
 			.saveSession(session)
 			.then(
 				setSession,
@@ -201,7 +204,7 @@ export const Main = (props: Props) => {
 	};
 
 	const persistHomebrewSourcebooks = (homebrew: Sourcebook[]) => {
-		return props.dataService
+		return dataService
 			.saveHomebrew(homebrew)
 			.then(
 				setHomebrewSourcebooks,
@@ -217,7 +220,7 @@ export const Main = (props: Props) => {
 	};
 
 	const persistHiddenSourcebookIDs = (ids: string[]) => {
-		return props.dataService
+		return dataService
 			.saveHiddenSettingIds(ids)
 			.then(
 				setHiddenSourcebookIDs,
@@ -233,7 +236,7 @@ export const Main = (props: Props) => {
 	};
 
 	const persistOptions = (options: Options) => {
-		return props.dataService
+		return dataService
 			.saveOptions(options)
 			.then(
 				setOptions,
@@ -261,7 +264,12 @@ export const Main = (props: Props) => {
 						placement: 'top'
 					});
 				}
-			);
+			).then(() => {
+				const storage = StorageServiceFactory.fromConnectionSettings(connectionSettings);
+				const ds = new DataService(storage);
+				ds.initialize();
+				setDataService(ds);
+			});
 	};
 
 	// #endregion
@@ -1431,7 +1439,7 @@ export const Main = (props: Props) => {
 				heroes={heroes}
 				setOptions={persistOptions}
 				connectionSettings={connectionSettings}
-				dataService={props.dataService}
+				dataService={dataService}
 				setConnectionSettings={persistConnectionSettings}
 				clearErrors={() => setErrors([])}
 				onClose={() => setDrawer(null)}
@@ -1898,8 +1906,7 @@ export const Main = (props: Props) => {
 						path='oauth-redirect'
 						element={
 							<AuthPage
-								connectionSettings={props.connectionSettings}
-								dataService={props.dataService}
+								connectionSettings={connectionSettings}
 								highlightAbout={errors.length > 0}
 								showReference={showReference}
 								showRoll={() => showRoll()}
@@ -1933,8 +1940,6 @@ export const Main = (props: Props) => {
 						element={
 							<TransferPage
 								connectionSettings={connectionSettings}
-								heroes={heroes}
-								homebrewSourcebooks={homebrewSourcebooks}
 								options={options}
 							/>
 						}

--- a/src/components/modals/settings/settings-modal.tsx
+++ b/src/components/modals/settings/settings-modal.tsx
@@ -1,4 +1,4 @@
-import { Alert, Button, Divider, Drawer, Flex, Segmented, Select, Space } from 'antd';
+import { Alert, Button, Drawer, Flex, Segmented, Select, Space } from 'antd';
 import { CopyOutlined, FlagFilled, FlagOutlined, MoonOutlined, SettingOutlined, SunOutlined } from '@ant-design/icons';
 import { AbilityData } from '@/data/ability-data';
 import { Collections } from '@/utils/collections';
@@ -619,6 +619,47 @@ export const SettingsModal = (props: Props) => {
 		);
 	};
 
+	const getConnections = () => {
+		const getWarehouseConnection = () => {
+			if (FeatureFlags.hasFlag(FeatureFlags.warehouse.code)) {
+				return (
+					<ConnectionSettingsPanel
+						connectionSettings={connectionSettings}
+						setConnectionSettings={updateConnectionSettings}
+					/>
+				);
+			}
+		};
+		return (
+			<Expander title='Connections'>
+				<Space orientation='vertical' style={{ width: '100%' }}>
+					<PatreonConnectPanel
+						connectionSettings={connectionSettings}
+						setConnectionSettings={updateConnectionSettings}
+					/>
+					<WarehouseActionsPanel
+						connectionSettings={connectionSettings}
+					/>
+					{getWarehouseConnection()}
+					{
+						reloadNeeded ?
+							<Alert
+								title='Reload Forge Steel to use new settings'
+								type='info'
+								showIcon
+								action={
+									<Button size='small' type='primary' onClick={() => location.reload()}>
+										Reload
+									</Button>
+								}
+							/>
+							: null
+					}
+				</Space>
+			</Expander>
+		);
+	};
+
 	const getFeatureFlags = () => {
 		return (
 			<Expander title='Feature Flags'>
@@ -669,59 +710,6 @@ export const SettingsModal = (props: Props) => {
 				</Space>
 			</Expander>
 		);
-	};
-
-	const getWarehouseSettings = () => {
-		if (FeatureFlags.hasFlag(FeatureFlags.warehouse.code)) {
-			return (
-				<Expander title='Forge Steel Warehouse'>
-					<Space orientation='vertical' style={{ width: '100%' }}>
-						{
-							connectionSettings.useWarehouse ?
-								<>
-									<WarehouseActionsPanel
-										connectionSettings={connectionSettings}
-									/>
-									<Divider size='small' />
-								</>
-								: null
-						}
-						<ConnectionSettingsPanel
-							connectionSettings={connectionSettings}
-							setConnectionSettings={updateConnectionSettings}
-						/>
-						{
-							reloadNeeded ?
-								<Alert
-									title='Reload Forge Steel to use new settings'
-									type='info'
-									showIcon
-									action={
-										<Button size='small' type='primary' onClick={() => location.reload()}>
-											Reload
-										</Button>
-									}
-								/>
-								: null
-						}
-					</Space>
-				</Expander>
-			);
-		}
-	};
-
-	const getPatreonSettings = () => {
-		if (FeatureFlags.hasFlag(FeatureFlags.patreon.code)) {
-			return (
-				<Expander title='Patreon'>
-					<PatreonConnectPanel
-						connectionSettings={connectionSettings}
-						setConnectionSettings={updateConnectionSettings}
-						dataService={props.dataService}
-					/>
-				</Expander>
-			);
-		}
 	};
 
 	const getErrors = () => {
@@ -800,14 +788,13 @@ export const SettingsModal = (props: Props) => {
 						{getEncounterRunner()}
 						{getDifficulty()}
 						{getTacticalMaps()}
+						{getConnections()}
 					</Space>
 				);
 			case 'Admin':
 				return (
 					<Space orientation='vertical' style={{ width: '100%' }}>
 						{getFeatureFlags()}
-						{getWarehouseSettings()}
-						{getPatreonSettings()}
 						{getErrors()}
 					</Space>
 				);

--- a/src/components/pages/auth/auth-page.scss
+++ b/src/components/pages/auth/auth-page.scss
@@ -18,7 +18,7 @@
 			display: flex;
 			flex-direction: column;
 			gap: 20px;
-			width: 350px;
+			min-width: 350px;
 			padding: 20px;
 			border-radius: 10px;
 			background-color: rgb(255, 255, 255);

--- a/src/components/panels/connection-settings/connection-settings-panel.tsx
+++ b/src/components/panels/connection-settings/connection-settings-panel.tsx
@@ -22,9 +22,9 @@ export const ConnectionSettingsPanel = (props: Props) => {
 	const [ hostInputStatus, setHostInputStatus ] = useState<'error' | undefined>(undefined);
 	const [ tokenInputStatus, setTokenInputStatus ] = useState<'error' | undefined>(undefined);
 
-	const setUseWarehouse = (value: boolean) => {
+	const setUseManualWarehouse = (value: boolean) => {
 		const copy = Utils.copy(connectionSettings);
-		copy.useWarehouse = value;
+		copy.useManualWarehouse = value;
 		setConnectionSettings(copy);
 		setConnectionSettingsChanged(true);
 	};
@@ -109,13 +109,21 @@ export const ConnectionSettingsPanel = (props: Props) => {
 
 	return (
 		<Space orientation='vertical' style={{ width: '100%' }}>
+			{
+				connectionSettings.usePatreonWarehouse &&
+					<Alert
+						type='warning'
+						title="You are a patron with automatic access to the Patron Warehouse - you don't need to manually connect to anything!"
+						showIcon={true}
+					/>
+			}
 			<Toggle
-				label='Connect with Forge Steel Warehouse'
-				value={connectionSettings.useWarehouse}
-				onChange={setUseWarehouse}
+				label='Manually connect with Forge Steel Warehouse'
+				value={connectionSettings.useManualWarehouse}
+				onChange={setUseManualWarehouse}
 			/>
 			{
-				connectionSettings.useWarehouse ?
+				connectionSettings.useManualWarehouse ?
 					<>
 						<HeaderText>Warehouse Host</HeaderText>
 						<TextInput
@@ -137,7 +145,7 @@ export const ConnectionSettingsPanel = (props: Props) => {
 			}
 			<Flex gap='small' justify='flex-end' wrap>
 				{
-					connectionSettings.useWarehouse ?
+					connectionSettings.useManualWarehouse ?
 						<Button
 							variant='solid'
 							loading={testingWarehouseConnection}

--- a/src/components/panels/connection-settings/patreon-connect-panel.tsx
+++ b/src/components/panels/connection-settings/patreon-connect-panel.tsx
@@ -1,9 +1,9 @@
 import { Alert, Button, Flex, Space, Spin, notification } from 'antd';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Browser } from '@/utils/browser';
 import { ConnectionSettings } from '@/models/connection-settings';
 import { DangerButton } from '@/components/controls/danger-button/danger-button';
-import { DataService } from '@/utils/data-service';
+import { PatreonService } from '@/service/patreon-service';
 import { PatreonSession } from '@/models/patreon-connection';
 import { PatreonStatusPanel } from '@/components/panels/connection-settings/patreon-status-panel';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
@@ -12,7 +12,6 @@ import { Utils } from '@/utils/utils';
 import patreon from '@/assets/icons/patreon.svg';
 
 interface Props {
-	dataService: DataService;
 	connectionSettings: ConnectionSettings;
 	setConnectionSettings: (settings: ConnectionSettings) => void
 }
@@ -22,26 +21,35 @@ export const PatreonConnectPanel = (props: Props) => {
 	const [ patreonSession, setPatreonSession ] = useState<PatreonSession | null>(null);
 	const [ notify, notifyContext ] = notification.useNotification();
 
+	const service = useMemo(() => new PatreonService(), []);
+
 	const connectOAuth = () => {
-		props.dataService.getPatreonAuthUrl()
+		service.getPatreonAuthUrl()
 			.then(authorizationUrl => {
 				window.location.href = authorizationUrl;
 			});
 	};
 
 	const logout = () => {
-		props.dataService.logoutPatreon()
+		service.logoutPatreon()
 			.then(() => {
 				const settingsCopy = Utils.copy(props.connectionSettings);
 				settingsCopy.patreonConnected = false;
+				settingsCopy.usePatreonWarehouse = false;
 				props.setConnectionSettings(settingsCopy);
 				updateSession();
-			});
+			}).then(() => location.reload());
 	};
 
+	const hasRun = useRef(false);
+
 	const updateSession = () => {
+		if (hasRun.current)
+			return;
+		hasRun.current = true;
+
 		setLoadingSession(true);
-		props.dataService.getPatreonSession()
+		service.getPatreonSession()
 			.then(setPatreonSession)
 			.catch(err => {
 				console.error(err);
@@ -56,7 +64,7 @@ export const PatreonConnectPanel = (props: Props) => {
 			});
 	};
 
-	useEffect(updateSession, [ props.dataService, notify ]);
+	useEffect(updateSession, [ notify, service ]);
 
 	if (loadingSession) {
 		return (

--- a/src/components/panels/connection-settings/patreon-status-panel.tsx
+++ b/src/components/panels/connection-settings/patreon-status-panel.tsx
@@ -13,12 +13,21 @@ interface Props {
 
 export const PatreonStatusPanel = (props: Props) => {
 	const getIsPatron = () => {
+		let patron = false;
+		let label = 'Not A Patron';
+		if (props.status && props.status.patron) {
+			patron = true;
+			const date = new Date(props.status.start);
+			const subDate = date.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+			label = `Patron since ${subDate}`;
+		}
+
 		return (
 			<Tag
-				color={props.status && props.status.patron ? 'blue' : 'red'}
-				variant={props.status && props.status.patron ? 'solid' : 'outlined'}
+				color={patron ? 'blue' : 'red'}
+				variant={patron ? 'solid' : 'outlined'}
 			>
-				{props.status && props.status.patron ? 'Patron' : 'Not A Patron'}
+				{label}
 			</Tag>
 		);
 	};
@@ -47,24 +56,6 @@ export const PatreonStatusPanel = (props: Props) => {
 		);
 	};
 
-	const getSubscribedDate = () => {
-		if (!props.status || !props.status.patron || !props.status.start) {
-			return null;
-		}
-
-		const date = new Date(props.status.start);
-		const subDate = date.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
-
-		return (
-			<Tag
-				color='blue'
-				variant='outlined'
-			>
-				Since {subDate}
-			</Tag>
-		);
-	};
-
 	return (
 		<div className='patreon-status-panel'>
 			<HeaderText>
@@ -76,7 +67,6 @@ export const PatreonStatusPanel = (props: Props) => {
 			<Flex gap={5}>
 				{getIsPatron()}
 				{getTiers()}
-				{getSubscribedDate()}
 			</Flex>
 		</div>
 	);

--- a/src/components/panels/connection-settings/warehouse-actions-panel.tsx
+++ b/src/components/panels/connection-settings/warehouse-actions-panel.tsx
@@ -1,4 +1,4 @@
-import { Button, Space } from 'antd';
+import { Alert, Button, Divider, Space } from 'antd';
 import { ConnectionSettings } from '@/models/connection-settings';
 import { useNavigate } from 'react-router';
 
@@ -8,23 +8,40 @@ interface Props {
 
 export const WarehouseActionsPanel = (props: Props) => {
 	const navigate = useNavigate();
+	const showTransferButton = props.connectionSettings.useManualWarehouse
+		|| props.connectionSettings.usePatreonWarehouse;
 
 	const goToTransferPage = () => {
 		navigate('/transfer');
 	};
 
 	return (
-		<Space orientation='vertical' style={{ width: '100%' }}>
+		<>
+			<Space orientation='vertical' style={{ width: '100%' }}>
+				{
+					props.connectionSettings.usePatreonWarehouse &&
+						<Alert
+							type='info'
+							title='Patron Warehouse'
+							description='You are a patron with automatic access to the Patron cloud storage - you can transfer your local data to the cloud here:'
+							showIcon={true}
+						/>
+				}
+				{
+					showTransferButton &&
+						<Button
+							block={true}
+							type='primary'
+							onClick={goToTransferPage}
+						>
+							Transfer Data
+						</Button>
+				}
+			</Space>
 			{
-				props.connectionSettings.useWarehouse ?
-					<Button
-						block={true}
-						onClick={goToTransferPage}
-					>
-						Transfer Data
-					</Button>
-					: null
+				showTransferButton &&
+					<Divider size='small' />
 			}
-		</Space>
+		</>
 	);
 };

--- a/src/components/panels/data-loader/data-loader.scss
+++ b/src/components/panels/data-loader/data-loader.scss
@@ -8,7 +8,7 @@
     overflow-y: scroll;
 
     .data-loader-container {
-        width: 250px;
+        min-width: 250px;
         padding: 20px;
         border-radius: 10px;
         background-color: rgb(255, 255, 255);

--- a/src/hooks/use-navigation.ts
+++ b/src/hooks/use-navigation.ts
@@ -41,6 +41,9 @@ export const useNavigation = () => {
 		},
 		goToPlayerView: () => {
 			return navigate('/session/player');
+		},
+		goToTransfer: () => {
+			return navigate('/transfer');
 		}
 	};
 };

--- a/src/logic/factory-logic.ts
+++ b/src/logic/factory-logic.ts
@@ -1081,10 +1081,11 @@ export class FactoryLogic {
 
 	static createConnectionSettings = (): ConnectionSettings => {
 		return {
-			useWarehouse: false,
+			useManualWarehouse: false,
 			warehouseHost: '',
 			warehouseToken: '',
-			patreonConnected: false
+			patreonConnected: false,
+			usePatreonWarehouse: false
 		};
 	};
 

--- a/src/logic/patreon-logic.test.ts
+++ b/src/logic/patreon-logic.test.ts
@@ -1,0 +1,86 @@
+import { PatreonSession, PatronTier } from '@/models/patreon-connection';
+import { describe, expect, test } from 'vitest';
+import { PatreonLogic } from './patreon-logic';
+
+describe('PatreonLogic', () => {
+	describe('hasWarehouseAccess', () => {
+		test('returns false if not authenticated with patreon', () => {
+			const session = {
+				authenticated: false
+			} as PatreonSession;
+
+			expect(PatreonLogic.hasWarehouseAccess(session)).toBe(false);
+		});
+
+		test('returns false if authenticated, but not a member of the Forge Steel patreon', () => {
+			const session1 = {
+				authenticated: true,
+				connections: [ {
+					id: 'not_forgesteel'
+				} ]
+			} as PatreonSession;
+
+			expect(PatreonLogic.hasWarehouseAccess(session1)).toBe(false);
+
+			const session2 = {
+				authenticated: true,
+				connections: [ {
+					id: 'forgesteel',
+					status: {
+						patron: false
+					}
+				} ]
+			} as PatreonSession;
+
+			expect(PatreonLogic.hasWarehouseAccess(session2)).toBe(false);
+		});
+
+		test('returns false if authenticated and a patreon member, but not at the right tier', () => {
+			const session1 = {
+				authenticated: true,
+				connections: [ {
+					id: 'forgesteel',
+					status: {
+						patron: true,
+						tiers: ([] as PatronTier[])
+					}
+				} ]
+			} as PatreonSession;
+
+			expect(PatreonLogic.hasWarehouseAccess(session1)).toBe(false);
+
+			const session2 = {
+				authenticated: true,
+				connections: [ {
+					id: 'forgesteel',
+					status: {
+						patron: true,
+						tiers: [ {
+							id: 'not-correct'
+						} ]
+					}
+				} ]
+			} as PatreonSession;
+
+			expect(PatreonLogic.hasWarehouseAccess(session2)).toBe(false);
+		});
+
+		test('returns true if authenticated, and a member of the correct tier', () => {
+			const session = {
+				authenticated: true,
+				connections: [ {
+					id: 'forgesteel',
+					status: {
+						patron: true,
+						tiers: [ {
+							id: '27589669',
+							title: 'Forge Steel'
+						} ]
+					}
+				} ]
+			} as PatreonSession;
+
+			expect(PatreonLogic.hasWarehouseAccess(session)).toBe(true);
+		});
+	});
+});

--- a/src/logic/patreon-logic.ts
+++ b/src/logic/patreon-logic.ts
@@ -1,0 +1,18 @@
+import { PatreonSession } from '@/models/patreon-connection';
+
+export class PatreonLogic {
+	static hasWarehouseAccess = (session: PatreonSession): boolean => {
+		const FORGESTEEL_PATRON_TIER_ID = '27589669';
+
+		if (session && session.authenticated) {
+			const fs_connection = session.connections.find(con => con.id === 'forgesteel');
+			if (fs_connection
+					&& fs_connection.status
+					&& fs_connection.status.patron
+					&& fs_connection.status.tiers) {
+				return fs_connection.status.tiers.map(t => t.id).includes(FORGESTEEL_PATRON_TIER_ID);
+			}
+		}
+		return false;
+	};
+};

--- a/src/logic/update/connection-settings-update-logic.ts
+++ b/src/logic/update/connection-settings-update-logic.ts
@@ -2,8 +2,8 @@ import { ConnectionSettings } from '@/models/connection-settings';
 
 export class ConnectionSettingsUpdateLogic {
 	static updateSettings = (settings: ConnectionSettings) => {
-		if (settings.useWarehouse === undefined) {
-			settings.useWarehouse = false;
+		if (settings.useManualWarehouse === undefined) {
+			settings.useManualWarehouse = false;
 		}
 
 		if (settings.warehouseHost === undefined) {
@@ -16,6 +16,10 @@ export class ConnectionSettingsUpdateLogic {
 
 		if (settings.patreonConnected === undefined) {
 			settings.patreonConnected = false;
+		}
+
+		if (settings.usePatreonWarehouse === undefined) {
+			settings.usePatreonWarehouse = false;
 		}
 	};
 }

--- a/src/models/connection-settings.ts
+++ b/src/models/connection-settings.ts
@@ -1,6 +1,7 @@
 export interface ConnectionSettings {
-	useWarehouse: boolean;
+	useManualWarehouse: boolean;
 	warehouseHost: string;
 	warehouseToken: string;
 	patreonConnected: boolean;
+	usePatreonWarehouse: boolean;
 }

--- a/src/models/patreon-connection.ts
+++ b/src/models/patreon-connection.ts
@@ -4,6 +4,7 @@ export interface PatreonSession {
 }
 
 export interface PatreonConnection {
+	id: string,
 	name: string;
 	status: PatronStatus | null;
 }

--- a/src/service/patreon-service.test.ts
+++ b/src/service/patreon-service.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import MockAdapter from 'axios-mock-adapter';
+import { PatreonService } from './patreon-service';
+import axios from 'axios';
+
+describe('PatreonService', () => {
+	afterEach(() => {
+		vi.resetAllMocks();
+	});
+
+	vi.mock('axios', async () => {
+		return {
+			...(await vi.importActual('axios') as object),
+			create: vi.fn().mockReturnValue(await vi.importActual('axios'))
+		};
+	});
+
+	const mockAdapter = new MockAdapter(axios);
+
+	// #region Token Handler
+	describe('getPatreonAuthUrl', () => {
+		test('calls the token handler login/start endpoint', async () => {
+			const svc = new PatreonService();
+
+			const catchFn = vi.fn();
+			const thenFn = vi.fn();
+
+			const authUrl = 'https://some.fake/auth/url';
+
+			mockAdapter.onPost('/th/login/start').reply(() => {
+				return [ 200, { authorizationUrl: authUrl } ];
+			});
+			await svc.getPatreonAuthUrl()
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(thenFn).toHaveBeenCalledWith(authUrl);
+			expect(catchFn).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('finishPatreonLogin', () => {
+		test('returns a successful login correctly', async () => {
+			const catchFn = vi.fn();
+			const thenFn = vi.fn();
+
+			const sessionResponse = {
+				authenticated_with_patreon: true,
+				user: {
+					mcdm: {
+						patron: true,
+						tier_cents: 800,
+						start: 'Wed, 14 Feb 2024 00:00:00 GMT'
+					}
+				}
+			};
+
+			mockAdapter.onPost('/th/login/end').reply(() => {
+				return [ 200, sessionResponse ];
+			});
+
+			const svc = new PatreonService();
+
+			await svc.finishPatreonLogin('some_code', 'some_state')
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(thenFn.mock.lastCall).toEqual([ {
+				authenticated: true,
+				connections: [
+					{
+						id: 'forgesteel',
+						name: 'Forge Steel Patreon',
+						status: undefined
+					},
+					{
+						id: 'mcdm',
+						name: 'MCDM Patreon',
+						status: {
+							patron: true,
+							tier_cents: 800,
+							start: 'Wed, 14 Feb 2024 00:00:00 GMT'
+						}
+					}
+				]
+			} ]);
+			expect(catchFn).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('getPatreonSession', () => {
+		test('returns a logged in session correctly', async () => {
+			const catchFn = vi.fn();
+			const thenFn = vi.fn();
+
+			const sessionResponse = {
+				authenticated_with_patreon: true,
+				user: {
+					mcdm: {
+						patron: false,
+						tier_cents: 0,
+						start: null
+					}
+				}
+			};
+
+			mockAdapter.onGet('/th/session').reply(() => {
+				return [ 200, sessionResponse ];
+			});
+
+			const svc = new PatreonService();
+
+			await svc.getPatreonSession()
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(thenFn.mock.lastCall).toEqual([ {
+				authenticated: true,
+				connections: [
+					{
+						id: 'forgesteel',
+						name: 'Forge Steel Patreon',
+						status: undefined
+					},
+					{
+						id: 'mcdm',
+						name: 'MCDM Patreon',
+						status: {
+							patron: false,
+							tier_cents: 0,
+							start: null
+						}
+					}
+				]
+			} ]);
+			expect(catchFn).not.toHaveBeenCalled();
+		});
+
+		test('returns a NON logged in session correctly', async () => {
+			const catchFn = vi.fn();
+			const thenFn = vi.fn();
+
+			const sessionResponse = {
+				authenticated_with_patreon: false,
+				user: null
+			};
+
+			mockAdapter.onGet('/th/session').reply(() => {
+				return [ 200, sessionResponse ];
+			});
+
+			const svc = new PatreonService();
+
+			await svc.getPatreonSession()
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(thenFn.mock.lastCall).toEqual([ {
+				authenticated: false,
+				connections: []
+			} ]);
+			expect(catchFn).not.toHaveBeenCalled();
+		});
+	});
+	// #endregion Token Handler
+});

--- a/src/service/patreon-service.ts
+++ b/src/service/patreon-service.ts
@@ -1,0 +1,157 @@
+import axios, { AxiosError, AxiosInstance, AxiosRequestHeaders } from 'axios';
+import { Config } from '@/utils/config';
+import { PatreonSession } from '@/models/patreon-connection';
+
+export class PatreonService {
+	private tokenHandlerHost: string;
+
+	private api: AxiosInstance;
+
+	constructor() {
+		this.tokenHandlerHost = Config.getTokenHandlerHost();
+
+		this.api = axios.create({
+			baseURL: this.tokenHandlerHost,
+			withCredentials: true,
+			withXSRFToken: true,
+			xsrfCookieName: 'csrf_access_token',
+			xsrfHeaderName: 'X-CSRF-TOKEN'
+		});
+
+		const NO_RETRY_HEADER = 'X-NO-RETRY';
+		this.api.interceptors.response.use(undefined, async error => {
+			if (!axios.isCancel(error)
+				&& axios.isAxiosError(error)
+				&& error.config
+				&& error.response?.status === 401) {
+				if (error.config.headers && error.config.headers[NO_RETRY_HEADER])
+					return Promise.reject(error);
+
+				error.config.headers ||= {} as AxiosRequestHeaders;
+				error.config.headers[NO_RETRY_HEADER] = 'true';
+
+				await axios.post(`${this.tokenHandlerHost}/refresh`, {}, {
+					withCredentials: true,
+					withXSRFToken: true,
+					xsrfCookieName: 'csrf_refresh_token',
+					xsrfHeaderName: 'X-CSRF-TOKEN'
+				});
+
+				return this.api(error.config);
+			}
+		});
+	};
+
+	private getErrorMessage = (error: unknown) => {
+		let msg = 'Error communicating with FS Warehouse';
+		if (error instanceof AxiosError) {
+			msg = `There was a problem with Forge Steel Warehouse: ${error.message}`;
+			if (error.response) {
+				const code = error.response.status;
+				const respMsg = error.response.data.message ?? error.response.data.msg ?? error.response.data;
+				msg = `FS Warehouse Error: [${code}] ${respMsg}`;
+			}
+		}
+		return msg;
+	};
+
+	// #region login
+	async getPatreonAuthUrl(): Promise<string> {
+		try {
+			const response = await this.api.post('/th/login/start');
+			return response.data.authorizationUrl;
+		} catch (error) {
+			console.error('Error communicating with Token Handler', error);
+			throw new Error(this.getErrorMessage(error), { cause: error });
+		}
+	}
+
+	async finishPatreonLogin(code: string, state: string): Promise<PatreonSession> {
+		try {
+			const response = await this.api.post('/th/login/end', { code: code, state: state });
+			const result: PatreonSession = {
+				authenticated: false,
+				connections: []
+			};
+
+			if (response.data) {
+				result.authenticated = response.data.authenticated_with_patreon;
+
+				if (response.data.authenticated_with_patreon && response.data.user) {
+					result.connections.push({
+						id: 'forgesteel',
+						name: 'Forge Steel Patreon',
+						status: response.data.user.forgesteel
+					});
+
+					result.connections.push({
+						id: 'mcdm',
+						name: 'MCDM Patreon',
+						status: response.data.user.mcdm
+					});
+				}
+			}
+
+			return result;
+		} catch (error) {
+			console.error('Error communicating with Token Handler', error);
+			throw new Error(this.getErrorMessage(error), { cause: error });
+		}
+	}
+
+	// #region session
+	async getPatreonSession(): Promise<PatreonSession> {
+		try {
+			const response = await this.api.get('/th/session');
+			const result: PatreonSession = {
+				authenticated: false,
+				connections: []
+			};
+
+			if (response.data) {
+				result.authenticated = response.data.authenticated_with_patreon;
+
+				if (response.data.authenticated_with_patreon && response.data.user) {
+					result.connections.push({
+						id: 'forgesteel',
+						name: 'Forge Steel Patreon',
+						status: response.data.user.forgesteel
+					});
+
+					result.connections.push({
+						id: 'mcdm',
+						name: 'MCDM Patreon',
+						status: response.data.user.mcdm
+					});
+				}
+			}
+
+			return result;
+		} catch (error) {
+			console.error('Error communicating with Token Handler', error);
+			throw new Error(this.getErrorMessage(error), { cause: error });
+		}
+	}
+
+	// #region refresh
+	async refreshTokens() {
+		try {
+			await this.api.post('/th/refresh');
+			return;
+		} catch (error) {
+			console.error('Error communicating with Token Handler', error);
+			throw new Error(this.getErrorMessage(error), { cause: error });
+		}
+	};
+
+	// #region logout
+	async logoutPatreon() {
+		try {
+			await this.api.post('/th/logout');
+			return;
+		} catch (error) {
+			console.error('Error communicating with Token Handler', error);
+			throw new Error(this.getErrorMessage(error), { cause: error });
+		}
+	}
+};

--- a/src/service/storage/storage-service-factory.test.ts
+++ b/src/service/storage/storage-service-factory.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from 'vitest';
+import { ConnectionSettings } from '@/models/connection-settings';
+import { LocalService } from './local-service';
+import { StorageServiceFactory } from './storage-service-factory';
+import { WarehouseService } from './warehouse-service';
+
+describe('StorageServiceFactory', () => {
+	describe('fromConnectionSettings', () => {
+		test('returns LocalService when appropriate', () => {
+			const settings = {
+				useManualWarehouse: false,
+				usePatreonWarehouse: false
+			} as ConnectionSettings;
+
+			expect(StorageServiceFactory.fromConnectionSettings(settings)).toBeInstanceOf(LocalService);
+		});
+
+		test('returns WarehouseService when using manual warehouse', () => {
+			const settings = {
+				useManualWarehouse: true,
+				usePatreonWarehouse: false
+			} as ConnectionSettings;
+
+			expect(StorageServiceFactory.fromConnectionSettings(settings)).toBeInstanceOf(WarehouseService);
+		});
+
+		test('returns WarehouseService when using patreon warehouse', () => {
+			const settings = {
+				useManualWarehouse: false,
+				usePatreonWarehouse: true
+			} as ConnectionSettings;
+
+			expect(StorageServiceFactory.fromConnectionSettings(settings)).toBeInstanceOf(WarehouseService);
+		});
+	});
+});

--- a/src/service/storage/storage-service-factory.ts
+++ b/src/service/storage/storage-service-factory.ts
@@ -5,7 +5,7 @@ import { WarehouseService } from '@/service/storage/warehouse-service';
 
 export class StorageServiceFactory {
 	static fromConnectionSettings = (settings: ConnectionSettings): StorageService => {
-		if (settings.useWarehouse) {
+		if (settings.useManualWarehouse || settings.usePatreonWarehouse) {
 			return new WarehouseService(settings);
 		} else {
 			return new LocalService();

--- a/src/service/storage/warehouse-service.test.ts
+++ b/src/service/storage/warehouse-service.test.ts
@@ -10,10 +10,11 @@ afterEach(() => {
 });
 
 const defaultSettings: ConnectionSettings = {
-	useWarehouse: true,
+	useManualWarehouse: true,
 	warehouseHost: 'http://test-fake-host',
 	warehouseToken: 'abcd123',
-	patreonConnected: false
+	patreonConnected: false,
+	usePatreonWarehouse: false
 };
 
 describe('WarehouseService', () => {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,0 +1,13 @@
+import { Utils } from './utils';
+
+export class Config {
+	static getTokenHandlerHost = (): string => {
+		const envVal = import.meta.env.VITE_PATREON_TOKEN_HANDLER_HOST;
+		return Utils.valueOrDefault(envVal, 'https://warehouse.forgesteel.net');
+	};
+
+	static getPatreonWarehouseHost = (): string => {
+		const envVal = import.meta.env.VITE_PATREON_TOKEN_HANDLER_HOST;
+		return Utils.valueOrDefault(envVal, 'https://warehouse.forgesteel.net');
+	};
+};

--- a/src/utils/data-service.test.ts
+++ b/src/utils/data-service.test.ts
@@ -1,13 +1,12 @@
 /* eslint-disable @typescript-eslint/no-deprecated */
 import { afterEach, describe, expect, test, vi } from 'vitest';
-import { ConnectionSettings } from '@/models/connection-settings';
 import { DataService } from '@/utils/data-service';
 import { Hero } from '@/models/hero';
 import { Options } from '@/models/options';
 import { Playbook } from '@/models/playbook';
 import { Session } from '@/models/session';
 import { Sourcebook } from '@/models/sourcebook';
-import axios from 'axios';
+import { StorageService } from '@/service/storage/storage-service';
 import localforage from 'localforage';
 
 afterEach(() => {
@@ -15,15 +14,8 @@ afterEach(() => {
 });
 
 vi.mock('localforage');
-vi.mock('LocalService');
-vi.mock('WarehouseService');
 
-const defaultSettings: ConnectionSettings = {
-	useWarehouse: false,
-	warehouseHost: '',
-	warehouseToken: '',
-	patreonConnected: false
-};
+const mockStorage = {} as StorageService;
 
 const mockOptions = {} as Options;
 const mockHeroes = [] as Hero[];
@@ -38,14 +30,8 @@ const thenFn = vi.fn();
 describe('DataService', () => {
 	// #region Options
 	describe('getOptions', () => {
-		test.each([
-			[ true ],
-			[ false ]
-		])('always calls localforage', async (useWarehouse: boolean) => {
-			const connSettings = { ...defaultSettings,
-				useWarehouse: useWarehouse
-			};
-			const ds = new DataService(connSettings);
+		test('always calls localforage', async () => {
+			const ds = new DataService(mockStorage);
 
 			localforage.getItem = vi.fn().mockImplementation(() => Promise.resolve(mockOptions));
 
@@ -60,14 +46,8 @@ describe('DataService', () => {
 	});
 
 	describe('saveOptions', () => {
-		test.each([
-			[ true ],
-			[ false ]
-		])('always calls localforage', async (useWarehouse: boolean) => {
-			const connSettings = { ...defaultSettings,
-				useWarehouse: useWarehouse
-			};
-			const ds = new DataService(connSettings);
+		test('always calls localforage', async () => {
+			const ds = new DataService(mockStorage);
 
 			localforage.setItem = vi.fn().mockImplementation(() => Promise.resolve(mockOptions));
 
@@ -84,32 +64,32 @@ describe('DataService', () => {
 
 	// #region Heroes
 	describe('getHeroes', () => {
-		test('calls localforage when configured to not use warehouse', async () => {
-			const ds = new DataService(defaultSettings);
+		test('forwards to the storage service', async () => {
+			const ds = new DataService(mockStorage);
 
-			localforage.getItem = vi.fn().mockImplementation(() => Promise.resolve(mockHeroes));
+			mockStorage.get = vi.fn().mockImplementation(() => Promise.resolve(mockHeroes));
 
 			await ds.getHeroes()
 				.then(thenFn)
 				.catch(catchFn);
 
-			expect(localforage.getItem).toHaveBeenCalledWith('forgesteel-heroes');
+			expect(mockStorage.get).toHaveBeenCalledWith('forgesteel-heroes');
 			expect(thenFn).toHaveBeenCalledWith(mockHeroes);
 			expect(catchFn).not.toHaveBeenCalled();
 		});
 	});
 
 	describe('saveHeroes', () => {
-		test('calls localforage when configured to not use warehouse', async () => {
-			const ds = new DataService(defaultSettings);
+		test('forwards to the storage service', async () => {
+			const ds = new DataService(mockStorage);
 
-			localforage.setItem = vi.fn().mockImplementation(() => Promise.resolve(mockHeroes));
+			mockStorage.put = vi.fn().mockImplementation(() => Promise.resolve(mockHeroes));
 
 			await ds.saveHeroes(mockHeroes)
 				.then(thenFn)
 				.catch(catchFn);
 
-			expect(localforage.setItem).toHaveBeenCalledWith('forgesteel-heroes', mockHeroes);
+			expect(mockStorage.put).toHaveBeenCalledWith('forgesteel-heroes', mockHeroes);
 			expect(thenFn).toHaveBeenCalledWith(mockHeroes);
 			expect(catchFn).not.toHaveBeenCalled();
 		});
@@ -118,32 +98,32 @@ describe('DataService', () => {
 
 	// #region Playbook
 	describe('getHomebrew', () => {
-		test('calls localforage when configured to not use warehouse', async () => {
-			const ds = new DataService(defaultSettings);
+		test('forwards to the storage service', async () => {
+			const ds = new DataService(mockStorage);
 
-			localforage.getItem = vi.fn().mockImplementation(() => Promise.resolve(mockHomebrew));
+			mockStorage.get = vi.fn().mockImplementation(() => Promise.resolve(mockHomebrew));
 
 			await ds.getHomebrew()
 				.then(thenFn)
 				.catch(catchFn);
 
-			expect(localforage.getItem).toHaveBeenCalledWith('forgesteel-homebrew-settings');
+			expect(mockStorage.get).toHaveBeenCalledWith('forgesteel-homebrew-settings');
 			expect(thenFn).toHaveBeenCalledWith(mockHomebrew);
 			expect(catchFn).not.toHaveBeenCalled();
 		});
 	});
 
 	describe('saveHomebrew', () => {
-		test('calls localforage when configured to not use warehouse', async () => {
-			const ds = new DataService(defaultSettings);
+		test('forwards to the storage service', async () => {
+			const ds = new DataService(mockStorage);
 
-			localforage.setItem = vi.fn().mockImplementation(() => Promise.resolve(mockHomebrew));
+			mockStorage.put = vi.fn().mockImplementation(() => Promise.resolve(mockHomebrew));
 
 			await ds.saveHomebrew(mockHomebrew)
 				.then(thenFn)
 				.catch(catchFn);
 
-			expect(localforage.setItem).toHaveBeenCalledWith('forgesteel-homebrew-settings', mockHomebrew);
+			expect(mockStorage.put).toHaveBeenCalledWith('forgesteel-homebrew-settings', mockHomebrew);
 			expect(thenFn).toHaveBeenCalledWith(mockHomebrew);
 			expect(catchFn).not.toHaveBeenCalled();
 		});
@@ -152,8 +132,8 @@ describe('DataService', () => {
 
 	// #region Playbook
 	describe('getPlaybook', () => {
-		test('calls localforage when configured to not use warehouse', async () => {
-			const ds = new DataService(defaultSettings);
+		test('always calls localforage', async () => {
+			const ds = new DataService(mockStorage);
 
 			localforage.getItem = vi.fn().mockImplementation(() => Promise.resolve(mockPlaybook));
 
@@ -168,8 +148,8 @@ describe('DataService', () => {
 	});
 
 	describe('savePlaybook', () => {
-		test('calls localforage when configured to not use warehouse', async () => {
-			const ds = new DataService(defaultSettings);
+		test('always calls localforage', async () => {
+			const ds = new DataService(mockStorage);
 
 			localforage.setItem = vi.fn().mockImplementation(() => Promise.resolve(mockPlaybook));
 
@@ -186,32 +166,32 @@ describe('DataService', () => {
 
 	// #region Session
 	describe('getSession', () => {
-		test('calls localforage when configured to not use warehouse', async () => {
-			const ds = new DataService(defaultSettings);
+		test('forwards to the storage service', async () => {
+			const ds = new DataService(mockStorage);
 
-			localforage.getItem = vi.fn().mockImplementation(() => Promise.resolve(mockSession));
+			mockStorage.get = vi.fn().mockImplementation(() => Promise.resolve(mockSession));
 
 			await ds.getSession()
 				.then(thenFn)
 				.catch(catchFn);
 
-			expect(localforage.getItem).toHaveBeenCalledWith('forgesteel-session');
+			expect(mockStorage.get).toHaveBeenCalledWith('forgesteel-session');
 			expect(thenFn).toHaveBeenCalledWith(mockSession);
 			expect(catchFn).not.toHaveBeenCalled();
 		});
 	});
 
 	describe('saveSession', () => {
-		test('calls localforage when configured to not use warehouse', async () => {
-			const ds = new DataService(defaultSettings);
+		test('forwards to the storage service', async () => {
+			const ds = new DataService(mockStorage);
 
-			localforage.setItem = vi.fn().mockImplementation(() => Promise.resolve(mockSession));
+			mockStorage.put = vi.fn().mockImplementation(() => Promise.resolve(mockSession));
 
 			await ds.saveSession(mockSession)
 				.then(thenFn)
 				.catch(catchFn);
 
-			expect(localforage.setItem).toHaveBeenCalledWith('forgesteel-session', mockSession);
+			expect(mockStorage.put).toHaveBeenCalledWith('forgesteel-session', mockSession);
 			expect(thenFn).toHaveBeenCalledWith(mockSession);
 			expect(catchFn).not.toHaveBeenCalled();
 		});
@@ -220,194 +200,35 @@ describe('DataService', () => {
 
 	// #region HiddenSettingIds
 	describe('getHiddenSettingIds', () => {
-		test('calls localforage when configured to not use warehouse', async () => {
-			const ds = new DataService(defaultSettings);
+		test('forwards to the storage service', async () => {
+			const ds = new DataService(mockStorage);
 
-			localforage.getItem = vi.fn().mockImplementation(() => Promise.resolve(mockHiddenSettingIds));
+			mockStorage.get = vi.fn().mockImplementation(() => Promise.resolve(mockHiddenSettingIds));
 
 			await ds.getHiddenSettingIds()
 				.then(thenFn)
 				.catch(catchFn);
 
-			expect(localforage.getItem).toHaveBeenCalledWith('forgesteel-hidden-setting-ids');
+			expect(mockStorage.get).toHaveBeenCalledWith('forgesteel-hidden-setting-ids');
 			expect(thenFn).toHaveBeenCalledWith(mockHiddenSettingIds);
 			expect(catchFn).not.toHaveBeenCalled();
 		});
 	});
 
 	describe('saveHiddenSettingIds', () => {
-		test('calls localforage when configured to not use warehouse', async () => {
-			const ds = new DataService(defaultSettings);
+		test('forwards to the storage service', async () => {
+			const ds = new DataService(mockStorage);
 
-			localforage.setItem = vi.fn().mockImplementation(() => Promise.resolve(mockHiddenSettingIds));
+			mockStorage.put = vi.fn().mockImplementation(() => Promise.resolve(mockHiddenSettingIds));
 
 			await ds.saveHiddenSettingIds(mockHiddenSettingIds)
 				.then(thenFn)
 				.catch(catchFn);
 
-			expect(localforage.setItem).toHaveBeenCalledWith('forgesteel-hidden-setting-ids', mockHiddenSettingIds);
+			expect(mockStorage.put).toHaveBeenCalledWith('forgesteel-hidden-setting-ids', mockHiddenSettingIds);
 			expect(thenFn).toHaveBeenCalledWith(mockHiddenSettingIds);
 			expect(catchFn).not.toHaveBeenCalled();
 		});
 	});
 	// #endregion HiddenSettingIds
-
-	// #region Token Handler
-	describe('getPatreonAuthUrl', () => {
-		test('calls the token handler login/start endpoint', async () => {
-			const ds = new DataService(defaultSettings);
-
-			const catchFn = vi.fn();
-			const thenFn = vi.fn();
-
-			const authUrl = 'https://some.fake/auth/url';
-			const urlResponse = {
-				data: {
-					authorizationUrl: authUrl
-				}
-			};
-
-			axios.post = vi.fn()
-				.mockImplementationOnce(() => Promise.resolve(urlResponse));
-
-			await ds.getPatreonAuthUrl()
-				.then(thenFn)
-				.catch(catchFn);
-
-			expect(thenFn).toHaveBeenCalledWith(authUrl);
-			expect(catchFn).not.toHaveBeenCalled();
-		});
-	});
-
-	describe('finishPatreonLogin', () => {
-		test('returns a successful login correctly', async () => {
-			const catchFn = vi.fn();
-			const thenFn = vi.fn();
-
-			const sessionResponse = {
-				data: {
-					authenticated_with_patreon: true,
-					user: {
-						mcdm: {
-							patron: true,
-							tier_cents: 800,
-							start: 'Wed, 14 Feb 2024 00:00:00 GMT'
-						}
-					}
-				}
-			};
-
-			axios.post = vi.fn()
-				.mockImplementationOnce(() => Promise.resolve(sessionResponse));
-
-			const ds = new DataService(defaultSettings);
-
-			await ds.finishPatreonLogin('some_code', 'some_state')
-				.then(thenFn)
-				.catch(catchFn);
-
-			expect(thenFn.mock.lastCall).toEqual([ {
-				authenticated: true,
-				connections: [
-					{
-						name: 'Forge Steel Patreon',
-						status: undefined
-					},
-					{
-						name: 'MCDM Patreon',
-						status: {
-							patron: true,
-							tier_cents: 800,
-							start: 'Wed, 14 Feb 2024 00:00:00 GMT'
-						}
-					}
-				]
-			} ]);
-			expect(catchFn).not.toHaveBeenCalled();
-		});
-	});
-
-	describe('getPatreonSession', () => {
-		test('returns a logged in session correctly', async () => {
-			const connSettings = { ...defaultSettings,
-				patreonConnected: true
-			};
-
-			const catchFn = vi.fn();
-			const thenFn = vi.fn();
-
-			const sessionResponse = {
-				data: {
-					authenticated_with_patreon: true,
-					user: {
-						mcdm: {
-							patron: false,
-							tier_cents: 0,
-							start: null
-						}
-					}
-				}
-			};
-
-			axios.get = vi.fn()
-				.mockImplementationOnce(() => Promise.resolve(sessionResponse));
-
-			const ds = new DataService(connSettings);
-
-			await ds.getPatreonSession()
-				.then(thenFn)
-				.catch(catchFn);
-
-			expect(thenFn.mock.lastCall).toEqual([ {
-				authenticated: true,
-				connections: [
-					{
-						name: 'Forge Steel Patreon',
-						status: undefined
-					},
-					{
-						name: 'MCDM Patreon',
-						status: {
-							patron: false,
-							tier_cents: 0,
-							start: null
-						}
-					}
-				]
-			} ]);
-			expect(catchFn).not.toHaveBeenCalled();
-		});
-
-		test('returns a NON logged in session correctly', async () => {
-			const connSettings = { ...defaultSettings,
-				patreonConnected: true
-			};
-
-			const catchFn = vi.fn();
-			const thenFn = vi.fn();
-
-			const sessionResponse = {
-				data: {
-					authenticated_with_patreon: false,
-					user: null
-				}
-			};
-
-			axios.get = vi.fn()
-				.mockImplementationOnce(() => Promise.resolve(sessionResponse));
-
-			const ds = new DataService(connSettings);
-
-			await ds.getPatreonSession()
-				.then(thenFn)
-				.catch(catchFn);
-
-			expect(thenFn.mock.lastCall).toEqual([ {
-				authenticated: false,
-				connections: []
-			} ]);
-			expect(catchFn).not.toHaveBeenCalled();
-		});
-	});
-	// #endregion Token Handler
 });

--- a/src/utils/feature-flags.ts
+++ b/src/utils/feature-flags.ts
@@ -10,7 +10,7 @@ export class FeatureFlags {
 
 	static warehouse: FeatureFlag = {
 		code: 1551245932421255,
-		description: 'Access to the Warehouse beta'
+		description: 'Manual Forge Steel Warehouse connections'
 	};
 
 	static playtest: FeatureFlag = {
@@ -23,16 +23,10 @@ export class FeatureFlags {
 		description: 'Access to the (pre-release) Community sourcebook'
 	};
 
-	static patreon: FeatureFlag = {
-		code: Utils.hashCode('patreon'),
-		description: 'Show the Patreon connector'
-	};
-
 	private static all = [
 		FeatureFlags.warehouse,
 		FeatureFlags.playtest,
-		FeatureFlags.communityPreRelease,
-		FeatureFlags.patreon
+		FeatureFlags.communityPreRelease
 	];
 
 	// #endregion


### PR DESCRIPTION
## Changes

- Added a small indicator in the data loader to indicate the data source that is being used - Local, Warehouse, or Patron
    <img width="263" height="123" alt="image" src="https://github.com/user-attachments/assets/89671ff5-4a13-442b-b3a6-21b28e4b9e99" />
- Moved around the settings for the manual warehouse and Patreon connector
    - Same as in previous PR
    - Patreon connection no longer behind a feature flag
    - New 'Connections' panel under Settings
        <img width="482" height="215" alt="image" src="https://github.com/user-attachments/assets/85981026-c138-4945-b430-230d042b225d" />
    - If enabled via feature flag, manual warehouse connections also appear in this panel
        <img width="478" height="264" alt="image" src="https://github.com/user-attachments/assets/712f7a84-a606-4491-b970-cfe24d23896e" />

## Testing

### Setup
- For quick testing, I'm hosting my `host-deployment` branch up on [my own testing domain](https://hulahut.xyz/) with the latest fs-warehouse backend. The state of that deployment should match what is in this PR
- If you have any local data stored for this domain in your browser, clear it

### Default, non-patron behavior

- Go to the app, and verify you see the 'Local' tag on the data loader screen on initial load.
- Create a hero (Random Hero is fantastic for this), and confirm that it successfully creates, and that it is stored in the local storage.
- Confirm that the 'Connections' settings panel displays, and shows the Patreon connect button
    <img width="482" height="215" alt="image" src="https://github.com/user-attachments/assets/85981026-c138-4945-b430-230d042b225d" />

### Patreon Connection - patron

- In the app, click the 'Connect with Patreon' button, and log in with a patreon account that is a Forge Steel patron.
- Verify that the connection successfully completes and the status of patron shows properly.
    <img width="469" height="625" alt="image" src="https://github.com/user-attachments/assets/727703f5-92f5-4071-a8b2-0f051c93ac41" />
- On the OAuth end page, click the 'Transfer Data' button, and verify it takes you to the transfer page. (on reload, the 'Connection Settings' tag should now show 'Patron')
- You should see your previously created local hero, and nothing in the warehouse
    <img width="233" height="387" alt="image" src="https://github.com/user-attachments/assets/fddbb70d-650b-4d52-a3fa-39eaaa756c1d" />
- Transfer/merge the local data to the Patron warehouse by clicking 'Merge Local data into Warehouse' (I am realizing Colville would probably get annoyed if he ever worked with me because I tend to do Random Capitalization of Stuff)
- Return to the Heroes page, and confirm that the previous Hero is present.
- Create another Hero, and verify that it saves successfully
- In another browser (or in a private tab), go to the app, and connect with Patreon again using the same patreon account.
- After returning to the app ('Return' button), verify both Heroes show up.
- Back in the first browser, do a hard refresh to confirm you remain connected to the Patreon and the data shows as expected

### Disconnect from Patreon

- After connecting with patreon, click and confirm the 'Disconnect from Patreon' button in the Connections panel.
- Verify that the app reloads, and that the previous patron warehouse content is no longer present (should just be the initial Hero that shows up)
- In the second browser, refresh and verify Patreon is also no longer connected

### Patreon Connection - non patron
*I find it easiest to test this flow in a private browser window*
- In the app, click the 'Connect with Patreon' button, and log in with a patreon account that is not a Forge Steel patron.
- Verify that the connection successfully completes and the status of non-patron shows properly.
    <img width="378" height="437" alt="image" src="https://github.com/user-attachments/assets/59e965ac-6b51-44c6-8e03-ce0fa0e559d4" />
- Verify that local storage is still used

### Session token refreshing
- Connect with a Patreon account that is a Forge Steel patron
- wait at least 15 minutes in a browser that has been connected to patreon and refresh (15 mins is the default session token expiration time)
- Verify the network log shows a call to `/session` that returns a `401` for expired token, followed by a call to `/refresh`
    <img width="442" height="106" alt="image" src="https://github.com/user-attachments/assets/88a00529-15bd-4fc7-915e-698461c37e25" />

### Manual Warehouse
- In a session that is connected to Patreon, enable the manual warehouse conenction using the Feature Flag `Treat Curve`
- Verify the manual settings show under 'Connections', along with an alert that you already have access to the Patron warehouse.
    <img width="430" height="123" alt="image" src="https://github.com/user-attachments/assets/2a344421-247d-480e-9d5b-10a7415f9f41" />
- Connect to a warehouse instance using your api key, and reload the app
- Verify the Data Loader shows 'Warehouse', since manual warehouse connections override patron access
- Verify the data shows as expected for the manual warehouse instance
- Verify that disabling the manual warehouse returns you to using the patron warehouse on app reload.