### PR TITLE
Update Utils.copy to dynamically update all ids with Utils.guid

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -50,7 +50,12 @@ export class Utils {
 			return structuredClone<T>(object);
 		}
 
-		return JSON.parse(JSON.stringify(object)) as T;
+		return JSON.parse(JSON.stringify(object, (key, value) => {
+			if (key === 'id') {
+				return Utils.guid();
+			}
+			return value;
+		})) as T;
 	};
 
 	static wait = (ms: number) => {


### PR DESCRIPTION
Currently, when copying items with Utils.copy, the ids are also copied and then are manually replaced by calling Utils.guid. This is a problem for objects that contain other objects which also have IDs because those object IDs stay the same, even though they can later be edited. Fix this by dynamically updating all IDs using Utils.guid inside of Utils.copy.