### PR TITLE
Add a setting to update the minion multiplier value

### DIFF
--- a/src/components/modals/encounter-tools/encounter-tools-modal.tsx
+++ b/src/components/modals/encounter-tools/encounter-tools-modal.tsx
@@ -29,13 +29,13 @@ export const EncounterToolsModal = (props: Props) => {
 		.forEach(slot => {
 			const existing = monsters.find(m => m.monster.id === slot.monsterID);
 			if (existing) {
-				existing.count += slot.count * MonsterLogic.getRoleMultiplier(existing.monster.role.organization);
+				existing.count += slot.count * MonsterLogic.getRoleMultiplier(props.options.minionMultiplier, existing.monster.role.organization);
 			} else {
 				const monster = SourcebookLogic.getMonster(props.sourcebooks, slot.monsterID);
 				if (monster) {
 					monsters.push({
 						monster: monster,
-						count: slot.count * MonsterLogic.getRoleMultiplier(monster.role.organization)
+						count: slot.count * MonsterLogic.getRoleMultiplier(props.options.minionMultiplier, monster.role.organization)
 					});
 				}
 			}

--- a/src/components/modals/settings/settings-modal.tsx
+++ b/src/components/modals/settings/settings-modal.tsx
@@ -462,6 +462,13 @@ export const SettingsModal = (props: Props) => {
 			props.setOptions(copy);
 		};
 
+		const setMinionMultiplier = (value: number) => {
+			const copy = Utils.copy(options);
+			copy.minionMultiplier = value;
+			setOptions(copy);
+			props.setOptions(copy);
+		};
+
 		return (
 			<Expander title='Monster Builder'>
 				<Space orientation='vertical' style={{ width: '100%' }}>
@@ -470,6 +477,7 @@ export const SettingsModal = (props: Props) => {
 					<Toggle label='Monster role' value={options.similarRole} onChange={setSimilarRole} />
 					<Toggle label='Monster organization' value={options.similarOrganization} onChange={setSimilarOrganization} />
 					<Toggle label='Monster size' value={options.similarSize} onChange={setSimilarSize} />
+					<NumberSpin label='Minion multiplier' min={1} value={options.minionMultiplier} onChange={setMinionMultiplier} />
 				</Space>
 			</Expander>
 		);

--- a/src/components/panels/edit/encounter-edit/encounter-edit-panel.tsx
+++ b/src/components/panels/edit/encounter-edit/encounter-edit-panel.tsx
@@ -1192,7 +1192,7 @@ const MonsterSlotPanel = (props: MonsterSlotPanelProps) => {
 					<div className='actions'>
 						<NumberSpin
 							value={props.slot.count}
-							format={value => (value * MonsterLogic.getRoleMultiplier(monster.role.organization)).toString()}
+							format={value => (value * MonsterLogic.getRoleMultiplier(props.options.minionMultiplier, monster.role.organization)).toString()}
 							onChange={value => props.setSlotCount(props.group.id, props.slot.id, value)}
 						/>
 					</div>

--- a/src/components/panels/elements/encounter-panel/encounter-panel.tsx
+++ b/src/components/panels/elements/encounter-panel/encounter-panel.tsx
@@ -79,7 +79,7 @@ export const EncounterPanel = (props: Props) => {
 											return null;
 										}
 
-										const count = slot.count * MonsterLogic.getRoleMultiplier(monster.role.organization);
+										const count = slot.count * MonsterLogic.getRoleMultiplier(props.options.minionMultiplier, monster.role.organization);
 
 										return (
 											<div key={slot.id} className='encounter-slot'>

--- a/src/components/panels/encounter-difficulty/encounter-difficulty-panel.tsx
+++ b/src/components/panels/encounter-difficulty/encounter-difficulty-panel.tsx
@@ -25,7 +25,7 @@ interface Props {
 }
 
 export const EncounterDifficultyPanel = (props: Props) => {
-	const count = EncounterLogic.getMonsterCount(props.encounter, props.sourcebooks);
+	const count = EncounterLogic.getMonsterCount(props.encounter, props.sourcebooks, props.options.minionMultiplier);
 	const budgets = EncounterDifficultyLogic.getBudgets(props.options, props.heroes);
 	const strength = EncounterDifficultyLogic.getStrength(props.encounter, props.sourcebooks);
 	const difficulty = EncounterDifficultyLogic.getDifficulty(strength, props.options, props.heroes);

--- a/src/components/panels/run/encounter-run/encounter-run-panel.tsx
+++ b/src/components/panels/run/encounter-run/encounter-run-panel.tsx
@@ -103,7 +103,7 @@ export const EncounterRunPanel = (props: Props) => {
 
 	const addSlot = (monster: Monster) => {
 		const slot = FactoryLogic.createEncounterSlot(monster.id);
-		slot.count = MonsterLogic.getRoleMultiplier(monster.role.organization);
+		slot.count = MonsterLogic.getRoleMultiplier(props.options.minionMultiplier, monster.role.organization);
 
 		while (slot.monsters.length < slot.count) {
 			const monsterCopy = Utils.copy(monster);

--- a/src/logic/encounter-logic.ts
+++ b/src/logic/encounter-logic.ts
@@ -13,7 +13,7 @@ import { SourcebookLogic } from '@/logic/sourcebook-logic';
 import { Utils } from '@/utils/utils';
 
 export class EncounterLogic {
-	static getMonsterCount = (encounter: Encounter, sourcebooks: Sourcebook[]) => {
+	static getMonsterCount = (encounter: Encounter, sourcebooks: Sourcebook[], minionMultiplier: number) => {
 		let total = 0;
 
 		encounter.groups.forEach(g => {
@@ -22,7 +22,7 @@ export class EncounterLogic {
 
 				const monster = SourcebookLogic.getMonster(sourcebooks, s.monsterID);
 				if (monster) {
-					count *= MonsterLogic.getRoleMultiplier(monster.role.organization);
+					count *= MonsterLogic.getRoleMultiplier(minionMultiplier, monster.role.organization);
 				}
 
 				total += count;

--- a/src/logic/factory-logic.ts
+++ b/src/logic/factory-logic.ts
@@ -1060,6 +1060,7 @@ export class FactoryLogic {
 			similarRole: true,
 			similarOrganization: true,
 			similarSize: true,
+			minionMultiplier: 4,
 			// Encounter
 			party: '',
 			// Encounter: Running

--- a/src/logic/monster-logic.ts
+++ b/src/logic/monster-logic.ts
@@ -224,10 +224,10 @@ export class MonsterLogic {
 		return true;
 	};
 
-	static getRoleMultiplier = (organization: MonsterOrganizationType) => {
+	static getRoleMultiplier = (minionMultiplier: number, organization: MonsterOrganizationType) => {
 		switch (organization) {
 			case MonsterOrganizationType.Minion:
-				return 4;
+				return minionMultiplier;
 		}
 
 		return 1;

--- a/src/logic/playbook-sheets/encounter-sheet-builder.ts
+++ b/src/logic/playbook-sheets/encounter-sheet-builder.ts
@@ -42,7 +42,7 @@ export class EncounterSheetBuilder {
 		sheet.successCondition = encounter.objective?.successCondition;
 		sheet.failureCondition = encounter.objective?.failureCondition;
 
-		sheet.groups = encounter.groups.map(g => this.buildEncounterGroupSheet(g, sourcebooks));
+		sheet.groups = encounter.groups.map(g => this.buildEncounterGroupSheet(g, sourcebooks, options.minionMultiplier));
 
 		const terrain = encounter.terrain.map(slot => SourcebookLogic.getTerrains(sourcebooks).find(t => t.id === slot.terrainID)).filter(t => !!t);
 		sheet.terrain = terrain;
@@ -78,8 +78,8 @@ export class EncounterSheetBuilder {
 		return sheet;
 	};
 
-	static buildEncounterGroupSheet = (group: EncounterGroup, sourcebooks: Sourcebook[]): EncounterGroupSheet => {
-		const slots = group.slots.map(s => this.buildEncounterSlotSheet(s, sourcebooks)).filter(s => !!s);
+	static buildEncounterGroupSheet = (group: EncounterGroup, sourcebooks: Sourcebook[], minionMultiplier: number): EncounterGroupSheet => {
+		const slots = group.slots.map(s => this.buildEncounterSlotSheet(s, sourcebooks, minionMultiplier)).filter(s => !!s);
 		const adjustedSlots: EncounterSlotSheet[] = [];
 		slots.forEach(slot => {
 			const existingMinion = adjustedSlots.filter(s => s.isMinion).find(s => s.monster.id === slot.monster.id);
@@ -117,13 +117,13 @@ export class EncounterSheetBuilder {
 		return sheet;
 	};
 
-	static buildEncounterSlotSheet = (slot: EncounterSlot, sourcebooks: Sourcebook[]): EncounterSlotSheet | null => {
+	static buildEncounterSlotSheet = (slot: EncounterSlot, sourcebooks: Sourcebook[], minionMultiplier: number): EncounterSlotSheet | null => {
 		const monster = EncounterLogic.getCustomizedMonster(slot.monsterID, slot.customization, sourcebooks);
 		if (!monster) {
 			console.error('Failed to get monster for encounter slot:', slot);
 			return null;
 		}
-		const roleMult = MonsterLogic.getRoleMultiplier(monster.role.organization);
+		const roleMult = MonsterLogic.getRoleMultiplier(minionMultiplier, monster.role.organization);
 		const sheet: EncounterSlotSheet = {
 			id: slot.id,
 			monster: monster,

--- a/src/logic/session-logic.ts
+++ b/src/logic/session-logic.ts
@@ -28,7 +28,7 @@ export class SessionLogic {
 				const monster = EncounterLogic.getCustomizedMonster(slot.monsterID, slot.customization, sourcebooks);
 				const monsterGroup = SourcebookLogic.getMonsterGroup(sourcebooks, slot.monsterID);
 				if (monster && monsterGroup) {
-					const count = slot.count * MonsterLogic.getRoleMultiplier(monster.role.organization);
+					const count = slot.count * MonsterLogic.getRoleMultiplier(options.minionMultiplier, monster.role.organization);
 					const current = monsterInfo.find(info => info.monsterID === slot.monsterID);
 					if (current) {
 						current.count += count;
@@ -49,7 +49,7 @@ export class SessionLogic {
 			.forEach(slot => {
 				const info = monsterInfo.find(info => info.monsterID === slot.monsterID);
 				if (info) {
-					const count = slot.count * MonsterLogic.getRoleMultiplier(info.monster.role.organization);
+					const count = slot.count * MonsterLogic.getRoleMultiplier(options.minionMultiplier, info.monster.role.organization);
 					for (let n = 1; n <= count; ++n) {
 						const monsterCopy = Utils.copy(info.monster);
 						monsterCopy.id = Utils.guid();

--- a/src/models/options.ts
+++ b/src/models/options.ts
@@ -28,6 +28,7 @@ export interface Options {
 	similarRole: boolean;
 	similarOrganization: boolean;
 	similarSize: boolean;
+	minionMultiplier: number;
 	// Encounter
 	party: string;
 	// Encounter: Running


### PR DESCRIPTION
This change allows users to set the minion multiplier to 1 (or another numerical value) and add a number of minions to encounter groups that isn't divisible by 4 (e.g. adding 10 minions). This is supported by modules which use a number of minions that aren't divisible by 4 and uses monsters that add minions to the map that aren't divisible by 4.