### PR TITLE
Refactor class specialization display to show Conduit Domains as subclasses

### DIFF
--- a/src/components/panels/hero/hero-panel.tsx
+++ b/src/components/panels/hero/hero-panel.tsx
@@ -634,12 +634,7 @@ export const HeroPanel = (props: Props) => {
 						props.hero.class ?
 							useRows ?
 								<div className='selectable-row clickable' onClick={onSelectClass}>
-									{
-										props.hero.class.subclasses.filter(sc => sc.selected).length > 0 ?
-											<div>Class: <b>{props.hero.class.name} ({props.hero.class.subclasses.filter(sc => sc.selected).map(sc => sc.name).join(' ')}, level {props.hero.class.level})</b></div>
-											:
-											<div>Class: <b>{props.hero.class.name} (level {props.hero.class.level})</b></div>
-									}
+									<div>Class: <b>{props.hero.class.name} ({[`level ${props.hero.class.level}`, ...HeroLogic.getClassSpecialization(props.hero)].join(' ')})</b></div>
 								</div>
 								:
 								<div className='overview-tile clickable' onClick={onSelectClass}>
@@ -647,8 +642,8 @@ export const HeroPanel = (props: Props) => {
 									<Field label='Class' value={props.hero.class.name} />
 									<Field label='Level' value={props.hero.class.level} />
 									{
-										props.hero.class.subclasses.filter(sc => sc.selected).length > 0 ?
-											<Field label={props.hero.class.subclassName} value={props.hero.class.subclasses.filter(sc => sc.selected).map(sc => sc.name).join(', ') || ''} />
+										HeroLogic.getClassSpecialization(props.hero).length > 0 ?
+											<Field label={props.hero.class.subclassName || 'Domains'} value={HeroLogic.getClassSpecialization(props.hero).join(', ')} />
 											: null
 									}
 								</div>
@@ -1160,7 +1155,7 @@ export const HeroPanel = (props: Props) => {
 						props.hero.class ?
 							<Field
 								label='Class'
-								value={`${props.hero.class.name} (${[ `Level ${props.hero.class.level}`, ...props.hero.class.subclasses.filter(sc => sc.selected).map(sc => sc.name) ].join(' ')})`}
+								value={`${props.hero.class.name} (${[`Level ${props.hero.class.level}`, ...HeroLogic.getClassSpecialization(props.hero)].join(' ')})`}
 							/>
 							: null
 					}

--- a/src/logic/hero-logic.ts
+++ b/src/logic/hero-logic.ts
@@ -210,6 +210,15 @@ export class HeroLogic {
 		];
 	};
 
+	static getClassSpecialization = (hero: Hero): string[] => {
+		if (!hero.class) return [];
+		const selected = hero.class.subclasses.filter(sc => sc.selected).map(sc => sc.name);
+		if (selected.length > 0) return selected;
+		const domains = HeroLogic.getDomains(hero).map(d => d.name);
+		if (domains.length > 0) return [domains.join('/')];
+		return [];
+	};
+
 	static getDomains = (hero: Hero) => {
 		return HeroLogic.getFeatures(hero)
 			.map(f => f.feature)


### PR DESCRIPTION
I wanted to add in this feature request from a few months ago, and DRY'd up how the subclass features are displayed.

Before:
<img width="1548" height="588" alt="image" src="https://github.com/user-attachments/assets/8c90c951-e630-49e4-8a63-67e7f94ee460" />

After:
<img width="3752" height="2550" alt="image" src="https://github.com/user-attachments/assets/ec6f5299-6c07-4a7a-add1-397568d23987" />

