### PR TITLE
Fix access token refresh with patreon connection

### DIFF
--- a/src/service/storage/warehouse-service.ts
+++ b/src/service/storage/warehouse-service.ts
@@ -54,13 +54,17 @@ export class WarehouseService implements StorageService {
 
 	private async refreshJwt() {
 		try {
-			const response = await axios.post(`${this.host}/refresh`, {}, {
-				headers: { Authorization: `Bearer ${this.refreshToken}` },
+			const refreshConfig = {
+				headers: {},
 				withCredentials: true,
 				withXSRFToken: true,
 				xsrfCookieName: 'csrf_refresh_token',
 				xsrfHeaderName: 'X-CSRF-TOKEN'
-			});
+			};
+			if (this.refreshToken) {
+				refreshConfig.headers = { Authorization: `Bearer ${this.refreshToken}` };
+			}
+			const response = await axios.post(`${this.host}/refresh`, {}, refreshConfig);
 			this.jwt = response.data.access_token;
 		} catch (error) {
 			console.error('Error communicating with FS Warehouse', error);


### PR DESCRIPTION
When connected to the patreon warehouse, it was frequently disconnecting mid-session for people, causing them to lose work, and generally being not a great user experience.

It should have been refreshing the access tokens automatically and preventing this, but I found in debugging that this was not happening like it should.

This change should resolve that issue, by not sending an empty Bearer Auth header - which seems to have been causing the backend to fail out before finding the correct cookie token value.