### PR TITLE
Fix inventory item quantity reset to 1 on data load

### DIFF
--- a/src/logic/update/hero-update-logic.ts
+++ b/src/logic/update/hero-update-logic.ts
@@ -349,7 +349,9 @@ export class HeroUpdateLogic {
 					const id = origItem.id;
 					const item = SourcebookLogic.getItems(sourcebooks).find(itm => itm.id === id);
 					if (item) {
-						return Utils.copy(item);
+						const copiedItem = Utils.copy(item);
+						copiedItem.count = origItem.count;
+						return copiedItem;
 					} else {
 						return origItem;
 					}
@@ -508,7 +510,14 @@ export class HeroUpdateLogic {
 					const selectedIDs = oFeature.data.selected.map(i => i.id);
 					feature.data.selected = SourcebookLogic.getItems(sourcebooks)
 						.filter(i => selectedIDs.includes(i.id))
-						.map(i => Utils.copy(i));
+						.map(i => {
+							const copiedItem = Utils.copy(i);
+							const origItem = oFeature.data.selected.find(oi => oi.id === i.id);
+							if (origItem) {
+								copiedItem.count = origItem.count;
+							}
+							return copiedItem;
+						});
 					break;
 				}
 				case FeatureType.Kit: {


### PR DESCRIPTION
Fixes #834

Inventory item quantity was being reset to 1 when data was loaded via import or browser local storage. This occurred because when updating hero data during the load process, inventory items were being copied from sourcebooks without preserving the original item's `count` field.

## Root Cause

In `updateHeroData`, when inventory items are updated from sourcebooks, the code was creating a fresh copy of the item from the sourcebook (which defaults to `count: 1`) without preserving the user's original quantity value.

## Changes

- **Inventory items**: Modified `updateHeroData` to preserve the `count` field when copying inventory items from sourcebooks (lines 352-353)
- **Feature item choices**: Modified `updateFeatureData` for `FeatureType.ItemChoice` to preserve the `count` field for items selected through features (lines 513-518)

Both locations now copy the item from the sourcebook but then restore the original `count` value from the user's data.

## Testing

1. Add an inventory item to a character
2. Set its quantity to a number other than 1
3. Export the character data file
4. Import the data file (or reload from browser local storage)
5. Verify the inventory item quantity is preserved (should still be 5, not reset to 1)
