### PR TITLE
Update Ability Card Formatting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "forgesteel",
-	"version": "12.94.0",
+	"version": "12.95.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "forgesteel",
-			"version": "12.94.0",
+			"version": "12.95.0",
 			"dependencies": {
 				"@ant-design/icons": "^6.1.0",
 				"@dnd-kit/core": "^6.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "forgesteel",
-	"version": "12.95.0",
+	"version": "12.96.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "forgesteel",
-			"version": "12.95.0",
+			"version": "12.96.0",
 			"dependencies": {
 				"@ant-design/icons": "^6.1.0",
 				"@dnd-kit/core": "^6.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "forgesteel",
-	"version": "12.96.0",
+	"version": "12.97.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "forgesteel",
-			"version": "12.96.0",
+			"version": "12.97.0",
 			"dependencies": {
 				"@ant-design/icons": "^6.1.0",
 				"@dnd-kit/core": "^6.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "forgesteel",
-	"version": "12.93.0",
+	"version": "12.94.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "forgesteel",
-			"version": "12.93.0",
+			"version": "12.94.0",
 			"dependencies": {
 				"@ant-design/icons": "^6.1.0",
 				"@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "forgesteel",
 	"private": true,
-	"version": "12.94.0",
+	"version": "12.95.0",
 	"type": "module",
 	"repository": "https://github.com/andyaiken/forgesteel.git",
 	"homepage": "https://andyaiken.github.io/forgesteel/",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "forgesteel",
 	"private": true,
-	"version": "12.93.0",
+	"version": "12.94.0",
 	"type": "module",
 	"repository": "https://github.com/andyaiken/forgesteel.git",
 	"homepage": "https://andyaiken.github.io/forgesteel/",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "forgesteel",
 	"private": true,
-	"version": "12.95.0",
+	"version": "12.96.0",
 	"type": "module",
 	"repository": "https://github.com/andyaiken/forgesteel.git",
 	"homepage": "https://andyaiken.github.io/forgesteel/",
@@ -11,7 +11,7 @@
 		"lint": "eslint \"src/**/*.{ts,tsx}\"",
 		"fix": "eslint \"src/**/*.{ts,tsx}\" --fix",
 		"test": "vitest",
-		"check": "npm run lint && tsc -p tsconfig.json && vitest run && npm audit",
+		"check": "npm run lint && tsc -p tsconfig.json && vitest run",
 		"build": "vite build",
 		"predeploy": "npm run check && npm run build",
 		"deploy": "gh-pages -d dist"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "forgesteel",
 	"private": true,
-	"version": "12.96.0",
+	"version": "12.97.0",
 	"type": "module",
 	"repository": "https://github.com/andyaiken/forgesteel.git",
 	"homepage": "https://andyaiken.github.io/forgesteel/",
@@ -11,7 +11,7 @@
 		"lint": "eslint \"src/**/*.{ts,tsx}\"",
 		"fix": "eslint \"src/**/*.{ts,tsx}\" --fix",
 		"test": "vitest",
-		"check": "npm run lint && tsc -p tsconfig.json && vitest run",
+		"check": "npm run lint && tsc -p tsconfig.json && vitest run && npm audit",
 		"build": "vite build",
 		"predeploy": "npm run check && npm run build",
 		"deploy": "gh-pages -d dist"

--- a/src/components/controls/header-text/header-text.scss
+++ b/src/components/controls/header-text/header-text.scss
@@ -1,6 +1,5 @@
 .header-text-panel {
 	padding: 5px 0;
-	border-bottom: 1px solid rgba(5, 5, 5, 0.06);
 	display: flex;
 	align-items: center;
 	justify-content: space-between;

--- a/src/components/controls/header-text/header-text.tsx
+++ b/src/components/controls/header-text/header-text.tsx
@@ -19,19 +19,17 @@ export const HeaderText = (props: Props) => {
 	}
 
 	return (
-		<ErrorBoundary>
-			<div className={`header-text-panel level-${props.level || 2}`} style={props.style}>
-				<div className='header-text-content'>
-					{props.ribbon}
-					<div className='header-text'>{props.children}</div>
-					{
-						props.tags ?
-							<Flex gap={3}>{props.tags.map((t, n) => <Tag key={n} variant='outlined'>{t}</Tag>)}</Flex>
-							: null
-					}
-				</div>
-				{props.extra}
-			</div>
-		</ErrorBoundary>
-	);
+    <ErrorBoundary>
+      <div
+        className={`header-text-panel level-${props.level || 2}`}
+        style={props.style}
+      >
+        <div className="header-text-content">
+          <div className="header-text">{props.children}</div>
+          {props.ribbon}
+        </div>
+        {props.extra}
+      </div>
+    </ErrorBoundary>
+  );
 };

--- a/src/components/controls/header-text/header-text.tsx
+++ b/src/components/controls/header-text/header-text.tsx
@@ -1,5 +1,4 @@
-import { CSSProperties, ReactNode } from 'react';
-import { Flex, Tag } from 'antd';
+import { CSSProperties, ReactNode } from 'react';\
 import { ErrorBoundary } from '@/components/controls/error-boundary/error-boundary';
 
 import './header-text.scss';
@@ -19,17 +18,17 @@ export const HeaderText = (props: Props) => {
 	}
 
 	return (
-    <ErrorBoundary>
-      <div
-        className={`header-text-panel level-${props.level || 2}`}
-        style={props.style}
-      >
-        <div className="header-text-content">
-          <div className="header-text">{props.children}</div>
-          {props.ribbon}
-        </div>
-        {props.extra}
-      </div>
-    </ErrorBoundary>
-  );
+		<ErrorBoundary>
+			<div
+				className={`header-text-panel level-${props.level || 2}`}
+				style={props.style}
+			>
+				<div className='header-text-content'>
+					<div className='header-text'>{props.children}</div>
+					{props.ribbon}
+				</div>
+				{props.extra}
+			</div>
+		</ErrorBoundary>
+	);
 };

--- a/src/components/controls/pill/pill.scss
+++ b/src/components/controls/pill/pill.scss
@@ -2,7 +2,8 @@
 	margin: -2px 0;
 	border: 1px solid rgb(22, 119, 255);
 	border-radius: 10px;
-	background-color: rgb(230, 244, 255);
+	background-color: rgb(22, 119, 255);
+	color: rgb(241, 237, 253);
 	padding: 2px 6px;
 	font-size: 10px;
 	font-weight: 600;

--- a/src/components/features/feature-data/perk.tsx
+++ b/src/components/features/feature-data/perk.tsx
@@ -164,7 +164,11 @@ export const ConfigPerk = (props: ConfigProps) => {
 					</Flex>
 				))
 			}
-			{props.data.selected.length < props.data.count ? getAddButton() : null}
+			{
+				props.data.selected.length < props.data.count ?
+					getAddButton()
+					: null
+			}
 			<Drawer open={perkSelectorOpen} onClose={() => setPerkSelectorOpen(false)} closeIcon={null} size={500}>
 				<PerkSelectModal
 					perks={sortedPerks.filter(p => !currentPerkIDs.includes(p.id))}

--- a/src/components/features/feature-data/title-choice.tsx
+++ b/src/components/features/feature-data/title-choice.tsx
@@ -1,19 +1,15 @@
 import { Button, Drawer, Flex, Space } from 'antd';
 import { CloseOutlined, InfoCircleOutlined } from '@ant-design/icons';
 import { Feature, FeatureTitleChoiceData } from '@/models/feature';
-import { Collections } from '@/utils/collections';
-import { FactoryLogic } from '@/logic/factory-logic';
 import { Field } from '@/components/controls/field/field';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
-import { HeroLogic } from '@/logic/hero-logic';
 import { Markdown } from '@/components/controls/markdown/markdown';
 import { Modal } from '@/components/modals/modal/modal';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
 import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Sourcebook } from '@/models/sourcebook';
-import { SourcebookLogic } from '@/logic/sourcebook-logic';
 import { Title } from '@/models/title';
 import { TitlePanel } from '@/components/panels/elements/title-panel/title-panel';
 import { TitleSelectModal } from '@/components/modals/select/title-select/title-select-modal';
@@ -86,17 +82,6 @@ export const ConfigTitleChoice = (props: ConfigProps) => {
 	const [ titleSelectorOpen, setTitleSelectorOpen ] = useState<boolean>(false);
 	const [ selectedTitle, setSelectedTitle ] = useState<Title | null>(null);
 
-	const currentTitleIDs = HeroLogic.getTitles(props.hero).map(t => t.id);
-	const titles = SourcebookLogic.getTitles(props.sourcebooks as Sourcebook[])
-		.filter(t => t.echelon === props.data.echelon)
-		.filter(t => !currentTitleIDs.includes(t.id));
-	const sortedTitles = Collections.sort(titles, t => t.name);
-
-	const customTitle = FactoryLogic.createTitle();
-	customTitle.name = 'Custom Title';
-	customTitle.echelon = props.data.echelon;
-	customTitle.features.push(FactoryLogic.feature.create({ id: Utils.guid(), name: 'Custom Title', description: 'Details' }));
-
 	const getAddButton = () => {
 		return (
 			<Button className='status-warning' block={true} onClick={() => setTitleSelectorOpen(true)}>
@@ -153,7 +138,6 @@ export const ConfigTitleChoice = (props: ConfigProps) => {
 			{props.data.selected.length < props.data.count ? getAddButton() : null}
 			<Drawer open={titleSelectorOpen} onClose={() => setTitleSelectorOpen(false)} closeIcon={null} size={500}>
 				<TitleSelectModal
-					titles={[ customTitle, ...sortedTitles ]}
 					hero={props.hero}
 					sourcebooks={props.sourcebooks}
 					options={props.options}

--- a/src/components/modals/hero-customize/hero-customize-modal.tsx
+++ b/src/components/modals/hero-customize/hero-customize-modal.tsx
@@ -1,5 +1,5 @@
 import { Button, Flex, Popover, Segmented, Select, Space } from 'antd';
-import { Feature, FeatureAbility, FeatureAncestryFeatureChoice, FeatureBonus, FeatureCharacteristicBonus, FeatureClassAbility, FeatureConditionImmunity, FeatureDamageModifier, FeatureData, FeatureFollower, FeatureMovementMode, FeaturePerk, FeatureProficiency, FeatureTitleChoice } from '@/models/feature';
+import { Feature, FeatureAbility, FeatureAncestryFeatureChoice, FeatureBonus, FeatureCharacteristicBonus, FeatureClassAbility, FeatureConditionImmunity, FeatureDamageModifier, FeatureData, FeatureFollower, FeatureMovementMode, FeaturePerk, FeatureProficiency } from '@/models/feature';
 import { Ability } from '@/models/ability';
 import { AbilityEditPanel } from '@/components/panels/edit/ability-edit/ability-edit-panel';
 import { Characteristic } from '@/enums/characteristic';
@@ -226,19 +226,6 @@ export const HeroCustomizeModal = (props: Props) => {
 								}}
 							>
 								Perk
-							</Button>
-							<Button
-								block={true}
-								type='text'
-								onClick={() => {
-									setMenuOpen(false);
-									addFeature(FactoryLogic.feature.createTitleChoice({
-										id: Utils.guid(),
-										echelon: 1
-									}));
-								}}
-							>
-								Title
 							</Button>
 						</div>
 						<HeaderText level={3}>NPCs</HeaderText>
@@ -483,13 +470,6 @@ export const HeroCustomizeModal = (props: Props) => {
 			setFeature(feature.id, copy);
 		};
 
-		const setEchelon = (value: number) => {
-			const copy = Utils.copy(feature) as FeatureTitleChoice;
-			copy.data.echelon = value;
-			copy.data.selected = [];
-			setFeature(feature.id, copy);
-		};
-
 		const setAbility = (value: Ability) => {
 			const copy = Utils.copy(feature) as FeatureAbility;
 			copy.data.ability = value;
@@ -717,18 +697,6 @@ export const HeroCustomizeModal = (props: Props) => {
 							optionRender={option => <div className='ds-text'>{option.data.value}</div>}
 							value={feature.data.armor}
 							onChange={setProficiencyArmor}
-						/>
-					</div>
-				);
-			case FeatureType.TitleChoice:
-				return (
-					<div>
-						<HeaderText>Echelon</HeaderText>
-						<NumberSpin
-							min={1}
-							max={4}
-							value={feature.data.echelon}
-							onChange={setEchelon}
 						/>
 					</div>
 				);

--- a/src/components/modals/hero-state/hero-state-modal.tsx
+++ b/src/components/modals/hero-state/hero-state-modal.tsx
@@ -9,6 +9,7 @@ import { ProjectsPanel } from '@/components/modals/hero-state/projects-panel/pro
 import { ResourcesPanel } from '@/components/modals/hero-state/resources-panel/resources-panel';
 import { Segmented } from 'antd';
 import { Sourcebook } from '@/models/sourcebook';
+import { TitlesPanel } from '@/components/modals/hero-state/titles-panel/titles-panel';
 import { Utils } from '@/utils/utils';
 import { useState } from 'react';
 
@@ -70,6 +71,15 @@ export const HeroStateModal = (props: Props) => {
 						onChange={onChange}
 					/>
 				);
+			case HeroStatePage.Titles:
+				return (
+					<TitlesPanel
+						hero={hero}
+						sourcebooks={props.sourcebooks}
+						options={props.options}
+						onChange={onChange}
+					/>
+				);
 		}
 	};
 
@@ -86,7 +96,8 @@ export const HeroStateModal = (props: Props) => {
 									HeroStatePage.Resources,
 									HeroStatePage.Vitals,
 									HeroStatePage.Inventory,
-									HeroStatePage.Projects
+									HeroStatePage.Projects,
+									HeroStatePage.Titles
 								]
 								:
 								[

--- a/src/components/modals/hero-state/titles-panel/titles-panel.scss
+++ b/src/components/modals/hero-state/titles-panel/titles-panel.scss
@@ -1,0 +1,6 @@
+.titles-panel {
+	padding: 20px 0;
+	display: flex;
+	flex-direction: column;
+	gap: 10px;	
+}

--- a/src/components/modals/hero-state/titles-panel/titles-panel.tsx
+++ b/src/components/modals/hero-state/titles-panel/titles-panel.tsx
@@ -1,0 +1,107 @@
+import { Button, Drawer, Space } from 'antd';
+import { CaretDownOutlined, CaretUpOutlined, PlusOutlined } from '@ant-design/icons';
+import { Collections } from '@/utils/collections';
+import { DangerButton } from '@/components/controls/danger-button/danger-button';
+import { Empty } from '@/components/controls/empty/empty';
+import { ErrorBoundary } from '@/components/controls/error-boundary/error-boundary';
+import { Expander } from '@/components/controls/expander/expander';
+import { HeaderText } from '@/components/controls/header-text/header-text';
+import { Hero } from '@/models/hero';
+import { Options } from '@/models/options';
+import { PanelMode } from '@/enums/panel-mode';
+import { Sourcebook } from '@/models/sourcebook';
+import { Title } from '@/models/title';
+import { TitlePanel } from '@/components/panels/elements/title-panel/title-panel';
+import { TitleSelectModal } from '@/components/modals/select/title-select/title-select-modal';
+import { Utils } from '@/utils/utils';
+import { useState } from 'react';
+
+import './titles-panel.scss';
+
+interface Props {
+	hero: Hero;
+	sourcebooks: Sourcebook[];
+	options: Options;
+	onChange: (hero: Hero) => void;
+}
+
+export const TitlesPanel = (props: Props) => {
+	const [ hero, setHero ] = useState<Hero>(Utils.copy(props.hero));
+	const [ titlesVisible, setTitlesVisible ] = useState<boolean>(false);
+
+	const addTitle = (title: Title) => {
+		const copy = Utils.copy(hero);
+		copy.state.titles.push(Utils.copy(title));
+		setHero(copy);
+		setTitlesVisible(false);
+		props.onChange(copy);
+	};
+
+	const changeTitle = (title: Title) => {
+		const copy = Utils.copy(hero);
+		const index = copy.state.titles.findIndex(t => t.id === title.id);
+		copy.state.titles[index] = title;
+		setHero(copy);
+		props.onChange(copy);
+	};
+
+	const moveTitle = (title: Title, direction: 'up' | 'down') => {
+		const copy = Utils.copy(hero);
+		const index = copy.state.titles.findIndex(p => p.id === title.id);
+		copy.state.titles = Collections.move(copy.state.titles, index, direction);
+		setHero(copy);
+		props.onChange(copy);
+	};
+
+	const deleteTitle = (title: Title) => {
+		const copy = Utils.copy(hero);
+		copy.state.titles = copy.state.titles.filter(p => p.id !== title.id);
+		setHero(copy);
+		props.onChange(copy);
+	};
+
+	return (
+		<ErrorBoundary>
+			<Space orientation='vertical' style={{ width: '100%', paddingBottom: '20px' }}>
+				<HeaderText
+					extra={
+						<Button type='text' icon={<PlusOutlined />} onClick={() => setTitlesVisible(true)} />
+					}
+				>
+					Titles
+				</HeaderText>
+				{
+					hero.state.titles.map(title => (
+						<Expander
+							key={title.id}
+							title={title.name}
+							tags={[ `Echelon ${title.echelon}` ]}
+							extra={[
+								<Button key='up' type='text' title='Move Up' icon={<CaretUpOutlined />} onClick={e => { e.stopPropagation(); moveTitle(title, 'up'); }} />,
+								<Button key='down' type='text' title='Move Down' icon={<CaretDownOutlined />} onClick={e => { e.stopPropagation(); moveTitle(title, 'down'); }} />,
+								<DangerButton key='delete' mode='clear' onConfirm={e => { e.stopPropagation(); deleteTitle(title); }} />
+							]}
+						>
+							<TitlePanel
+								title={title}
+								hero={hero}
+								sourcebooks={props.sourcebooks}
+								options={props.options}
+								mode={PanelMode.Full}
+								onChange={changeTitle}
+							/>
+						</Expander>
+					))
+				}
+				{
+					hero.state.titles.length === 0 ?
+						<Empty text='You have no titles.' />
+						: null
+				}
+				<Drawer open={titlesVisible} onClose={() => setTitlesVisible(false)} closeIcon={null} size={500}>
+					<TitleSelectModal hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} onSelect={addTitle} onClose={() => setTitlesVisible(false)} />
+				</Drawer>
+			</Space>
+		</ErrorBoundary>
+	);
+};

--- a/src/components/modals/select/title-select/title-select-modal.tsx
+++ b/src/components/modals/select/title-select/title-select-modal.tsx
@@ -1,14 +1,20 @@
 import { Alert, Button, Space } from 'antd';
+import { Collections } from '@/utils/collections';
+import { CreatureLogic } from '@/logic/creature-logic';
 import { Empty } from '@/components/controls/empty/empty';
+import { FactoryLogic } from '@/logic/factory-logic';
 import { Feature } from '@/models/feature';
 import { FeaturePanel } from '@/components/panels/elements/feature-panel/feature-panel';
 import { Hero } from '@/models/hero';
+import { HeroLogic } from '@/logic/hero-logic';
 import { Modal } from '@/components/modals/modal/modal';
+import { NumberSpin } from '@/components/controls/number-spin/number-spin';
 import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { SearchBox } from '@/components/controls/text-input/text-input';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
 import { Sourcebook } from '@/models/sourcebook';
+import { SourcebookLogic } from '@/logic/sourcebook-logic';
 import { Title } from '@/models/title';
 import { TitlePanel } from '@/components/panels/elements/title-panel/title-panel';
 import { Utils } from '@/utils/utils';
@@ -17,7 +23,6 @@ import { useState } from 'react';
 import './title-select-modal.scss';
 
 interface Props {
-	titles: Title[];
 	hero: Hero;
 	sourcebooks: Sourcebook[];
 	options: Options;
@@ -26,6 +31,7 @@ interface Props {
 }
 
 export const TitleSelectModal = (props: Props) => {
+	const [ echelon, setEchelon ] = useState<number>(CreatureLogic.getEchelon(props.hero.class ? props.hero.class.level : 1));
 	const [ searchTerm, setSearchTerm ] = useState<string>('');
 	const [ selectedTitle, setSelectedTitle ] = useState<Title | null>(null);
 
@@ -47,7 +53,18 @@ export const TitleSelectModal = (props: Props) => {
 		}
 	};
 
-	const titles = props.titles
+	const customTitle = FactoryLogic.createTitle();
+	customTitle.name = 'Custom Title';
+	customTitle.echelon = echelon;
+	customTitle.features.push(FactoryLogic.feature.create({ id: Utils.guid(), name: 'Custom Title', description: 'Details' }));
+
+	const currentTitleIDs = HeroLogic.getTitles(props.hero).map(t => t.id);
+	const echelonTitles = SourcebookLogic.getTitles(props.sourcebooks as Sourcebook[])
+		.filter(t => t.echelon === echelon)
+		.filter(t => !currentTitleIDs.includes(t.id));
+	const sortedTitles = Collections.sort(echelonTitles, t => t.name);
+
+	const titles = sortedTitles
 		.filter(t => Utils.textMatches([
 			t.name,
 			t.description
@@ -63,8 +80,9 @@ export const TitleSelectModal = (props: Props) => {
 					{
 						selectedTitle === null ?
 							<Space orientation='vertical' style={{ width: '100%' }}>
+								<NumberSpin label='Echelon' min={1} max={4} value={echelon} onChange={setEchelon} />
 								{
-									titles.map(t => (
+									[ customTitle, ...titles ].map(t => (
 										<SelectablePanel
 											key={t.id}
 											onSelect={() => selectTitle(t)}
@@ -72,11 +90,6 @@ export const TitleSelectModal = (props: Props) => {
 											<TitlePanel title={t} hero={props.hero} sourcebooks={props.sourcebooks} mode={PanelMode.Full} options={props.options} />
 										</SelectablePanel>
 									))
-								}
-								{
-									titles.length === 0 ?
-										<Empty />
-										: null
 								}
 							</Space>
 							:

--- a/src/components/modals/settings/settings-modal.tsx
+++ b/src/components/modals/settings/settings-modal.tsx
@@ -92,12 +92,14 @@ export const SettingsModal = (props: Props) => {
 		const setXPPerLevel = (value: number) => {
 			const copy = Utils.copy(options);
 			copy.xpPerLevel = value;
+			setOptions(copy);
 			props.setOptions(copy);
 		};
 
 		const setShownStandardAbilities = (value: string | string[]) => {
 			const copy = Utils.copy(options);
 			copy.shownStandardAbilities = [ value ].flat(1);
+			setOptions(copy);
 			props.setOptions(copy);
 		};
 

--- a/src/components/pages/welcome/welcome-page.scss
+++ b/src/components/pages/welcome/welcome-page.scss
@@ -106,5 +106,9 @@ html[data-theme="dark"] {
 				}
 			}
 		}
+
+		.banner {
+			background-color: rgba(50, 50, 50);
+		}
 	}
 }

--- a/src/components/pages/welcome/welcome-page.scss
+++ b/src/components/pages/welcome/welcome-page.scss
@@ -69,6 +69,28 @@
 			height: 45px;
 		}
 	}
+
+	.banner-container {
+		position: absolute;
+		height: 100%;
+		width: 100%;
+		left: 0;
+		right: 0;
+		top: 0;
+		bottom: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background-color: rgba(0, 0, 0, 0.25);
+		backdrop-filter: blur(3px);
+	}
+
+	.banner {
+		background-color: white;
+		border-radius: 10px;
+		box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.1), 0 3px 6px 0 rgba(0, 0, 0, 0.12);
+		padding: 0 20px 25px 20px;
+	}
 }
 
 html[data-theme="dark"] {

--- a/src/components/pages/welcome/welcome-page.tsx
+++ b/src/components/pages/welcome/welcome-page.tsx
@@ -1,5 +1,5 @@
 import { Alert, Button, Flex, Segmented } from 'antd';
-import { BookOutlined, PlayCircleOutlined, PlusOutlined, TeamOutlined } from '@ant-design/icons';
+import { BookOutlined, CloseOutlined, PlayCircleOutlined, PlusOutlined, TeamOutlined } from '@ant-design/icons';
 import { AppFooter } from '@/components/panels/app-footer/app-footer';
 import { AppHeader } from '@/components/panels/app-header/app-header';
 import { Collections } from '@/utils/collections';
@@ -31,21 +31,20 @@ interface Props {
 
 export const WelcomePage = (props: Props) => {
 	const isSmall = useMediaQuery('(max-width: 1000px)');
+	const [ showBanner, setShowBanner ] = useState<boolean>(true);
 
 	if (isSmall) {
 		return (
 			<ErrorBoundary name='welcome-page'>
 				<div className='welcome-page'>
 					<AppHeader />
-					<ErrorBoundary>
-						<div className='welcome-page-content compact'>
-							<div className='welcome-column'>
-								<Welcome
-									onNewHero={props.onNewHero}
-								/>
-							</div>
+					<div className='welcome-page-content compact'>
+						<div className='welcome-column'>
+							<Welcome
+								onNewHero={props.onNewHero}
+							/>
 						</div>
-					</ErrorBoundary>
+					</div>
 					<AppFooter
 						page='welcome'
 						highlightAbout={props.highlightAbout}
@@ -54,6 +53,11 @@ export const WelcomePage = (props: Props) => {
 						showAbout={props.showAbout}
 						showSettings={props.showSettings}
 					/>
+					{
+						showBanner ?
+							<Banner onClose={() => setShowBanner(false)} />
+							: null
+					}
 				</div>
 			</ErrorBoundary>
 		);
@@ -87,6 +91,11 @@ export const WelcomePage = (props: Props) => {
 					showAbout={props.showAbout}
 					showSettings={props.showSettings}
 				/>
+				{
+					showBanner ?
+						<Banner onClose={() => setShowBanner(false)} />
+						: null
+				}
 			</div>
 		</ErrorBoundary>
 	);
@@ -362,5 +371,24 @@ const Tips = () => {
 				onNext={tipIndex === tips.length - 1 ? undefined : nextTip}
 			/>
 		</ErrorBoundary>
+	);
+};
+
+interface BannerProps {
+	onClose: () => void;
+}
+
+const Banner = (props: BannerProps) => {
+	return (
+		<div className='banner-container' onClick={e => e.stopPropagation()}>
+			<div className='banner'>
+				<HeaderText extra={<Button type='text' icon={<CloseOutlined />} onClick={props.onClose} />}>
+					FORGE STEEL has a new home!
+				</HeaderText>
+				<div>
+					Export your heroes and homebrew sourcebooks <a href='https://andyaiken.github.io/forgesteel/#/backup'>here</a>, then join us at <a href='https://forgesteel.net'>https://forgesteel.net</a>.
+				</div>
+			</div>
+		</div>
 	);
 };

--- a/src/components/panels/elements/ability-panel/ability-panel.tsx
+++ b/src/components/panels/elements/ability-panel/ability-panel.tsx
@@ -308,84 +308,92 @@ export const AbilityPanel = (props: Props) => {
 	}
 
 	return (
-    <ErrorBoundary>
-      <div
-        className="ability-panel"
-        id={SheetFormatter.getPageId("ability", props.ability.id)}
-      >
-        <Space
-          orientation="vertical"
-          style={{ marginTop: "15px", width: "100%" }}
-        >
-          {getWarnings().map((warn, n) => (
-            <Alert
-              key={n}
-              type="warning"
-              showIcon={true}
-              title={
-                <div>
-                  <b>{warn.label}</b>: {warn.text}
-                </div>
-              }
-            />
-          ))}
-        </Space>
-        <HeaderText
-          ribbon={getRibbon()}
-          tags={props.tags}
-          extra={
-            autoCalcAvailable() ? (
-              <Button
-                type="text"
-                title="Auto-calculate damage, potency, etc"
-                icon={
-                  autoCalc ? (
-                    <ThunderboltFilled style={{ color: "rgb(22, 119, 255)" }} />
-                  ) : (
-                    <ThunderboltOutlined />
-                  )
-                }
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setAutoCalc(!autoCalc);
-                }}
-              />
-            ) : null
-          }
-        >
-          {props.ability.name || "Unnamed Ability"}
-        </HeaderText>
-        {props.ability.keywords.length > 0 ? (
-          <Flex gap={3} justify="between">
-            <>
-              {props.ability.keywords.map((k, n) => (
-                <Tag key={n} variant="outlined">
-                  {k}
-                </Tag>
-              ))}
-            </>
-            {props.tags?.map((t, n) => (
-              <Tag key={n} variant="outlined" color="blue">
-                {t}
-              </Tag>
-            ))}
-          </Flex>
-        ) : null}
-        <Markdown
-          text={props.ability.description}
-          className="ability-description-text"
-        />
-        <AbilityInfoPanel ability={props.ability} hero={props.hero} />
-        {(props.ability.sections || []).map(getSection)}
-        {props.ability.keywords.includes(AbilityKeyword.Charge) &&
-        props.ability.id !== AbilityData.freeStrikeMelee.id ? (
-          <Alert
-            type="info"
-            showIcon={true}
-            title="This ability can be used in place of a melee free strike when you take the Charge action."
-          />
-        ) : null}
-      </div>
-    </ErrorBoundary>
-  );
+		<ErrorBoundary>
+			<div
+				className='ability-panel'
+				id={SheetFormatter.getPageId('ability', props.ability.id)}
+			>
+				<Space
+					orientation='vertical'
+					style={{ marginTop: '15px', width: '100%' }}
+				>
+					{getWarnings().map((warn, n) => (
+						<Alert
+							key={n}
+							type='warning'
+							showIcon={true}
+							title={
+								<div>
+									<b>{warn.label}</b>: {warn.text}
+								</div>
+							}
+						/>
+					))}
+				</Space>
+				<HeaderText
+					ribbon={getRibbon()}
+					tags={props.tags}
+					extra={
+						autoCalcAvailable()
+							? (
+								<Button
+									type='text'
+									title='Auto-calculate damage, potency, etc'
+									icon={
+										autoCalc
+											? (
+												<ThunderboltFilled style={{ color: 'rgb(22, 119, 255)' }} />
+											)
+											: (
+												<ThunderboltOutlined />
+											)
+									}
+									onClick={e => {
+										e.stopPropagation();
+										setAutoCalc(!autoCalc);
+									}}
+								/>
+							)
+							: null
+					}
+				>
+					{props.ability.name || 'Unnamed Ability'}
+				</HeaderText>
+				{props.ability.keywords.length > 0
+					? (
+						<Flex gap={3} justify='between'>
+							<>
+								{props.ability.keywords.map((k, n) => (
+									<Tag key={n} variant='outlined'>
+										{k}
+									</Tag>
+								))}
+							</>
+							{props.tags?.map((t, n) => (
+								<Tag key={n} variant='outlined' color='blue'>
+									{t}
+								</Tag>
+							))}
+						</Flex>
+					)
+					: null}
+				<Markdown
+					text={props.ability.description}
+					className='ability-description-text'
+				/>
+				<AbilityInfoPanel ability={props.ability} hero={props.hero} />
+				{(props.ability.sections || []).map(getSection)}
+				{props.ability.keywords.includes(AbilityKeyword.Charge) &&
+        props.ability.id !== AbilityData.freeStrikeMelee.id
+					? (
+						<Alert
+							type='info'
+							showIcon={true}
+							title='This ability can be used in place of a melee free strike when you take the Charge action.'
+						/>
+					)
+					: null}
+			</div>
+		</ErrorBoundary>
+	);
 };

--- a/src/components/panels/elements/ability-panel/ability-panel.tsx
+++ b/src/components/panels/elements/ability-panel/ability-panel.tsx
@@ -308,54 +308,84 @@ export const AbilityPanel = (props: Props) => {
 	}
 
 	return (
-		<ErrorBoundary>
-			<div className='ability-panel' id={SheetFormatter.getPageId('ability', props.ability.id)}>
-				<Space orientation='vertical' style={{ marginTop: '15px', width: '100%' }}>
-					{
-						getWarnings().map((warn, n) => (
-							<Alert
-								key={n}
-								type='warning'
-								showIcon={true}
-								title={<div><b>{warn.label}</b>: {warn.text}</div>}
-							/>
-						))
-					}
-				</Space>
-				<HeaderText
-					ribbon={getRibbon()}
-					tags={props.tags}
-					extra={
-						autoCalcAvailable() ?
-							<Button
-								type='text'
-								title='Auto-calculate damage, potency, etc'
-								icon={autoCalc ? <ThunderboltFilled style={{ color: 'rgb(22, 119, 255)' }} /> : <ThunderboltOutlined />}
-								onClick={e => { e.stopPropagation(); setAutoCalc(!autoCalc); }}
-							/>
-							: null
-					}
-				>
-					{props.ability.name || 'Unnamed Ability'}
-				</HeaderText>
-				<Markdown text={props.ability.description} className='ability-description-text' />
-				{
-					props.ability.keywords.length > 0 ?
-						<Flex gap={3}>{props.ability.keywords.map((k, n) => <Tag key={n} variant='outlined'>{k}</Tag>)}</Flex>
-						: null
-				}
-				<AbilityInfoPanel ability={props.ability} hero={props.hero} />
-				{(props.ability.sections || []).map(getSection)}
-				{
-					props.ability.keywords.includes(AbilityKeyword.Charge) && (props.ability.id !== AbilityData.freeStrikeMelee.id) ?
-						<Alert
-							type='info'
-							showIcon={true}
-							title='This ability can be used in place of a melee free strike when you take the Charge action.'
-						/>
-						: null
-				}
-			</div>
-		</ErrorBoundary>
-	);
+    <ErrorBoundary>
+      <div
+        className="ability-panel"
+        id={SheetFormatter.getPageId("ability", props.ability.id)}
+      >
+        <Space
+          orientation="vertical"
+          style={{ marginTop: "15px", width: "100%" }}
+        >
+          {getWarnings().map((warn, n) => (
+            <Alert
+              key={n}
+              type="warning"
+              showIcon={true}
+              title={
+                <div>
+                  <b>{warn.label}</b>: {warn.text}
+                </div>
+              }
+            />
+          ))}
+        </Space>
+        <HeaderText
+          ribbon={getRibbon()}
+          tags={props.tags}
+          extra={
+            autoCalcAvailable() ? (
+              <Button
+                type="text"
+                title="Auto-calculate damage, potency, etc"
+                icon={
+                  autoCalc ? (
+                    <ThunderboltFilled style={{ color: "rgb(22, 119, 255)" }} />
+                  ) : (
+                    <ThunderboltOutlined />
+                  )
+                }
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setAutoCalc(!autoCalc);
+                }}
+              />
+            ) : null
+          }
+        >
+          {props.ability.name || "Unnamed Ability"}
+        </HeaderText>
+        {props.ability.keywords.length > 0 ? (
+          <Flex gap={3} justify="between">
+            <>
+              {props.ability.keywords.map((k, n) => (
+                <Tag key={n} variant="outlined">
+                  {k}
+                </Tag>
+              ))}
+            </>
+            {props.tags?.map((t, n) => (
+              <Tag key={n} variant="outlined" color="blue">
+                {t}
+              </Tag>
+            ))}
+          </Flex>
+        ) : null}
+        <Markdown
+          text={props.ability.description}
+          className="ability-description-text"
+        />
+        <AbilityInfoPanel ability={props.ability} hero={props.hero} />
+        {(props.ability.sections || []).map(getSection)}
+        {props.ability.keywords.includes(AbilityKeyword.Charge) &&
+        props.ability.id !== AbilityData.freeStrikeMelee.id ? (
+          <Alert
+            type="info"
+            showIcon={true}
+            title="This ability can be used in place of a melee free strike when you take the Charge action."
+          />
+        ) : null}
+      </div>
+    </ErrorBoundary>
+  );
 };

--- a/src/data/heroes/dwarf-fury.ts
+++ b/src/data/heroes/dwarf-fury.ts
@@ -4367,6 +4367,7 @@ export const dwarfFury = {
 		conditions: [],
 		inventory: [],
 		projects: [],
+		titles: [],
 		controlledSlots: [],
 		notes: '',
 		encounterState: 'ready',

--- a/src/data/heroes/high-elf-tactician.ts
+++ b/src/data/heroes/high-elf-tactician.ts
@@ -4141,6 +4141,7 @@ export const highElfTactician = {
 		conditions: [],
 		inventory: [],
 		projects: [],
+		titles: [],
 		controlledSlots: [],
 		notes: '',
 		encounterState: 'ready',

--- a/src/data/heroes/human-censor.ts
+++ b/src/data/heroes/human-censor.ts
@@ -4560,6 +4560,7 @@ export const humanCensor = {
 		conditions: [],
 		inventory: [],
 		projects: [],
+		titles: [],
 		controlledSlots: [],
 		notes: '',
 		encounterState: 'ready',

--- a/src/data/heroes/human-null.ts
+++ b/src/data/heroes/human-null.ts
@@ -4622,6 +4622,7 @@ export const humanNull = {
 		conditions: [],
 		inventory: [],
 		projects: [],
+		titles: [],
 		controlledSlots: [],
 		notes: '',
 		encounterState: 'ready',

--- a/src/data/heroes/human-talent.ts
+++ b/src/data/heroes/human-talent.ts
@@ -5747,6 +5747,7 @@ export const humanTalent = {
 		conditions: [],
 		inventory: [],
 		projects: [],
+		titles: [],
 		controlledSlots: [],
 		notes: '',
 		encounterState: 'ready',

--- a/src/data/heroes/orc-conduit.ts
+++ b/src/data/heroes/orc-conduit.ts
@@ -3835,6 +3835,7 @@ export const orcConduit = {
 		conditions: [],
 		inventory: [],
 		projects: [],
+		titles: [],
 		controlledSlots: [],
 		notes: '',
 		encounterState: 'ready',

--- a/src/data/heroes/polder-elementalist.ts
+++ b/src/data/heroes/polder-elementalist.ts
@@ -5330,6 +5330,7 @@ export const polderElementalist = {
 		conditions: [],
 		inventory: [],
 		projects: [],
+		titles: [],
 		controlledSlots: [],
 		notes: '',
 		encounterState: 'ready',

--- a/src/data/heroes/polder-shadow.ts
+++ b/src/data/heroes/polder-shadow.ts
@@ -4923,6 +4923,7 @@ export const polderShadow = {
 		conditions: [],
 		inventory: [],
 		projects: [],
+		titles: [],
 		controlledSlots: [],
 		notes: '',
 		encounterState: 'ready',

--- a/src/data/heroes/wode-elf-troubadour.ts
+++ b/src/data/heroes/wode-elf-troubadour.ts
@@ -5307,6 +5307,7 @@ export const wodeElfTroubadour = {
 		conditions: [],
 		inventory: [],
 		projects: [],
+		titles: [],
 		controlledSlots: [],
 		notes: '',
 		encounterState: 'ready',

--- a/src/data/imbuements/imbued-implement-data.ts
+++ b/src/data/imbuements/imbued-implement-data.ts
@@ -1,3 +1,4 @@
+import { AbilityKeyword } from '@/enums/ability-keyword';
 import { Characteristic } from '@/enums/characteristic';
 import { FactoryLogic } from '@/logic/factory-logic';
 import { FeatureField } from '@/enums/feature-field';
@@ -115,10 +116,31 @@ export class ImbuedImplementData {
 			goal: 150
 		}),
 		level: 1,
-		feature: FactoryLogic.feature.create({
+		feature: FactoryLogic.feature.createMultiple({
 			id: 'imbuement-seeking',
 			name: 'Seeking',
-			description: 'Your ranged magic or psionic abilities gain a +2 distance bonus. Additionally, if you think the name of a specific creature, place, or object to the implement, the implement points toward that target, provided you are on the same world.'
+			description: 'Your ranged magic or psionic abilities gain a +2 distance bonus.',
+			features: [
+				FactoryLogic.feature.createAbilityDistance({
+					id: 'imbuement-seeking-magic',
+					name: 'Seeking (Magic)',
+					description: 'Your ranged magic abilities gain a +2 distance bonus.',
+					keywords: [ AbilityKeyword.Ranged, AbilityKeyword.Magic ],
+					value: 2
+				}),
+				FactoryLogic.feature.createAbilityDistance({
+					id: 'imbuement-seeking-psionic',
+					name: 'Seeking (Psionic)',
+					description: 'Your ranged psionic abilities gain a +2 distance bonus.',
+					keywords: [ AbilityKeyword.Ranged, AbilityKeyword.Psionic ],
+					value: 2
+				}),
+				FactoryLogic.feature.create({
+					id: 'imbuement-seeking-text',
+					name: 'Seeking',
+					description: 'If you think the name of a specific creature, place, or object to the implement, the implement points toward that target, provided you are on the same world.'
+				})
+			]
 		})
 	});
 
@@ -131,10 +153,31 @@ export class ImbuedImplementData {
 			goal: 150
 		}),
 		level: 1,
-		feature: FactoryLogic.feature.create({
+		feature: FactoryLogic.feature.createMultiple({
 			id: 'imbuement-thought-sending',
 			name: 'Thought Sending',
-			description: 'Your ranged magic and psionic abilities gain a +2 distance bonus. Additionally, you can telepathically communicate with any willing creature who knows a language and whose name you know, provided they are on the same world as you. You must initiate the conversation, but once you do, the creature can respond until you end the conversation.'
+			description: 'Your ranged magic and psionic abilities gain a +2 distance bonus.',
+			features: [
+				FactoryLogic.feature.createAbilityDistance({
+					id: 'imbuement-thought-sending-magic',
+					name: 'Thought Sending (Magic)',
+					description: 'Your ranged magic abilities gain a +2 distance bonus.',
+					keywords: [ AbilityKeyword.Ranged, AbilityKeyword.Magic ],
+					value: 2
+				}),
+				FactoryLogic.feature.createAbilityDistance({
+					id: 'imbuement-thought-sending-psionic',
+					name: 'Thought Sending (Psionic)',
+					description: 'Your ranged psionic abilities gain a +2 distance bonus.',
+					keywords: [ AbilityKeyword.Ranged, AbilityKeyword.Psionic ],
+					value: 2
+				}),
+				FactoryLogic.feature.create({
+					id: 'imbuement-thought-sending-text',
+					name: 'Thought Sending',
+					description: 'You can telepathically communicate with any willing creature who knows a language and whose name you know, provided they are on the same world as you. You must initiate the conversation, but once you do, the creature can respond until you end the conversation.'
+				})
+			]
 		})
 	});
 

--- a/src/enums/hero-state-page.ts
+++ b/src/enums/hero-state-page.ts
@@ -2,5 +2,6 @@ export enum HeroStatePage {
 	Resources = 'Resources',
 	Vitals = 'Vitals',
 	Inventory = 'Inventory',
-	Projects = 'Projects'
+	Projects = 'Projects',
+	Titles = 'Titles'
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,7 @@ import { DataLoader, LoadedData } from '@/components/panels/data-loader/data-loa
 import { ErrorBoundary } from '@/components/controls/error-boundary/error-boundary';
 import { HashRouter } from 'react-router';
 import { Main } from '@/components/main/main.tsx';
+import { ServiceWorkerLogic } from './logic/service-worker-logic';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { initializeTheme } from '@/utils/initialize-theme';
@@ -10,17 +11,28 @@ import './index.scss';
 
 initializeTheme();
 
-// Register Service Worker for PWA functionality
-if ('serviceWorker' in navigator) {
-	window.addEventListener('load', () => {
-		navigator.serviceWorker.register('/forgesteel/sw.js')
-			.catch(registrationError => {
-				console.error('SW registration failed: ', registrationError);
-			});
-	});
-}
+const unregisterServiceWorker = async () => {
+	if ('serviceWorker' in navigator) {
+		const registrations = await navigator.serviceWorker.getRegistrations();
+		for (const registration of registrations) {
+			await registration.unregister();
+		}
+	}
+};
 
 const onDataLoaded = (data: LoadedData) => {
+	if ('serviceWorker' in navigator) {
+		if (ServiceWorkerLogic.shouldDisableServiceWorker(data.connectionSettings)) {
+			unregisterServiceWorker();
+		} else {
+			window.addEventListener('load', () => {
+				navigator.serviceWorker.register('/forgesteel/sw.js')
+					.catch(registrationError => {
+						console.error('SW registration failed: ', registrationError);
+					});
+			});
+		}
+	}
 	root.render(
 		<StrictMode>
 			<HashRouter>

--- a/src/logic/factory-logic.ts
+++ b/src/logic/factory-logic.ts
@@ -115,6 +115,7 @@ export class FactoryLogic {
 			conditions: [],
 			inventory: [],
 			projects: [],
+			titles: [],
 			controlledSlots: [],
 			notes: '',
 			encounterState: 'ready',

--- a/src/logic/hero-logic.ts
+++ b/src/logic/hero-logic.ts
@@ -187,10 +187,13 @@ export class HeroLogic {
 	};
 
 	static getTitles = (hero: Hero) => {
-		return HeroLogic.getFeatures(hero)
-			.map(f => f.feature)
-			.filter(f => f.type === FeatureType.TitleChoice)
-			.flatMap(f => f.data.selected);
+		return [
+			...hero.state.titles,
+			...HeroLogic.getFeatures(hero)
+				.map(f => f.feature)
+				.filter(f => f.type === FeatureType.TitleChoice)
+				.flatMap(f => f.data.selected)
+		];
 	};
 
 	static getDomains = (hero: Hero) => {

--- a/src/logic/service-worker-logic.ts
+++ b/src/logic/service-worker-logic.ts
@@ -1,0 +1,7 @@
+import { ConnectionSettings } from '../models/connection-settings';
+
+export class ServiceWorkerLogic {
+	public static shouldDisableServiceWorker(connectionSettings: ConnectionSettings): boolean {
+		return connectionSettings.useWarehouse && 'serviceWorker' in navigator;
+	}
+}

--- a/src/logic/update/feature-update-logic.ts
+++ b/src/logic/update/feature-update-logic.ts
@@ -118,6 +118,11 @@ export class FeatureUpdateLogic {
 					feature.data.tag = 'conduit-prayer';
 				}
 				break;
+			case FeatureType.Perk:
+				if (feature.data.lists === undefined) {
+					feature.data.lists = [];
+				}
+				break;
 		}
 	};
 }

--- a/src/logic/update/hero-update-logic.ts
+++ b/src/logic/update/hero-update-logic.ts
@@ -1,4 +1,4 @@
-import { Feature, FeatureAncestryChoice, FeatureChoice, FeatureClassAbility, FeatureCompanion, FeatureDomain, FeatureDomainFeature, FeatureItemChoice, FeatureKit, FeatureLanguageChoice, FeatureMultiple, FeaturePerk, FeatureSkillChoice, FeatureSummon, FeatureSummonChoice, FeatureTaggedFeatureChoice, FeatureTitleChoice } from '@/models/feature';
+import { Feature, FeatureAncestryChoice, FeatureChoice, FeatureClassAbility, FeatureCompanion, FeatureDomain, FeatureDomainFeature, FeatureItemChoice, FeatureKit, FeatureLanguageChoice, FeatureMultiple, FeaturePerk, FeatureRetainer, FeatureSkillChoice, FeatureSummon, FeatureSummonChoice, FeatureTaggedFeatureChoice, FeatureTitleChoice } from '@/models/feature';
 import { AbilityUpdateLogic } from '@/logic/update/ability-update-logic';
 import { Ancestry } from '@/models/ancestry';
 import { AncestryData } from '@/data/ancestry-data';
@@ -467,6 +467,11 @@ export class HeroUpdateLogic {
 				}
 				case FeatureType.Companion: {
 					const oFeature = originalFeature as FeatureCompanion;
+					feature.data.selected = oFeature.data.selected;
+					break;
+				}
+				case FeatureType.Retainer: {
+					const oFeature = originalFeature as FeatureRetainer;
 					feature.data.selected = oFeature.data.selected;
 					break;
 				}

--- a/src/logic/update/hero-update-logic.ts
+++ b/src/logic/update/hero-update-logic.ts
@@ -349,7 +349,9 @@ export class HeroUpdateLogic {
 					const id = origItem.id;
 					const item = SourcebookLogic.getItems(sourcebooks).find(itm => itm.id === id);
 					if (item) {
-						return Utils.copy(item);
+						const copiedItem = Utils.copy(item);
+						copiedItem.count = origItem.count;
+						return copiedItem;
 					} else {
 						return origItem;
 					}
@@ -508,7 +510,14 @@ export class HeroUpdateLogic {
 					const selectedIDs = oFeature.data.selected.map(i => i.id);
 					feature.data.selected = SourcebookLogic.getItems(sourcebooks)
 						.filter(i => selectedIDs.includes(i.id))
-						.map(i => Utils.copy(i));
+						.map(i => {
+							const copiedItem = Utils.copy(i);
+							const origItem = oFeature.data.selected.find(oi => oi.id === i.id);
+							if (origItem) {
+								copiedItem.count = origItem.count;
+							}
+							return copiedItem;
+						});
 					break;
 				}
 				case FeatureType.Kit: {

--- a/src/logic/update/hero-update-logic.ts
+++ b/src/logic/update/hero-update-logic.ts
@@ -167,6 +167,10 @@ export class HeroUpdateLogic {
 			hero.state.projects = [];
 		}
 
+		if (hero.state.titles === undefined) {
+			hero.state.titles = [];
+		}
+
 		if (hero.state.controlledSlots === undefined) {
 			hero.state.controlledSlots = [];
 		}
@@ -192,6 +196,9 @@ export class HeroUpdateLogic {
 				}
 			}
 		});
+
+		hero.state.titles.push(...hero.features.filter(f => f.type === FeatureType.TitleChoice).flatMap(f => f.data.selected));
+		hero.features = hero.features.filter(f => f.type !== FeatureType.TitleChoice);
 
 		if (hero.abilityCustomizations === undefined) {
 			hero.abilityCustomizations = [];

--- a/src/logic/update/sourcebook-update-logic.ts
+++ b/src/logic/update/sourcebook-update-logic.ts
@@ -175,6 +175,9 @@ export class SourcebookUpdateLogic {
 			domain.featuresByLevel.forEach(lvl => {
 				lvl.features.forEach(FeatureUpdateLogic.updateFeature);
 			});
+			if (domain.defaultFeatures === undefined) {
+				domain.defaultFeatures = [];
+			}
 			domain.defaultFeatures.forEach(FeatureUpdateLogic.updateFeature);
 		});
 

--- a/src/logic/update/sourcebook-update-logic.ts
+++ b/src/logic/update/sourcebook-update-logic.ts
@@ -127,6 +127,7 @@ export class SourcebookUpdateLogic {
 			if (a.ancestryPoints === undefined) {
 				a.ancestryPoints = 0;
 			}
+			a.features.forEach(FeatureUpdateLogic.updateFeature);
 		});
 
 		sourcebook.classes.forEach(c => {
@@ -174,6 +175,7 @@ export class SourcebookUpdateLogic {
 			domain.featuresByLevel.forEach(lvl => {
 				lvl.features.forEach(FeatureUpdateLogic.updateFeature);
 			});
+			domain.defaultFeatures.forEach(FeatureUpdateLogic.updateFeature);
 		});
 
 		sourcebook.encounters.forEach(e => {
@@ -287,6 +289,7 @@ export class SourcebookUpdateLogic {
 		sourcebook.items.forEach(item => {
 			if (item.customizationsByLevel && (item.customizationsByLevel.length > 0)) {
 				item.customizationsByLevel.forEach(level => {
+					level.features.map(f => f.feature).forEach(FeatureUpdateLogic.updateFeature);
 					level.features.forEach(feature => {
 						if (!sourcebook.imbuements.find(imbuement => imbuement.id === feature.feature.id)) {
 							sourcebook.imbuements.push(FactoryLogic.createImbuement({
@@ -338,11 +341,13 @@ export class SourcebookUpdateLogic {
 			}
 		});
 
-		sourcebook.perks.forEach(p => {
-			FeatureUpdateLogic.updateFeature(p);
-		});
+		sourcebook.perks.forEach(FeatureUpdateLogic.updateFeature);
 
 		sourcebook.subclasses.forEach(sc => {
+			sc.featuresByLevel.forEach(lvl => {
+				lvl.features.forEach(FeatureUpdateLogic.updateFeature);
+			});
+
 			if (sc.abilities === undefined) {
 				sc.abilities = [];
 			}

--- a/src/models/hero-state.ts
+++ b/src/models/hero-state.ts
@@ -2,6 +2,7 @@ import { Condition } from '@/models/condition';
 import { EncounterSlot } from '@/models/encounter-slot';
 import { Item } from '@/models/item';
 import { Project } from '@/models/project';
+import { Title } from '@/models/title';
 
 export interface HeroState {
 	staminaDamage: number;
@@ -17,6 +18,7 @@ export interface HeroState {
 	conditions: Condition[];
 	inventory: Item[];
 	projects: Project[];
+	titles: Title[];
 	controlledSlots: EncounterSlot[];
 	notes: string;
 	hidden: boolean;

--- a/to do.md
+++ b/to do.md
@@ -6,7 +6,6 @@
   * Add ability to create standalone 'reference sheets' with selectable 'reference cards'
   * (possibly solved along with above) Have ability to create handout sheets with items, followers, etc without being attached to a character
   * Check hero features/abilities for certain keywords and ensure relevant reference cards get put into the character sheet?
-  * Add user-selectable color scheme
 
 ### Library
 


### PR DESCRIPTION
Goal is to give more of a visual hierarchy/consistency to ability cards
- Moved point cost/signature pill to the right of the ability name. This keeps ability name in a consistent place across all cards
- Moved ability source tag to be with other tags for a) consistency and b) to free up space for ability name. Highlight ability source tag to distinguish from other tags.
- Moved flavor text below tags, to keep tags in consistent place across cards
- Ability tags function as horizontal divider, removed old divider
- Increased loudness on abilities that are ready to be used (eg have enough heroic resource to cast)

BEFORE:
<img width="1002" height="521" alt="image" src="https://github.com/user-attachments/assets/acc991d5-4330-4169-8d57-2bde5405303e" />

AFTER:
<img width="949" height="547" alt="image" src="https://github.com/user-attachments/assets/78de7e0f-2f12-4a4e-9fe3-2a960daeaae1" />
