### PR TITLE
Fix Meddling Butler retainer data lost on data load

### DIFF
--- a/src/logic/update/hero-update-logic.ts
+++ b/src/logic/update/hero-update-logic.ts
@@ -1,4 +1,4 @@
-import { Feature, FeatureAncestryChoice, FeatureChoice, FeatureClassAbility, FeatureCompanion, FeatureDomain, FeatureDomainFeature, FeatureItemChoice, FeatureKit, FeatureLanguageChoice, FeatureMultiple, FeaturePerk, FeatureSkillChoice, FeatureSummon, FeatureSummonChoice, FeatureTaggedFeatureChoice, FeatureTitleChoice } from '@/models/feature';
+import { Feature, FeatureAncestryChoice, FeatureChoice, FeatureClassAbility, FeatureCompanion, FeatureDomain, FeatureDomainFeature, FeatureItemChoice, FeatureKit, FeatureLanguageChoice, FeatureMultiple, FeaturePerk, FeatureRetainer, FeatureSkillChoice, FeatureSummon, FeatureSummonChoice, FeatureTaggedFeatureChoice, FeatureTitleChoice } from '@/models/feature';
 import { AbilityUpdateLogic } from '@/logic/update/ability-update-logic';
 import { Ancestry } from '@/models/ancestry';
 import { AncestryData } from '@/data/ancestry-data';
@@ -467,6 +467,11 @@ export class HeroUpdateLogic {
 				}
 				case FeatureType.Companion: {
 					const oFeature = originalFeature as FeatureCompanion;
+					feature.data.selected = oFeature.data.selected;
+					break;
+				}
+				case FeatureType.Retainer: {
+					const oFeature = originalFeature as FeatureRetainer;
 					feature.data.selected = oFeature.data.selected;
 					break;
 				}


### PR DESCRIPTION
Fixes #833

Meddling Butler retainer data was being lost when data was loaded via import or browser local storage.

## Changes

- Added `FeatureRetainer` to imports in `hero-update-logic.ts`
- Added case for `FeatureType.Retainer` in `updateFeatureData` method to preserve selected retainer data when updating features during data load

## Testing

1. Create or open a hero
2. Select the "Meddling Butler" complication
3. Assign a retainer to the complication
4. Export the hero data file
5. Import the data file (or reload from browser local storage)
6. Verify the retainer is still assigned to the Meddling Butler complication

**Note:** This fix follows the same pattern as `FeatureType.Companion` which already preserves selected data.