### PR TITLE
Add tag indicating current data storage to app footer

### DIFF
--- a/src/components/main/main.tsx
+++ b/src/components/main/main.tsx
@@ -1813,7 +1813,8 @@ export const Main = (props: Props) => {
 		showAbout: showAbout,
 		showSettings: showSettings,
 		showErrors: showErrors,
-		setOptions: persistOptions
+		setOptions: persistOptions,
+		connectionSettings: connectionSettings
 	};
 
 	return (

--- a/src/components/panels/app-footer/app-footer.tsx
+++ b/src/components/panels/app-footer/app-footer.tsx
@@ -1,17 +1,17 @@
-import { BookOutlined, InfoCircleOutlined, PlayCircleOutlined, ReadOutlined, SettingOutlined, TeamOutlined, WarningFilled } from '@ant-design/icons';
-import { Button, Divider, Drawer, Flex, Space } from 'antd';
+import { BookOutlined, DatabaseFilled, InfoCircleOutlined, PlayCircleOutlined, ReadOutlined, SettingOutlined, TeamOutlined, WarningFilled } from '@ant-design/icons';
+import { Button, Divider, Drawer, Flex, Space, Tag } from 'antd';
 import { ButtonConfig, ButtonGroup } from '@/components/controls/button-group/button-group';
+import { ConnectionSettings } from '@/models/connection-settings';
 import { ErrorBoundary } from '@/components/controls/error-boundary/error-boundary';
 import { Modal } from '@/components/modals/modal/modal';
 import { Options } from '@/models/options';
 import { SyncStatus } from '@/components/panels/sync-status/sync-status';
+import shield from '@/assets/shield.png';
 import { useIsSmall } from '@/hooks/use-is-small';
 import { useNavigation } from '@/hooks/use-navigation';
 import { useState } from 'react';
 
 import './app-footer.scss';
-
-import shield from '@/assets/shield.png';
 
 export interface FooterParams {
 	errorsExist: boolean;
@@ -20,6 +20,7 @@ export interface FooterParams {
 	showSettings: () => void;
 	showErrors: () => void;
 	setOptions: (options: Options) => void;
+	connectionSettings: ConnectionSettings;
 }
 
 interface Props {
@@ -50,6 +51,8 @@ export const AppFooter = (props: Props) => {
 	if (props.params.errorsExist) {
 		actions.push({ type: 'button', icon: <WarningFilled className='danger' />, tooltip: 'Errors', onClick: props.params.showErrors });
 	}
+
+	const dataSource = props.params.connectionSettings.dataSource;
 
 	return (
 		<ErrorBoundary>
@@ -83,8 +86,21 @@ export const AppFooter = (props: Props) => {
 						/>
 						: null
 				}
-				<SyncStatus />
-				<ButtonGroup buttons={actions} />
+				<Space>
+					<SyncStatus />
+					{
+						dataSource ?
+							<Tag
+								icon={<DatabaseFilled />}
+								variant='outlined'
+								color='blue'
+							>
+								{dataSource}
+							</Tag>
+							: null
+					}
+					<ButtonGroup buttons={actions} />
+				</Space>
 			</div>
 			<Drawer open={showSidebar} onClose={() => setShowSidebar(false)} closeIcon={null} size={500}>
 				<Modal

--- a/src/components/panels/connection-settings/patreon-connect-panel.tsx
+++ b/src/components/panels/connection-settings/patreon-connect-panel.tsx
@@ -26,6 +26,14 @@ export const PatreonConnectPanel = (props: Props) => {
 		service.getPatreonAuthUrl()
 			.then(authorizationUrl => {
 				window.location.href = authorizationUrl;
+			})
+			.catch(err => {
+				console.error(err);
+				notification.error({
+					title: 'Error connecting with Patreon',
+					description: Utils.getErrorMessage(err),
+					placement: 'top'
+				});
 			});
 	};
 
@@ -53,7 +61,7 @@ export const PatreonConnectPanel = (props: Props) => {
 			.then(setPatreonSession)
 			.catch(err => {
 				console.error(err);
-				notify.error({
+				notification.error({
 					title: 'Error connecting with Patreon',
 					description: Utils.getErrorMessage(err),
 					placement: 'top'

--- a/src/components/panels/data-loader/data-loader.tsx
+++ b/src/components/panels/data-loader/data-loader.tsx
@@ -1,8 +1,8 @@
 import { Alert, Button, Flex, Tag } from 'antd';
+import { ConnectionSettings, FSDataSource } from '@/models/connection-settings';
 import { SetStateAction, useEffect, useState } from 'react';
 import { CheckIcon } from '@/components/controls/check-icon/check-icon';
 import { CheckLabel } from '@/components/controls/check-label/check-label';
-import { ConnectionSettings } from '@/models/connection-settings';
 import { ConnectionSettingsPanel } from '@/components/panels/connection-settings/connection-settings-panel';
 import { ConnectionSettingsUpdateLogic } from '@/logic/update/connection-settings-update-logic';
 import { DataService } from '@/utils/data-service';
@@ -42,7 +42,6 @@ interface Props {
 }
 
 type LoadingStatus = 'pending' | 'success' | 'failure' | undefined;
-type DataSource = 'Local' | 'Patron' | 'Warehouse' | undefined;
 
 export const DataLoader = (props: Props) => {
 	const [ connectionSettingsState, setConnectionSettingsState ] = useState<LoadingStatus>(undefined);
@@ -53,7 +52,7 @@ export const DataLoader = (props: Props) => {
 	const [ hiddenSettingsState, setHiddenSettingsState ] = useState<LoadingStatus>(undefined);
 	const [ overallLoadState, setOverallLoadState ] = useState<LoadingStatus>('pending');
 	const [ connectionSettings, setConnectionSettings ] = useState<ConnectionSettings | null>(null);
-	const [ dataSource, setDataSource ] = useState<DataSource>(undefined);
+	const [ dataSource, setDataSource ] = useState<FSDataSource>(undefined);
 	const [ error, setError ] = useState<string | null>(null);
 
 	async function initializeConnectionSettings() {
@@ -63,7 +62,7 @@ export const DataLoader = (props: Props) => {
 		}
 		ConnectionSettingsUpdateLogic.updateSettings(settings);
 
-		let source: DataSource = undefined;
+		let source: FSDataSource = undefined;
 
 		// check patreon status
 		if (settings.patreonConnected) {
@@ -95,6 +94,7 @@ export const DataLoader = (props: Props) => {
 		if (!url.match(/oauth-redirect/)) {
 			setDataSource(source);
 		}
+		settings.dataSource = source;
 
 		return settings;
 	};

--- a/src/components/panels/sync-status/sync-status.scss
+++ b/src/components/panels/sync-status/sync-status.scss
@@ -8,4 +8,8 @@
 	&.offline {
 		color: rgb(128, 0, 0);
 	}
+
+	&.none {
+		width: 14px;
+	}
 }

--- a/src/components/panels/sync-status/sync-status.tsx
+++ b/src/components/panels/sync-status/sync-status.tsx
@@ -15,7 +15,7 @@ export const SyncStatus = () => {
 		return (
 			<ErrorBoundary>
 				<div className='sync-status offline'>
-					<WifiOutlined title={statusMessage} />;
+					<WifiOutlined title={statusMessage} />
 				</div>
 			</ErrorBoundary>
 		);
@@ -30,6 +30,10 @@ export const SyncStatus = () => {
 			</ErrorBoundary>
 		);
 	}
-
-	return null;
+	return (
+		<ErrorBoundary>
+			<div className='sync-status none'>
+			</div>
+		</ErrorBoundary>
+	);
 };

--- a/src/models/connection-settings.ts
+++ b/src/models/connection-settings.ts
@@ -1,5 +1,7 @@
 import { PatreonConnection } from '@/models/patreon-connection';
 
+export type FSDataSource = 'Local' | 'Patron' | 'Warehouse' | undefined;
+
 export interface ConnectionSettings {
 	useManualWarehouse: boolean;
 	warehouseHost: string;
@@ -7,4 +9,5 @@ export interface ConnectionSettings {
 	patreonConnected: boolean;
 	usePatreonWarehouse: boolean;
 	patreonConnections: PatreonConnection[];
+	dataSource: FSDataSource;
 }


### PR DESCRIPTION
Adds a tag to the app footer that shows which data store is being used.

<img width="402" height="55" alt="image" src="https://github.com/user-attachments/assets/69f1effa-000b-4054-9128-17cc7623b6fd" />
