### PR TITLE
Heroes data load update

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
 		"react-dom": "^19.2.6",
 		"react-router": "^7.15.0",
 		"sass": "^1.99.0",
-		"showdown": "^2.1.0"
+		"showdown": "^2.1.0",
+		"uuid": "^14.0.0"
 	},
 	"devDependencies": {
 		"@eslint/js": "^10.0.1",

--- a/src/components/main/main.tsx
+++ b/src/components/main/main.tsx
@@ -1614,7 +1614,7 @@ export const Main = (props: Props) => {
 
 	const onSelectFeature = (feature: Feature, hero: Hero) => {
 		const sourcebooks = SourcebookLogic.getSourcebooks(homebrewSourcebooks)
-			.filter(sb => hero.settingIDs.includes(sb.id));
+			.filter(sb => hero.sourcebookIDs.includes(sb.id));
 
 		setDrawer(
 			<FeatureModal
@@ -1641,7 +1641,7 @@ export const Main = (props: Props) => {
 
 	const onShowHeroState = (hero: Hero, type: HeroModalType) => {
 		const sourcebooks = SourcebookLogic.getSourcebooks(homebrewSourcebooks)
-			.filter(sb => hero.settingIDs.includes(sb.id));
+			.filter(sb => hero.sourcebookIDs.includes(sb.id));
 
 		const takeRespite = () => {
 			const copy = Utils.copy(hero);

--- a/src/components/main/main.tsx
+++ b/src/components/main/main.tsx
@@ -203,20 +203,51 @@ export const Main = (props: Props) => {
 			});
 	};
 
-	const persistHomebrewSourcebooks = (homebrew: Sourcebook[]) => {
+	const persistHomebrewSourcebook = (homebrew: Sourcebook) => {
+		let newHomebrew: Sourcebook[];
+		if (homebrewSourcebooks.some(h => h.id === homebrew.id)) {
+			const copy = Utils.copy(homebrewSourcebooks);
+			const list = copy.map(h => h.id === homebrew.id ? homebrew : h);
+			newHomebrew = list;
+		} else {
+			const copy = Utils.copy(homebrewSourcebooks);
+			copy.push(homebrew);
+			Collections.sort(copy, h => h.name);
+			newHomebrew = copy;
+		}
+
 		return dataService
-			.saveHomebrew(homebrew)
-			.then(
-				setHomebrewSourcebooks,
-				err => {
-					console.error(err);
-					notify.error({
-						title: 'Error saving sourcebooks',
-						description: Utils.getErrorMessage(err),
-						placement: 'top'
-					});
-				}
-			);
+			.saveSourcebook(homebrew)
+			.then(() => setHomebrewSourcebooks(newHomebrew))
+			.catch(err => {
+				console.error(err);
+				notify.error({
+					title: 'Error saving sourcebooks',
+					description: Utils.getErrorMessage(err),
+					placement: 'top'
+				});
+			})
+			.then(() => {
+				// Trigger sync when data changes
+				triggerSyncOnChange();
+			});
+	};
+
+	const deleteHomebrewSourcebook = (homebrew: Sourcebook) => {
+		const copy = Utils.copy(homebrewSourcebooks.filter(h => h.id !== homebrew.id));
+
+		return dataService.deleteSourcebook(homebrew.id)
+			.then(() => {
+				setHomebrewSourcebooks(copy);
+			})
+			.catch(err => {
+				console.error(err);
+				notify.error({
+					title: 'Error deleting Sourcebook',
+					description: Utils.getErrorMessage(err),
+					placement: 'top'
+				});
+			});
 	};
 
 	const persistHiddenSourcebookIDs = (ids: string[]) => {
@@ -813,7 +844,6 @@ export const Main = (props: Props) => {
 		let sourcebook = sourcebooks.find(sb => sb.id === sourcebookID) || null;
 		if (!sourcebook) {
 			sourcebook = FactoryLogic.createSourcebook();
-			sourcebooks.push(sourcebook);
 		}
 
 		let id = '';
@@ -880,7 +910,8 @@ export const Main = (props: Props) => {
 				break;
 		}
 
-		persistHomebrewSourcebooks(sourcebooks).then(() => navigation.goToLibraryEdit(kind, sourcebook.id, id));
+		persistHomebrewSourcebook(sourcebook)
+			.then(() => navigation.goToLibraryEdit(kind, sourcebook.id, id));
 	};
 
 	const moveLibraryElement = (kind: SourcebookElementKind, sourcebookID: string, element: Element) => {
@@ -958,7 +989,6 @@ export const Main = (props: Props) => {
 		let destinationSourcebook = sourcebooks.find(sb => sb.id === sourcebookID) || null;
 		if (!destinationSourcebook) {
 			destinationSourcebook = FactoryLogic.createSourcebook();
-			sourcebooks.push(destinationSourcebook);
 		}
 
 		switch (kind) {
@@ -1044,7 +1074,7 @@ export const Main = (props: Props) => {
 				break;
 		}
 
-		persistHomebrewSourcebooks(sourcebooks);
+		persistHomebrewSourcebook(destinationSourcebook);
 	};
 
 	const deleteLibraryElement = (kind: SourcebookElementKind, sourcebookID: string, element: Element) => {
@@ -1113,10 +1143,12 @@ export const Main = (props: Props) => {
 					sourcebook.titles = sourcebook.titles.filter(x => x.id !== element.id);
 					break;
 			}
+
+			persistHomebrewSourcebook(sourcebook)
+				.then(() => navigation.goToLibrary(kind, element.id));
 		}
 
 		setDrawer(null);
-		persistHomebrewSourcebooks(copy).then(() => navigation.goToLibrary(kind, element.id));
 	};
 
 	const saveLibraryElement = (kind: SourcebookElementKind, sourcebookID: string, element: Element) => {
@@ -1187,18 +1219,19 @@ export const Main = (props: Props) => {
 					sourcebook.titles = sourcebook.titles.map(x => x.id === element.id ? element : x) as Title[];
 					break;
 			}
+
+			persistHomebrewSourcebook(sourcebook)
+				.then(() => {
+					const heroesCopy = Utils.copy(heroes);
+					heroesCopy
+						.filter(hero => hero.sourcebookIDs.includes(sourcebook.id))
+						.forEach(hero => {
+							HeroUpdateLogic.updateHero(hero, SourcebookLogic.getSourcebooks(copy));
+							persistHero(hero);
+						});
+				})
+				.then(() => navigation.goToLibrary(kind, element.id));
 		}
-
-		persistHomebrewSourcebooks(copy)
-			.then(() => {
-				const heroesCopy = Utils.copy(heroes);
-				heroesCopy.forEach(hero => HeroUpdateLogic.updateHero(hero, SourcebookLogic.getSourcebooks(copy)));
-
-				// TODO: save individually?? seems not great.
-				// Probably add logic to only call update on relevant heroes, and save those?
-				setHeroes(heroesCopy);
-			})
-			.then(() => navigation.goToLibrary(kind, element.id));
 	};
 
 	const importLibraryElement = (kind: SourcebookElementKind, sourcebookID: string, element: Element) => {
@@ -1216,7 +1249,6 @@ export const Main = (props: Props) => {
 		let sourcebook = copy.find(sb => sb.id === sourcebookID);
 		if (!sourcebook) {
 			sourcebook = FactoryLogic.createSourcebook();
-			copy.push(sourcebook);
 		}
 
 		switch (kind) {
@@ -1305,7 +1337,8 @@ export const Main = (props: Props) => {
 		SourcebookUpdateLogic.updateSourcebook(sourcebook);
 
 		setDrawer(null);
-		persistHomebrewSourcebooks(copy).then(() => navigation.goToLibrary(kind));
+		persistHomebrewSourcebook(sourcebook)
+			.then(() => navigation.goToLibrary(kind));
 	};
 
 	const exportLibraryElementData = (category: string, element: Element) => {
@@ -1755,11 +1788,7 @@ export const Main = (props: Props) => {
 						allSourcebooks={SourcebookLogic.getSourcebooks(homebrewSourcebooks)}
 						options={options}
 						onClose={() => setDrawer(null)}
-						onImportSourcebook={sourcebook => {
-							const copy = Utils.copy(homebrewSourcebooks);
-							copy.push(sourcebook);
-							persistHomebrewSourcebooks(copy);
-						}}
+						onImportSourcebook={persistHomebrewSourcebook}
 						onChange={persistHero}
 					/>
 				);
@@ -1799,7 +1828,8 @@ export const Main = (props: Props) => {
 				homebrewSourcebooks={homebrewSourcebooks}
 				hiddenSourcebookIDs={hiddenSourcebookIDs}
 				onClose={() => setDrawer(null)}
-				onHomebrewSourcebookChange={persistHomebrewSourcebooks}
+				onHomebrewSourcebookChange={persistHomebrewSourcebook}
+				onHomebrewSourcebookDelete={deleteHomebrewSourcebook}
 				onHiddenSourcebookIDsChange={persistHiddenSourcebookIDs}
 			/>
 		);
@@ -1936,11 +1966,7 @@ export const Main = (props: Props) => {
 									options={options}
 									params={footerParams}
 									saveChanges={saveHero}
-									importSourcebook={sourcebook => {
-										const copy = Utils.copy(homebrewSourcebooks);
-										copy.push(sourcebook);
-										persistHomebrewSourcebooks(copy);
-									}}
+									importSourcebook={persistHomebrewSourcebook}
 								/>
 							}
 						/>

--- a/src/components/main/main.tsx
+++ b/src/components/main/main.tsx
@@ -147,42 +147,29 @@ export const Main = (props: Props) => {
 	// #region Persistence
 
 	const persistHero = (hero: Hero) => {
+		let newHeroes: Hero[];
 		if (heroes.some(h => h.id === hero.id)) {
 			Analytics.logHeroEdited(hero);
 
 			const copy = Utils.copy(heroes);
 			const list = copy.map(h => h.id === hero.id ? hero : h);
-
-			return persistHeroes(list);
+			newHeroes = list;
 		} else {
 			Analytics.logHeroCreated(hero);
 
 			const copy = Utils.copy(heroes);
 			copy.push(hero);
 			Collections.sort(copy, h => h.name);
-
-			return persistHeroes(copy);
+			newHeroes = copy;
 		}
-	};
 
-	const persistHeroes = (heroes: Hero[]) => {
 		return dataService
-			.saveHeroes(Collections.sort(heroes, h => h.name))
-			.then(
-				setHeroes,
-				err => {
-					console.error(err);
-					notify.error({
-						title: 'Error saving heroes',
-						description: Utils.getErrorMessage(err),
-						placement: 'top'
-					});
-				}
-			)
+			.saveHero(hero)
+			.then(() => setHeroes(newHeroes))
 			.catch(err => {
 				console.error(err);
 				notify.error({
-					title: 'Error saving heroes',
+					title: 'Error saving hero',
 					description: Utils.getErrorMessage(err),
 					placement: 'top'
 				});
@@ -306,7 +293,19 @@ export const Main = (props: Props) => {
 		const stayInFolder = copy.some(h => h.folder === hero.folder);
 		navigation.goToHeroList(stayInFolder ? hero.folder : undefined);
 
-		persistHeroes(copy);
+		return dataService.deleteHero(hero.id)
+			.then(() => {
+				setHeroes(copy);
+				navigation.goToHeroList(stayInFolder ? hero.folder : undefined);
+			})
+			.catch(err => {
+				console.error(err);
+				notify.error({
+					title: 'Error deleting hero',
+					description: Utils.getErrorMessage(err),
+					placement: 'top'
+				});
+			});
 	};
 
 	const saveHero = (hero: Hero) => {
@@ -1194,7 +1193,10 @@ export const Main = (props: Props) => {
 			.then(() => {
 				const heroesCopy = Utils.copy(heroes);
 				heroesCopy.forEach(hero => HeroUpdateLogic.updateHero(hero, SourcebookLogic.getSourcebooks(copy)));
-				persistHeroes(heroesCopy);
+
+				// TODO: save individually?? seems not great.
+				// Probably add logic to only call update on relevant heroes, and save those?
+				setHeroes(heroesCopy);
 			})
 			.then(() => navigation.goToLibrary(kind, element.id));
 	};

--- a/src/components/modals/reference/reference-modal.tsx
+++ b/src/components/modals/reference/reference-modal.tsx
@@ -145,7 +145,7 @@ export const ReferenceModal = (props: Props) => {
 	};
 
 	const getSkillsSection = () => {
-		const sourcebooks = props.hero ? props.hero.settingIDs.map(id => props.sourcebooks.find(s => s.id === id)).filter(s => !!s) : props.sourcebooks;
+		const sourcebooks = props.hero ? props.hero.sourcebookIDs.map(id => props.sourcebooks.find(s => s.id === id)).filter(s => !!s) : props.sourcebooks;
 		const allSkills = SourcebookLogic.getSkills(sourcebooks);
 		const skillNames = props.hero ? HeroLogic.getSkills(props.hero, sourcebooks).map(s => s.name) : [];
 
@@ -183,7 +183,7 @@ export const ReferenceModal = (props: Props) => {
 	};
 
 	const getLanguagesSection = () => {
-		const sourcebooks = props.hero ? props.hero.settingIDs.map(id => props.sourcebooks.find(s => s.id === id)).filter(s => !!s) : props.sourcebooks;
+		const sourcebooks = props.hero ? props.hero.sourcebookIDs.map(id => props.sourcebooks.find(s => s.id === id)).filter(s => !!s) : props.sourcebooks;
 		const allLanguages = SourcebookLogic.getLanguages(sourcebooks);
 		const languageNames = props.hero ? HeroLogic.getLanguages(props.hero, sourcebooks).map(l => l.name) : [];
 

--- a/src/components/modals/sourcebooks/sourcebooks-modal.tsx
+++ b/src/components/modals/sourcebooks/sourcebooks-modal.tsx
@@ -25,7 +25,8 @@ interface Props {
 	hiddenSourcebookIDs: string[];
 	heroes: Hero[];
 	onClose: () => void;
-	onHomebrewSourcebookChange: (Sourcebooks: Sourcebook[]) => void;
+	onHomebrewSourcebookChange: (sourcebook: Sourcebook) => void;
+	onHomebrewSourcebookDelete: (sourcebook: Sourcebook) => void;
 	onHiddenSourcebookIDsChange: (ids: string[]) => void;
 }
 
@@ -54,16 +55,15 @@ export const SourcebooksModal = (props: Props) => {
 		if (index !== -1) {
 			copy[index] = sourcebook;
 			setHomebrewSourcebooks(copy);
-			props.onHomebrewSourcebookChange(copy);
 		}
+		props.onHomebrewSourcebookChange(sourcebook);
 	};
 
 	const deleteSourcebook = (sourcebook: Sourcebook) => {
 		setSelectedSourcebook(null);
-
 		const copy = Utils.copy(homebrewSourcebooks.filter(s => s.id !== sourcebook.id));
 		setHomebrewSourcebooks(copy);
-		props.onHomebrewSourcebookChange(copy);
+		props.onHomebrewSourcebookDelete(sourcebook);
 	};
 
 	const getContent = () => {
@@ -82,7 +82,7 @@ export const SourcebooksModal = (props: Props) => {
 										<SourcebookPanel
 											sourcebook={s}
 											heroes={props.heroes}
-											sourcebooks={[ ...props.officialSourcebooks, ...props.homebrewSourcebooks ]}
+											sourcebooks={[ ...props.officialSourcebooks, ...homebrewSourcebooks ]}
 											visibility={{
 												visible: !hiddenSourcebookIDs.includes(s.id),
 												onSetVisibility: (value: boolean) => setVisibility(s, value)
@@ -121,7 +121,7 @@ export const SourcebooksModal = (props: Props) => {
 										<SourcebookPanel
 											sourcebook={s}
 											heroes={props.heroes}
-											sourcebooks={[ ...props.officialSourcebooks, ...props.homebrewSourcebooks ]}
+											sourcebooks={[ ...props.officialSourcebooks, ...homebrewSourcebooks ]}
 											visibility={{
 												visible: !hiddenSourcebookIDs.includes(s.id),
 												onSetVisibility: (value: boolean) => setVisibility(s, value)
@@ -160,7 +160,7 @@ export const SourcebooksModal = (props: Props) => {
 										<SourcebookPanel
 											sourcebook={s}
 											heroes={props.heroes}
-											sourcebooks={[ ...props.officialSourcebooks, ...props.homebrewSourcebooks ]}
+											sourcebooks={[ ...props.officialSourcebooks, ...homebrewSourcebooks ]}
 											visibility={{
 												visible: !hiddenSourcebookIDs.includes(s.id),
 												onSetVisibility: (value: boolean) => setVisibility(s, value)
@@ -184,14 +184,14 @@ export const SourcebooksModal = (props: Props) => {
 					const sourcebook = FactoryLogic.createSourcebook();
 					copy.push(sourcebook);
 					setHomebrewSourcebooks(copy);
-					props.onHomebrewSourcebookChange(copy);
+					props.onHomebrewSourcebookChange(sourcebook);
 				};
 
 				const importSourcebook = (sourcebook: Sourcebook) => {
 					const copy = Utils.copy(homebrewSourcebooks);
 					copy.push(sourcebook);
 					setHomebrewSourcebooks(copy);
-					props.onHomebrewSourcebookChange(copy);
+					props.onHomebrewSourcebookChange(sourcebook);
 				};
 
 				return (

--- a/src/components/pages/heroes/hero-edit/hero-edit-page.tsx
+++ b/src/components/pages/heroes/hero-edit/hero-edit-page.tsx
@@ -143,7 +143,7 @@ export const HeroEditPage = (props: Props) => {
 	};
 
 	const clearRedundantSelections = (hero: Hero, features: Feature[]) => {
-		const sourcebooks = props.sourcebooks.filter(sb => hero.settingIDs.includes(sb.id));
+		const sourcebooks = props.sourcebooks.filter(sb => hero.sourcebookIDs.includes(sb.id));
 		const knownLanguages = HeroLogic.getLanguages(hero, sourcebooks).map(language => language.name);
 		const knownSkills = HeroLogic.getSkills(hero, sourcebooks).map(skill => skill.name);
 		features.forEach(feature => {
@@ -379,7 +379,7 @@ export const HeroEditPage = (props: Props) => {
 
 	const setSettingIDs = (settingIDs: string[]) => {
 		const heroCopy = Utils.copy(hero);
-		heroCopy.settingIDs = settingIDs;
+		heroCopy.sourcebookIDs = settingIDs;
 		setHero(heroCopy);
 		setDirty(true);
 	};
@@ -512,7 +512,7 @@ export const HeroEditPage = (props: Props) => {
 			case 'start':
 				return (
 					<StartSection
-						sourcebookIDs={hero.settingIDs}
+						sourcebookIDs={hero.sourcebookIDs}
 						sourcebooks={props.sourcebooks}
 						setSourcebookIDs={setSettingIDs}
 						importSourcebook={props.importSourcebook}
@@ -522,7 +522,7 @@ export const HeroEditPage = (props: Props) => {
 				return (
 					<AncestrySection
 						hero={hero}
-						sourcebooks={props.sourcebooks.filter(sb => hero.settingIDs.includes(sb.id))}
+						sourcebooks={props.sourcebooks.filter(sb => hero.sourcebookIDs.includes(sb.id))}
 						options={props.options}
 						searchTerm={searchTerm}
 						selectAncestry={setAncestry}
@@ -533,7 +533,7 @@ export const HeroEditPage = (props: Props) => {
 				return (
 					<CultureSection
 						hero={hero}
-						sourcebooks={props.sourcebooks.filter(sb => hero.settingIDs.includes(sb.id))}
+						sourcebooks={props.sourcebooks.filter(sb => hero.sourcebookIDs.includes(sb.id))}
 						options={props.options}
 						searchTerm={searchTerm}
 						selectCulture={setCulture}
@@ -547,7 +547,7 @@ export const HeroEditPage = (props: Props) => {
 				return (
 					<CareerSection
 						hero={hero}
-						sourcebooks={props.sourcebooks.filter(sb => hero.settingIDs.includes(sb.id))}
+						sourcebooks={props.sourcebooks.filter(sb => hero.sourcebookIDs.includes(sb.id))}
 						options={props.options}
 						searchTerm={searchTerm}
 						selectCareer={setCareer}
@@ -559,7 +559,7 @@ export const HeroEditPage = (props: Props) => {
 				return (
 					<ClassSection
 						hero={hero}
-						sourcebooks={props.sourcebooks.filter(sb => hero.settingIDs.includes(sb.id))}
+						sourcebooks={props.sourcebooks.filter(sb => hero.sourcebookIDs.includes(sb.id))}
 						options={props.options}
 						searchTerm={searchTerm}
 						selectClass={setClass}
@@ -575,7 +575,7 @@ export const HeroEditPage = (props: Props) => {
 				return (
 					<ComplicationSection
 						hero={hero}
-						sourcebooks={props.sourcebooks.filter(sb => hero.settingIDs.includes(sb.id))}
+						sourcebooks={props.sourcebooks.filter(sb => hero.sourcebookIDs.includes(sb.id))}
 						options={props.options}
 						searchTerm={searchTerm}
 						selectComplication={setComplication}
@@ -587,7 +587,7 @@ export const HeroEditPage = (props: Props) => {
 					<DetailsSection
 						hero={hero}
 						allHeroes={props.heroes}
-						sourcebooks={props.sourcebooks.filter(sb => hero.settingIDs.includes(sb.id))}
+						sourcebooks={props.sourcebooks.filter(sb => hero.sourcebookIDs.includes(sb.id))}
 						options={props.options}
 						setName={setName}
 						setPicture={setPicture}

--- a/src/components/pages/transfer/transfer-page.tsx
+++ b/src/components/pages/transfer/transfer-page.tsx
@@ -54,20 +54,32 @@ export const TransferPage = (props: Props) => {
 		return ds;
 	}, [ props.connectionSettings ]);
 
-	const mergeToWarehouse = () => {
+	const mergeToWarehouse = async () => {
 		const mergedHeroes = HeroMergeLogic.merge(localHeroes, remoteHeroes, mergeBehavior);
-		warehouseDs.saveHeroes(mergedHeroes).then(setRemoteHeroes);
+		for await (const hero of mergedHeroes) {
+			await warehouseDs.saveHero(hero);
+		}
+		setRemoteHeroes(mergedHeroes);
 
 		const mergedSourcebooks = SourcebookMergeLogic.merge(localHomebrewSourcebooks, remoteHomebrewSourcebooks, mergeBehavior);
-		warehouseDs.saveHomebrew(mergedSourcebooks).then(setRemoteHomebrewSourcebooks);
+		for await (const sourcebook of mergedSourcebooks) {
+			await warehouseDs.saveSourcebook(sourcebook);
+		}
+		setRemoteHomebrewSourcebooks(mergedSourcebooks);
 	};
 
-	const copyToLocal = () => {
+	const copyToLocal = async () => {
 		const heroesCopy = Utils.copy(remoteHeroes);
-		localDs.saveHeroes(heroesCopy).then(setLocalHeroes);
+		for await (const hero of heroesCopy) {
+			await localDs.saveHero(hero);
+		}
+		setLocalHeroes(heroesCopy);
 
 		const homebrewCopy = Utils.copy(remoteHomebrewSourcebooks);
-		localDs.saveHomebrew(homebrewCopy).then(setLocalHomebrewSourcebooks);
+		for await (const sourcebook of homebrewCopy) {
+			await localDs.saveSourcebook(sourcebook);
+		}
+		setLocalHomebrewSourcebooks(homebrewCopy);
 	};
 
 	const initializeData = () => {
@@ -87,11 +99,12 @@ export const TransferPage = (props: Props) => {
 
 		setLoadingRemoteHeroes(true);
 		warehouseDs.getHeroes()
-			.then(heroes => {
-				if (heroes !== null) {
-					setRemoteHeroes(heroes);
-				}
-				setLoadingRemoteHeroes(false);
+			.then(heroPartials => {
+				const getHeroPromises = heroPartials.map(p => warehouseDs.getHero(p.id));
+				Promise.all(getHeroPromises)
+					.then(results => results.filter(h => !!h))
+					.then(setRemoteHeroes)
+					.then(() => setLoadingRemoteHeroes(false));
 			});
 
 		setLoadingRemoteHomebrew(true);

--- a/src/components/panels/data-loader/data-loader.tsx
+++ b/src/components/panels/data-loader/data-loader.tsx
@@ -20,7 +20,6 @@ import { Session } from '@/models/session';
 import { SessionUpdateLogic } from '@/logic/update/session-update-logic';
 import { Sourcebook } from '@/models/sourcebook';
 import { SourcebookLogic } from '@/logic/sourcebook-logic';
-import { SourcebookType } from '@/enums/sourcebook-type';
 import { SourcebookUpdateLogic } from '@/logic/update/sourcebook-update-logic';
 import { StorageServiceFactory } from '@/services/storage/storage-service-factory';
 import localforage from 'localforage';
@@ -130,7 +129,7 @@ export const DataLoader = (props: Props) => {
 			});
 	};
 
-	async function getHero(getterPromise: Promise<Hero | null>, progressPercent: number): Promise<Hero | null> {
+	async function getHeroUpdateProgress(getterPromise: Promise<Hero | null>, progressPercent: number): Promise<Hero | null> {
 		return getterPromise
 			.then(hero => {
 				setHeroesProgress(heroesProgress => heroesProgress + progressPercent);
@@ -152,7 +151,7 @@ export const DataLoader = (props: Props) => {
 		const incrementPct = 100.0 / heroPartials.length;
 
 		const getHeroPromises = heroPartials.map(p => {
-			return getHero(dataService.getHero(p.id), incrementPct);
+			return getHeroUpdateProgress(dataService.getHero(p.id), incrementPct);
 		});
 
 		return Promise.all(getHeroPromises)
@@ -190,25 +189,16 @@ export const DataLoader = (props: Props) => {
 				];
 
 				Promise.all(promises).then(results => {
-					// #region Homebrew sourcebooks
-					let sourcebooks = results[0] as Sourcebook[] | null;
-					if (!sourcebooks) {
-						sourcebooks = [];
-					}
-
+					const sourcebooks = results[0] as Sourcebook[];
 					sourcebooks.forEach(sourcebook => {
-						sourcebook.type = SourcebookType.Homebrew;
 						try {
 							SourcebookUpdateLogic.updateSourcebook(sourcebook);
 						} catch (error) {
 							console.error(`Error while updating sourcebook [${sourcebook.name} - ${sourcebook.id}]`, error);
 						}
 					});
-					// #endregion
 
-					// #region Heroes
 					const heroes = results[1] as Hero[];
-
 					heroes.forEach(hero => {
 						try {
 							HeroUpdateLogic.updateHero(hero, SourcebookLogic.getSourcebooks(sourcebooks));
@@ -216,32 +206,14 @@ export const DataLoader = (props: Props) => {
 							console.error(`Error while updating hero [${hero.name} - ${hero.id}]`, error);
 						}
 					});
-					// #endregion
 
-					// #region Hidden sourcebook IDs
-					let hiddenSourcebookIDs = results[2] as string[] | null;
-					if (!hiddenSourcebookIDs) {
-						hiddenSourcebookIDs = [];
-					}
-					// #endregion
+					const hiddenSourcebookIDs = results[2] as string[];
 
-					// #region Session
-					let session = results[3] as Session | null;
-					if (!session) {
-						session = FactoryLogic.createSession();
-					}
-
+					const session = results[3] as Session;
 					SessionUpdateLogic.updateSession(session);
-					// #endregion
 
-					// #region Options
-					let options = results[4] as Options | null;
-					if (!options) {
-						options = FactoryLogic.createOptions();
-					}
-
+					const options = results[4] as Options;
 					OptionsUpdateLogic.updateOptions(options);
-					// #endregion
 
 					setOverallLoadState('success');
 
@@ -295,12 +267,12 @@ export const DataLoader = (props: Props) => {
 									: null
 							}
 						</CheckLabel>
+						<CheckLabel state={sourcebookState}>Sourcebooks</CheckLabel>
 						<CheckLabel state={heroesState}>Heroes</CheckLabel>
 						<Progress percent={heroesProgress} size='small' showInfo={false} />
-						<CheckLabel state={sourcebookState}>Homebrew Content</CheckLabel>
 						<CheckLabel state={sessionState}>Session</CheckLabel>
 						<CheckLabel state={optionsState}>Options</CheckLabel>
-						<CheckLabel state={hiddenSourcebookIDsState}>Identifying Manifold</CheckLabel>
+						<CheckLabel state={hiddenSourcebookIDsState}>Manifold</CheckLabel>
 					</Flex>
 					{
 						error ?

--- a/src/components/panels/data-loader/data-loader.tsx
+++ b/src/components/panels/data-loader/data-loader.tsx
@@ -31,7 +31,7 @@ export interface LoadedData {
 	connectionSettings: ConnectionSettings;
 	service: DataService;
 	heroes: Hero[];
-	homebrew: Sourcebook[];
+	homebrewSourcebooks: Sourcebook[];
 	hiddenSourcebookIDs: string[];
 	session: Session;
 	options: Options;
@@ -47,7 +47,7 @@ export const DataLoader = (props: Props) => {
 	const [ connectionSettingsState, setConnectionSettingsState ] = useState<LoadingStatus>(undefined);
 	const [ heroesState, setHeroesState ] = useState<LoadingStatus>(undefined);
 	const [ heroesProgress, setHeroesProgress ] = useState<number>(0);
-	const [ homebrewState, setHomebrewState ] = useState<LoadingStatus>(undefined);
+	const [ sourcebookState, setSourcebookState ] = useState<LoadingStatus>(undefined);
 	const [ optionsState, setOptionsState ] = useState<LoadingStatus>(undefined);
 	const [ sessionState, setSessionState ] = useState<LoadingStatus>(undefined);
 	const [ hiddenSourcebookIDsState, setHiddenSourcebookIDsState ] = useState<LoadingStatus>(undefined);
@@ -164,7 +164,7 @@ export const DataLoader = (props: Props) => {
 		setOverallLoadState('pending');
 		setConnectionSettingsState('pending');
 
-		setHomebrewState(undefined);
+		setSourcebookState(undefined);
 		setHeroesState(undefined);
 		setSessionState(undefined);
 		setOptionsState(undefined);
@@ -175,14 +175,14 @@ export const DataLoader = (props: Props) => {
 			getDataService(settings).then(dataService => {
 				setConnectionSettingsState('success');
 
-				setHomebrewState('pending');
+				setSourcebookState('pending');
 				setHeroesState('pending');
 				setSessionState('pending');
 				setOptionsState('pending');
 				setHiddenSourcebookIDsState('pending');
 
 				const promises = [
-					updateLoadingStatus(dataService.getHomebrew(), setHomebrewState),
+					updateLoadingStatus(dataService.getHomebrew(), setSourcebookState),
 					updateLoadingStatus(getHeroes(dataService, settings.dataSource), setHeroesState),
 					updateLoadingStatus(dataService.getHiddenSourcebookIDs(), setHiddenSourcebookIDsState),
 					updateLoadingStatus(dataService.getSession(), setSessionState),
@@ -249,7 +249,7 @@ export const DataLoader = (props: Props) => {
 						connectionSettings: settings,
 						service: dataService,
 						heroes: heroes,
-						homebrew: sourcebooks,
+						homebrewSourcebooks: sourcebooks,
 						hiddenSourcebookIDs: hiddenSourcebookIDs,
 						session: session,
 						options: options
@@ -297,7 +297,7 @@ export const DataLoader = (props: Props) => {
 						</CheckLabel>
 						<CheckLabel state={heroesState}>Heroes</CheckLabel>
 						<Progress percent={heroesProgress} size='small' showInfo={false} />
-						<CheckLabel state={homebrewState}>Homebrew Content</CheckLabel>
+						<CheckLabel state={sourcebookState}>Homebrew Content</CheckLabel>
 						<CheckLabel state={sessionState}>Session</CheckLabel>
 						<CheckLabel state={optionsState}>Options</CheckLabel>
 						<CheckLabel state={hiddenSourcebookIDsState}>Identifying Manifold</CheckLabel>

--- a/src/components/panels/data-loader/data-loader.tsx
+++ b/src/components/panels/data-loader/data-loader.tsx
@@ -1,4 +1,4 @@
-import { Alert, Button, Flex, Tag } from 'antd';
+import { Alert, Button, Flex, Progress, Tag } from 'antd';
 import { ConnectionSettings, FSDataSource } from '@/models/connection-settings';
 import { SetStateAction, useEffect, useState } from 'react';
 import { CheckIcon } from '@/components/controls/check-icon/check-icon';
@@ -46,6 +46,7 @@ type LoadingStatus = 'pending' | 'success' | 'failure' | undefined;
 export const DataLoader = (props: Props) => {
 	const [ connectionSettingsState, setConnectionSettingsState ] = useState<LoadingStatus>(undefined);
 	const [ heroesState, setHeroesState ] = useState<LoadingStatus>(undefined);
+	const [ heroesProgress, setHeroesProgress ] = useState<number>(0);
 	const [ homebrewState, setHomebrewState ] = useState<LoadingStatus>(undefined);
 	const [ optionsState, setOptionsState ] = useState<LoadingStatus>(undefined);
 	const [ sessionState, setSessionState ] = useState<LoadingStatus>(undefined);
@@ -129,6 +130,35 @@ export const DataLoader = (props: Props) => {
 			});
 	};
 
+	async function getHero(getterPromise: Promise<Hero | null>, progressPercent: number): Promise<Hero | null> {
+		return getterPromise
+			.then(hero => {
+				setHeroesProgress(heroesProgress => heroesProgress + progressPercent);
+				return hero;
+			})
+			.catch(reason => {
+				console.error('Error getting hero', reason);
+				return null;
+			});
+	};
+
+	async function getHeroes(dataService: DataService, source: FSDataSource): Promise<Hero[]> {
+		// Only do multi-stage loading for non-local storage
+		if (source === 'Local') {
+			return dataService.getHeroes().finally(() => setHeroesProgress(100));
+		}
+
+		const heroPartials = await dataService.getHeroes();
+		const incrementPct = 100.0 / heroPartials.length;
+
+		const getHeroPromises = heroPartials.map(p => {
+			return getHero(dataService.getHero(p.id), incrementPct);
+		});
+
+		return Promise.all(getHeroPromises)
+			.then(results => results.filter(h => !!h));
+	};
+
 	const loadData = () => {
 		setError(null);
 		setOverallLoadState('pending');
@@ -153,7 +183,7 @@ export const DataLoader = (props: Props) => {
 
 				const promises = [
 					updateLoadingStatus(dataService.getHomebrew(), setHomebrewState),
-					updateLoadingStatus(dataService.getHeroes(), setHeroesState),
+					updateLoadingStatus(getHeroes(dataService, settings.dataSource), setHeroesState),
 					updateLoadingStatus(dataService.getHiddenSourcebookIDs(), setHiddenSourcebookIDsState),
 					updateLoadingStatus(dataService.getSession(), setSessionState),
 					updateLoadingStatus(dataService.getOptions(), setOptionsState)
@@ -168,18 +198,23 @@ export const DataLoader = (props: Props) => {
 
 					sourcebooks.forEach(sourcebook => {
 						sourcebook.type = SourcebookType.Homebrew;
-						SourcebookUpdateLogic.updateSourcebook(sourcebook);
+						try {
+							SourcebookUpdateLogic.updateSourcebook(sourcebook);
+						} catch (error) {
+							console.error(`Error while updating sourcebook [${sourcebook.name} - ${sourcebook.id}]`, error);
+						}
 					});
 					// #endregion
 
 					// #region Heroes
-					let heroes = results[1] as Hero[] | null;
-					if (!heroes) {
-						heroes = [];
-					}
+					const heroes = results[1] as Hero[];
 
 					heroes.forEach(hero => {
-						HeroUpdateLogic.updateHero(hero, SourcebookLogic.getSourcebooks(sourcebooks));
+						try {
+							HeroUpdateLogic.updateHero(hero, SourcebookLogic.getSourcebooks(sourcebooks));
+						} catch (error) {
+							console.error(`Error while updating hero [${hero.name} - ${hero.id}]`, error);
+						}
 					});
 					// #endregion
 
@@ -261,6 +296,7 @@ export const DataLoader = (props: Props) => {
 							}
 						</CheckLabel>
 						<CheckLabel state={heroesState}>Heroes</CheckLabel>
+						<Progress percent={heroesProgress} size='small' showInfo={false} />
 						<CheckLabel state={homebrewState}>Homebrew Content</CheckLabel>
 						<CheckLabel state={sessionState}>Session</CheckLabel>
 						<CheckLabel state={optionsState}>Options</CheckLabel>

--- a/src/components/panels/elements/sourcebook-panel/sourcebook-panel.tsx
+++ b/src/components/panels/elements/sourcebook-panel/sourcebook-panel.tsx
@@ -401,7 +401,7 @@ export const SourcebookPanel = (props: Props) => {
 					/>
 				);
 
-				const heroes = props.heroes.filter(h => h.settingIDs.includes(sourcebook.id));
+				const heroes = props.heroes.filter(h => h.sourcebookIDs.includes(sourcebook.id));
 
 				const used: { element: Element, type: string, container: Element }[] = [];
 				const elements = [

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -32,7 +32,7 @@ root.render(
 								<HashRouter>
 									<Main
 										heroes={data.heroes}
-										homebrewSourcebooks={data.homebrew}
+										homebrewSourcebooks={data.homebrewSourcebooks}
 										hiddenSourcebookIDs={data.hiddenSourcebookIDs}
 										session={data.session}
 										options={data.options}

--- a/src/logic/factory-logic.ts
+++ b/src/logic/factory-logic.ts
@@ -82,7 +82,7 @@ export class FactoryLogic {
 			name: '',
 			picture: null,
 			folder: '',
-			settingIDs: sourcebookIDs,
+			sourcebookIDs: sourcebookIDs,
 			ancestry: null,
 			culture: null,
 			class: null,

--- a/src/logic/pregen-logic.ts
+++ b/src/logic/pregen-logic.ts
@@ -19,7 +19,7 @@ export class PregenLogic {
 		pregen.name = hero.name;
 		pregen.description = HeroLogic.getHeroDescription(hero);
 
-		pregen.sourcebookIDs = [ ...hero.settingIDs ];
+		pregen.sourcebookIDs = [ ...hero.sourcebookIDs ];
 		pregen.ancestryID = hero.ancestry?.id ?? null;
 		pregen.cultureID = hero.culture?.id ?? null;
 		pregen.careerID = hero.career?.id ?? null;

--- a/src/logic/update/hero-update-logic.ts
+++ b/src/logic/update/hero-update-logic.ts
@@ -31,11 +31,11 @@ export class HeroUpdateLogic {
 			hero.folder = '';
 		}
 
-		if (hero.settingIDs === undefined) {
-			hero.settingIDs = SourcebookLogic.getSourcebooks().map(sb => sb.id);
+		if (hero.sourcebookIDs === undefined) {
+			hero.sourcebookIDs = SourcebookLogic.getSourcebooks().map(sb => sb.id);
 		}
 
-		hero.settingIDs = hero.settingIDs.map(id => id === '' ? SourcebookData.core.id : id);
+		hero.sourcebookIDs = hero.sourcebookIDs.map(id => id === '' ? SourcebookData.core.id : id);
 
 		if (hero.ancestry) {
 			hero.ancestry.features.forEach(FeatureUpdateLogic.updateFeature);

--- a/src/logic/update/sourcebook-update-logic.ts
+++ b/src/logic/update/sourcebook-update-logic.ts
@@ -10,9 +10,13 @@ import { LanguageType } from '@/enums/language-type';
 import { MonsterUpdateLogic } from '@/logic/update/monster-update-logic';
 import { PlotContentReference } from '@/models/plot';
 import { Sourcebook } from '@/models/sourcebook';
+import { SourcebookType } from '@/enums/sourcebook-type';
 
 export class SourcebookUpdateLogic {
 	static updateSourcebook = (sourcebook: Sourcebook) => {
+		if (sourcebook.type === undefined) {
+			sourcebook.type = SourcebookType.Homebrew;
+		}
 		if (sourcebook.adventures === undefined) {
 			sourcebook.adventures = [];
 		}

--- a/src/models/hero.ts
+++ b/src/models/hero.ts
@@ -24,7 +24,7 @@ export interface Hero {
 
 	picture: string | null;
 	folder: string;
-	settingIDs: string[];
+	sourcebookIDs: string[];
 
 	ancestry: Ancestry | null;
 	culture: Culture | null;

--- a/src/services/data-service.test.ts
+++ b/src/services/data-service.test.ts
@@ -64,29 +64,13 @@ describe('DataService', () => {
 		test('forwards to the storage service', async () => {
 			const ds = new DataService(mockStorage);
 
-			mockStorage.get = vi.fn().mockImplementation(() => Promise.resolve(mockHeroes));
+			mockStorage.getHeroes = vi.fn().mockImplementation(() => Promise.resolve(mockHeroes));
 
 			await ds.getHeroes()
 				.then(thenFn)
 				.catch(catchFn);
 
-			expect(mockStorage.get).toHaveBeenCalledWith('forgesteel-heroes');
-			expect(thenFn).toHaveBeenCalledWith(mockHeroes);
-			expect(catchFn).not.toHaveBeenCalled();
-		});
-	});
-
-	describe('saveHeroes', () => {
-		test('forwards to the storage service', async () => {
-			const ds = new DataService(mockStorage);
-
-			mockStorage.put = vi.fn().mockImplementation(() => Promise.resolve(mockHeroes));
-
-			await ds.saveHeroes(mockHeroes)
-				.then(thenFn)
-				.catch(catchFn);
-
-			expect(mockStorage.put).toHaveBeenCalledWith('forgesteel-heroes', mockHeroes);
+			expect(mockStorage.getHeroes).toHaveBeenCalled();
 			expect(thenFn).toHaveBeenCalledWith(mockHeroes);
 			expect(catchFn).not.toHaveBeenCalled();
 		});

--- a/src/services/data-service.test.ts
+++ b/src/services/data-service.test.ts
@@ -82,29 +82,13 @@ describe('DataService', () => {
 		test('forwards to the storage service', async () => {
 			const ds = new DataService(mockStorage);
 
-			mockStorage.get = vi.fn().mockImplementation(() => Promise.resolve(mockHomebrew));
+			mockStorage.getSourcebooks = vi.fn().mockImplementation(() => Promise.resolve(mockHomebrew));
 
 			await ds.getHomebrew()
 				.then(thenFn)
 				.catch(catchFn);
 
-			expect(mockStorage.get).toHaveBeenCalledWith('forgesteel-homebrew-settings');
-			expect(thenFn).toHaveBeenCalledWith(mockHomebrew);
-			expect(catchFn).not.toHaveBeenCalled();
-		});
-	});
-
-	describe('saveHomebrew', () => {
-		test('forwards to the storage service', async () => {
-			const ds = new DataService(mockStorage);
-
-			mockStorage.put = vi.fn().mockImplementation(() => Promise.resolve(mockHomebrew));
-
-			await ds.saveHomebrew(mockHomebrew)
-				.then(thenFn)
-				.catch(catchFn);
-
-			expect(mockStorage.put).toHaveBeenCalledWith('forgesteel-homebrew-settings', mockHomebrew);
+			expect(mockStorage.getSourcebooks).toHaveBeenCalled();
 			expect(thenFn).toHaveBeenCalledWith(mockHomebrew);
 			expect(catchFn).not.toHaveBeenCalled();
 		});
@@ -116,13 +100,13 @@ describe('DataService', () => {
 		test('forwards to the storage service', async () => {
 			const ds = new DataService(mockStorage);
 
-			mockStorage.get = vi.fn().mockImplementation(() => Promise.resolve(mockSession));
+			mockStorage.getSession = vi.fn().mockImplementation(() => Promise.resolve(mockSession));
 
 			await ds.getSession()
 				.then(thenFn)
 				.catch(catchFn);
 
-			expect(mockStorage.get).toHaveBeenCalledWith('forgesteel-session');
+			expect(mockStorage.getSession).toHaveBeenCalled();
 			expect(thenFn).toHaveBeenCalledWith(mockSession);
 			expect(catchFn).not.toHaveBeenCalled();
 		});
@@ -132,13 +116,13 @@ describe('DataService', () => {
 		test('forwards to the storage service', async () => {
 			const ds = new DataService(mockStorage);
 
-			mockStorage.put = vi.fn().mockImplementation(() => Promise.resolve(mockSession));
+			mockStorage.putSession = vi.fn().mockImplementation(() => Promise.resolve(mockSession));
 
 			await ds.saveSession(mockSession)
 				.then(thenFn)
 				.catch(catchFn);
 
-			expect(mockStorage.put).toHaveBeenCalledWith('forgesteel-session', mockSession);
+			expect(mockStorage.putSession).toHaveBeenCalledWith(mockSession);
 			expect(thenFn).toHaveBeenCalledWith(mockSession);
 			expect(catchFn).not.toHaveBeenCalled();
 		});
@@ -150,13 +134,13 @@ describe('DataService', () => {
 		test('forwards to the storage service', async () => {
 			const ds = new DataService(mockStorage);
 
-			mockStorage.get = vi.fn().mockImplementation(() => Promise.resolve(mockHiddenSettingIds));
+			mockStorage.getHiddenSourcebookIDs = vi.fn().mockImplementation(() => Promise.resolve(mockHiddenSettingIds));
 
 			await ds.getHiddenSourcebookIDs()
 				.then(thenFn)
 				.catch(catchFn);
 
-			expect(mockStorage.get).toHaveBeenCalledWith('forgesteel-hidden-setting-ids');
+			expect(mockStorage.getHiddenSourcebookIDs).toHaveBeenCalled();
 			expect(thenFn).toHaveBeenCalledWith(mockHiddenSettingIds);
 			expect(catchFn).not.toHaveBeenCalled();
 		});
@@ -166,13 +150,13 @@ describe('DataService', () => {
 		test('forwards to the storage service', async () => {
 			const ds = new DataService(mockStorage);
 
-			mockStorage.put = vi.fn().mockImplementation(() => Promise.resolve(mockHiddenSettingIds));
+			mockStorage.putHiddenSourcebookIDs = vi.fn().mockImplementation(() => Promise.resolve(mockHiddenSettingIds));
 
 			await ds.saveHiddenSourcebookIDs(mockHiddenSettingIds)
 				.then(thenFn)
 				.catch(catchFn);
 
-			expect(mockStorage.put).toHaveBeenCalledWith('forgesteel-hidden-setting-ids', mockHiddenSettingIds);
+			expect(mockStorage.putHiddenSourcebookIDs).toHaveBeenCalledWith(mockHiddenSettingIds);
 			expect(thenFn).toHaveBeenCalledWith(mockHiddenSettingIds);
 			expect(catchFn).not.toHaveBeenCalled();
 		});

--- a/src/services/data-service.ts
+++ b/src/services/data-service.ts
@@ -31,12 +31,20 @@ export class DataService {
 
 	// #region Heroes
 
-	async getHeroes(): Promise<Hero[] | null> {
-		return this.storageService.get<Hero[]>('forgesteel-heroes');
+	async getHeroes(): Promise<Hero[]> {
+		return this.storageService.getHeroes();
 	};
 
-	async saveHeroes(heroes: Hero[]): Promise<Hero[]> {
-		return this.storageService.put<Hero[]>('forgesteel-heroes', heroes);
+	async getHero(id: string): Promise<Hero | null> {
+		return this.storageService.getHero(id);
+	}
+
+	async saveHero(hero: Hero): Promise<Hero> {
+		return this.storageService.putHero(hero);
+	}
+
+	async deleteHero(id: string): Promise<void> {
+		return this.storageService.deleteHero(id);
 	}
 
 	// #endregion

--- a/src/services/data-service.ts
+++ b/src/services/data-service.ts
@@ -1,3 +1,4 @@
+import { FactoryLogic } from '@/logic/factory-logic';
 import { Hero } from '@/models/hero';
 import { Options } from '@/models/options';
 import { Session } from '@/models/session';
@@ -22,8 +23,9 @@ export class DataService {
 	// #region Options
 	// Always local only
 
-	async getOptions(): Promise<Options | null> {
-		return localforage.getItem<Options>('forgesteel-options');
+	async getOptions(): Promise<Options> {
+		const result = await localforage.getItem<Options>('forgesteel-options');
+		return result ?? FactoryLogic.createOptions();
 	}
 
 	async saveOptions(options: Options): Promise<Options> {
@@ -54,8 +56,9 @@ export class DataService {
 
 	// #region Homebrew sourcebooks
 
-	async getHomebrew(): Promise<Sourcebook[] | null> {
-		return this.storageService.getSourcebooks();
+	async getHomebrew(): Promise<Sourcebook[]> {
+		const result = await this.storageService.getSourcebooks();
+		return result ?? [];
 	}
 
 	async getSourcebook(id: string): Promise<Sourcebook | null> {
@@ -74,8 +77,9 @@ export class DataService {
 
 	// #region Session
 
-	async getSession(): Promise<Session | null> {
-		return this.storageService.getSession();
+	async getSession(): Promise<Session> {
+		const result = await this.storageService.getSession();
+		return result ?? FactoryLogic.createSession();
 	}
 
 	async saveSession(session: Session): Promise<Session> {
@@ -86,8 +90,9 @@ export class DataService {
 
 	// #region Hidden sourcebook IDs
 
-	async getHiddenSourcebookIDs(): Promise<string[] | null> {
-		return this.storageService.getHiddenSourcebookIDs();
+	async getHiddenSourcebookIDs(): Promise<string[]> {
+		const result = await this.storageService.getHiddenSourcebookIDs();
+		return result ?? [];
 	}
 
 	async saveHiddenSourcebookIDs(ids: string[]): Promise<string[]> {

--- a/src/services/data-service.ts
+++ b/src/services/data-service.ts
@@ -5,6 +5,9 @@ import { Sourcebook } from '@/models/sourcebook';
 import { StorageService } from '@/services/storage/storage-service';
 import localforage from 'localforage';
 
+/**
+ * Handles data storage, abstracting out whether that data is stored locally or in a remote warehouse
+ */
 export class DataService {
 	private readonly storageService: StorageService;
 
@@ -52,11 +55,19 @@ export class DataService {
 	// #region Homebrew sourcebooks
 
 	async getHomebrew(): Promise<Sourcebook[] | null> {
-		return this.storageService.get<Sourcebook[]>('forgesteel-homebrew-settings');
+		return this.storageService.getSourcebooks();
 	}
 
-	async saveHomebrew(sourcebooks: Sourcebook[]): Promise<Sourcebook[]> {
-		return this.storageService.put<Sourcebook[]>('forgesteel-homebrew-settings', sourcebooks);
+	async getSourcebook(id: string): Promise<Sourcebook | null> {
+		return this.storageService.getSourcebook(id);
+	}
+
+	async saveSourcebook(sourcebook: Sourcebook): Promise<Sourcebook> {
+		return this.storageService.putSourcebook(sourcebook);
+	}
+
+	async deleteSourcebook(id: string): Promise<void> {
+		return this.storageService.deleteSourcebook(id);
 	}
 
 	// #endregion
@@ -64,11 +75,11 @@ export class DataService {
 	// #region Session
 
 	async getSession(): Promise<Session | null> {
-		return this.storageService.get<Session>('forgesteel-session');
+		return this.storageService.getSession();
 	}
 
 	async saveSession(session: Session): Promise<Session> {
-		return this.storageService.put<Session>('forgesteel-session', session);
+		return this.storageService.putSession(session);
 	}
 
 	// #endregion
@@ -76,11 +87,11 @@ export class DataService {
 	// #region Hidden sourcebook IDs
 
 	async getHiddenSourcebookIDs(): Promise<string[] | null> {
-		return this.storageService.get<string[]>('forgesteel-hidden-setting-ids');
+		return this.storageService.getHiddenSourcebookIDs();
 	}
 
 	async saveHiddenSourcebookIDs(ids: string[]): Promise<string[]> {
-		return this.storageService.put<string[]>('forgesteel-hidden-setting-ids', ids);
+		return this.storageService.putHiddenSourcebookIDs(ids);
 	}
 
 	// #endregion

--- a/src/services/storage/local-service.test.ts
+++ b/src/services/storage/local-service.test.ts
@@ -1,7 +1,8 @@
+import { DataStorageKeys, LocalService } from './local-service';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import { DataStorageKeys } from './storage-service';
 import { Hero } from '@/models/hero';
-import { LocalService } from './local-service';
+import { Session } from '@/models/session';
+import { Sourcebook } from '@/models/sourcebook';
 import localforage from 'localforage';
 
 afterEach(() => {
@@ -11,9 +12,6 @@ afterEach(() => {
 vi.mock('localforage');
 
 describe('LocalService', () => {
-	const mockHero1 = { id: 'test-hero1' } as Hero;
-	const mockHero2 = { id: 'test-hero2' } as Hero;
-
 	let service = new LocalService();
 	beforeEach(async () => {
 		service = new LocalService();
@@ -23,6 +21,9 @@ describe('LocalService', () => {
 
 	const catchFn = vi.fn();
 	const thenFn = vi.fn();
+
+	const mockHero1 = { id: 'test-hero1' } as Hero;
+	const mockHero2 = { id: 'test-hero2' } as Hero;
 
 	describe('getHeroes', () => {
 		test('retrieves Heroes stored at correct key', async () => {
@@ -217,6 +218,265 @@ describe('LocalService', () => {
 			expect(getResult).toBeDefined();
 			expect(getResult).toHaveLength(1);
 			expect(getResult).toContainEqual(mockHero2);
+			expect(catchFn).not.toHaveBeenCalled();
+		});
+	});
+
+	const mockSourcebook1 = { id: 'test-Sourcebook1' } as Sourcebook;
+	const mockSourcebook2 = { id: 'test-Sourcebook2' } as Sourcebook;
+
+	describe('getSourcebooks', () => {
+		test('retrieves sourcebooks stored at correct key', async () => {
+			const testData = [ mockSourcebook1, mockSourcebook2 ];
+			localforage.getItem = vi.fn().mockImplementation(() => Promise.resolve(testData));
+
+			await service.getSourcebooks()
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(localforage.getItem).toHaveBeenCalledWith(DataStorageKeys.Sourcebooks);
+			expect(thenFn).toHaveBeenCalledWith(testData);
+			expect(catchFn).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('getSourcebook', () => {
+		test('returns null when no Sourcebooks have been stored', async () => {
+			localforage.getItem = vi.fn().mockImplementation(() => Promise.resolve(null));
+
+			await service.getSourcebook('some-Sourcebook')
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(localforage.getItem).toHaveBeenCalledWith(DataStorageKeys.Sourcebooks);
+			expect(thenFn).toHaveBeenCalledWith(null);
+			expect(catchFn).not.toHaveBeenCalled();
+		});
+
+		test('returns null when no Sourcebook with id exists', async () => {
+			const testData = [ mockSourcebook1, mockSourcebook2 ];
+			localforage.getItem = vi.fn().mockImplementation(() => Promise.resolve(testData));
+
+			await service.getSourcebook('none-Sourcebook')
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(localforage.getItem).toHaveBeenCalledWith(DataStorageKeys.Sourcebooks);
+			expect(thenFn).toHaveBeenCalledWith(null);
+			expect(catchFn).not.toHaveBeenCalled();
+		});
+
+		test('returns the Sourcebook with the matching id if it exists', async () => {
+			const testData = [ mockSourcebook1, mockSourcebook2 ];
+			localforage.getItem = vi.fn().mockImplementation(() => Promise.resolve(testData));
+
+			await service.getSourcebook('test-Sourcebook1')
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(localforage.getItem).toHaveBeenCalledWith(DataStorageKeys.Sourcebooks);
+			expect(thenFn).toHaveBeenCalledWith(mockSourcebook1);
+			expect(catchFn).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('putSourcebook', () => {
+		const mockSourcebook3 = { id: 'test-Sourcebook3' } as Sourcebook;
+
+		beforeEach(() => {
+			// dirty mock of localforage that will return the last thing set when get is called
+			let lastSet: Sourcebook[];
+			localforage.setItem = vi.fn().mockImplementation((_key: string, value: Sourcebook[]) => { lastSet = value; });
+			localforage.getItem = vi.fn().mockImplementation(() => Promise.resolve(lastSet));
+		});
+
+		test('saving a new Sourcebook will return that Sourcebook with subsequent get single', async () => {
+			const putThenFn = vi.fn();
+			await service.putSourcebook(mockSourcebook3)
+				.then(putThenFn)
+				.catch(catchFn);
+
+			expect(putThenFn).toHaveBeenCalledWith(mockSourcebook3);
+			expect(catchFn).not.toHaveBeenCalled();
+
+			const getThenFn = vi.fn();
+			await service.getSourcebook('test-Sourcebook3')
+				.then(getThenFn)
+				.catch(catchFn);
+
+			expect(getThenFn).toHaveBeenCalledWith(mockSourcebook3);
+			expect(catchFn).not.toHaveBeenCalled();
+		});
+
+		test('saving a new Sourcebook will return that Sourcebook with subsequent get all - no prior', async () => {
+			const putThenFn = vi.fn();
+			await service.putSourcebook(mockSourcebook3)
+				.then(putThenFn)
+				.catch(catchFn);
+
+			expect(putThenFn).toHaveBeenCalledWith(mockSourcebook3);
+			expect(catchFn).not.toHaveBeenCalled();
+
+			const getThenFn = vi.fn();
+			await service.getSourcebooks()
+				.then(getThenFn)
+				.catch(catchFn);
+
+			expect(getThenFn).toHaveBeenCalled();
+			const getResult = getThenFn.mock.lastCall ? getThenFn.mock.lastCall[0] : undefined;
+			expect(getResult).toBeDefined();
+			expect(getResult).toHaveLength(1);
+			expect(getResult).toContainEqual(mockSourcebook3);
+			expect(catchFn).not.toHaveBeenCalled();
+		});
+
+		test('saving a new Sourcebook will return that Sourcebook with subsequent get all - with prior', async () => {
+			const existingData = [ mockSourcebook1, mockSourcebook2 ];
+			localforage.setItem<Sourcebook[]>(DataStorageKeys.Sourcebooks, existingData);
+
+			const putThenFn = vi.fn();
+			await service.putSourcebook(mockSourcebook3)
+				.then(putThenFn)
+				.catch(catchFn);
+
+			expect(putThenFn).toHaveBeenCalledWith(mockSourcebook3);
+			expect(catchFn).not.toHaveBeenCalled();
+
+			const getThenFn = vi.fn();
+			await service.getSourcebooks()
+				.then(getThenFn)
+				.catch(catchFn);
+
+			expect(getThenFn).toHaveBeenCalled();
+			const getResult = getThenFn.mock.lastCall ? getThenFn.mock.lastCall[0] : undefined;
+			expect(getResult).toBeDefined();
+			expect(getResult).toHaveLength(3);
+			expect(getResult).toContainEqual(mockSourcebook1);
+			expect(getResult).toContainEqual(mockSourcebook2);
+			expect(getResult).toContainEqual(mockSourcebook3);
+			expect(catchFn).not.toHaveBeenCalled();
+		});
+
+		test('saving an existing Sourcebook will update the existing entry', async () => {
+			const existingData = [ mockSourcebook1, mockSourcebook2 ];
+			localforage.setItem<Sourcebook[]>(DataStorageKeys.Sourcebooks, existingData);
+
+			const updatedSourcebook1 = {
+				id: 'test-Sourcebook1',
+				name: 'new value'
+			} as Sourcebook;
+
+			const putThenFn = vi.fn();
+			await service.putSourcebook(updatedSourcebook1)
+				.then(putThenFn)
+				.catch(catchFn);
+
+			expect(putThenFn).toHaveBeenCalledWith(updatedSourcebook1);
+			expect(catchFn).not.toHaveBeenCalled();
+
+			const getThenFn = vi.fn();
+			await service.getSourcebooks()
+				.then(getThenFn)
+				.catch(catchFn);
+
+			expect(getThenFn).toHaveBeenCalled();
+			const getResult = getThenFn.mock.lastCall ? getThenFn.mock.lastCall[0] : undefined;
+			expect(getResult).toBeDefined();
+			expect(getResult).toHaveLength(2);
+			expect(getResult).toContainEqual(updatedSourcebook1);
+			expect(getResult).toContainEqual(mockSourcebook2);
+			expect(catchFn).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('deleteSourcebook', () => {
+		beforeEach(() => {
+			// dirty mock of localforage that will return the last thing set when get is called
+			let lastSet: Sourcebook[];
+			localforage.setItem = vi.fn().mockImplementation((_key: string, value: Sourcebook[]) => { lastSet = value; });
+			localforage.getItem = vi.fn().mockImplementation(() => Promise.resolve(lastSet));
+		});
+
+		test('deleting a Sourcebook removes it from the set', async () => {
+			const existingData = [ mockSourcebook1, mockSourcebook2 ];
+			localforage.setItem<Sourcebook[]>(DataStorageKeys.Sourcebooks, existingData);
+
+			await service.deleteSourcebook('test-Sourcebook1')
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(thenFn).toHaveBeenCalled();
+			expect(catchFn).not.toHaveBeenCalled();
+
+			const getThenFn = vi.fn();
+			await service.getSourcebooks()
+				.then(getThenFn)
+				.catch(catchFn);
+
+			expect(getThenFn).toHaveBeenCalled();
+			const getResult = getThenFn.mock.lastCall ? getThenFn.mock.lastCall[0] : undefined;
+			expect(getResult).toBeDefined();
+			expect(getResult).toHaveLength(1);
+			expect(getResult).toContainEqual(mockSourcebook2);
+			expect(catchFn).not.toHaveBeenCalled();
+		});
+	});
+
+	const mockSession = { playerViewID: 'test-session' } as Session;
+
+	describe('getSession', () => {
+		test('retrieves session stored at correct key', async () => {
+			localforage.getItem = vi.fn().mockImplementation(() => Promise.resolve(mockSession));
+
+			await service.getSession()
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(localforage.getItem).toHaveBeenCalledWith(DataStorageKeys.Session);
+			expect(thenFn).toHaveBeenCalledWith(mockSession);
+			expect(catchFn).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('putSession', () => {
+		test('sets session at correct key', async () => {
+			localforage.setItem = vi.fn().mockImplementation(() => Promise.resolve(mockSession));
+
+			await service.putSession(mockSession)
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(localforage.setItem).toHaveBeenCalledWith(DataStorageKeys.Session, mockSession);
+			expect(thenFn).toHaveBeenCalledWith(mockSession);
+			expect(catchFn).not.toHaveBeenCalled();
+		});
+	});
+
+	const testSourcebookIDs = [ 'test-sourcebook-x', 'test-sourcebook-y' ];
+	describe('getHiddenSourcebookIDs', () => {
+		test('retrieves session stored at correct key', async () => {
+			localforage.getItem = vi.fn().mockImplementation(() => Promise.resolve(testSourcebookIDs));
+
+			await service.getHiddenSourcebookIDs()
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(localforage.getItem).toHaveBeenCalledWith(DataStorageKeys.HiddenSourcebookIDs);
+			expect(thenFn).toHaveBeenCalledWith(testSourcebookIDs);
+			expect(catchFn).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('putHiddenSourcebookIDs', () => {
+		test('sets session at correct key', async () => {
+			localforage.setItem = vi.fn().mockImplementation(() => Promise.resolve(testSourcebookIDs));
+
+			await service.putHiddenSourcebookIDs(testSourcebookIDs)
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(localforage.setItem).toHaveBeenCalledWith(DataStorageKeys.HiddenSourcebookIDs, testSourcebookIDs);
+			expect(thenFn).toHaveBeenCalledWith(testSourcebookIDs);
 			expect(catchFn).not.toHaveBeenCalled();
 		});
 	});

--- a/src/services/storage/local-service.test.ts
+++ b/src/services/storage/local-service.test.ts
@@ -1,0 +1,223 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { DataStorageKeys } from './storage-service';
+import { Hero } from '@/models/hero';
+import { LocalService } from './local-service';
+import localforage from 'localforage';
+
+afterEach(() => {
+	vi.resetAllMocks();
+});
+
+vi.mock('localforage');
+
+describe('LocalService', () => {
+	const mockHero1 = { id: 'test-hero1' } as Hero;
+	const mockHero2 = { id: 'test-hero2' } as Hero;
+
+	let service = new LocalService();
+	beforeEach(async () => {
+		service = new LocalService();
+		const connected = await service.initialize();
+		expect(connected).toBe(true);
+	});
+
+	const catchFn = vi.fn();
+	const thenFn = vi.fn();
+
+	describe('getHeroes', () => {
+		test('retrieves Heroes stored at correct key', async () => {
+			const testData = [ mockHero1, mockHero2 ];
+			localforage.getItem = vi.fn().mockImplementation(() => Promise.resolve(testData));
+
+			await service.getHeroes()
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(localforage.getItem).toHaveBeenCalledWith(DataStorageKeys.Heroes);
+			expect(thenFn).toHaveBeenCalledWith(testData);
+			expect(catchFn).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('getHero', () => {
+		test('returns null when no heroes have been stored', async () => {
+			localforage.getItem = vi.fn().mockImplementation(() => Promise.resolve(null));
+
+			await service.getHero('some-hero')
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(localforage.getItem).toHaveBeenCalledWith(DataStorageKeys.Heroes);
+			expect(thenFn).toHaveBeenCalledWith(null);
+			expect(catchFn).not.toHaveBeenCalled();
+		});
+
+		test('returns null when no hero with id exists', async () => {
+			const testData = [ mockHero1, mockHero2 ];
+			localforage.getItem = vi.fn().mockImplementation(() => Promise.resolve(testData));
+
+			await service.getHero('none-hero')
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(localforage.getItem).toHaveBeenCalledWith(DataStorageKeys.Heroes);
+			expect(thenFn).toHaveBeenCalledWith(null);
+			expect(catchFn).not.toHaveBeenCalled();
+		});
+
+		test('returns the hero with the matching id if it exists', async () => {
+			const testData = [ mockHero1, mockHero2 ];
+			localforage.getItem = vi.fn().mockImplementation(() => Promise.resolve(testData));
+
+			await service.getHero('test-hero1')
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(localforage.getItem).toHaveBeenCalledWith(DataStorageKeys.Heroes);
+			expect(thenFn).toHaveBeenCalledWith(mockHero1);
+			expect(catchFn).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('putHero', () => {
+		const mockHero3 = { id: 'test-hero3' } as Hero;
+
+		beforeEach(() => {
+			// dirty mock of localforage that will return the last thing set when get is called
+			let lastSet: Hero[];
+			localforage.setItem = vi.fn().mockImplementation((_key: string, value: Hero[]) => { lastSet = value; });
+			localforage.getItem = vi.fn().mockImplementation(() => Promise.resolve(lastSet));
+		});
+
+		test('saving a new hero will return that hero with subsequent get single', async () => {
+			const putThenFn = vi.fn();
+			await service.putHero(mockHero3)
+				.then(putThenFn)
+				.catch(catchFn);
+
+			expect(putThenFn).toHaveBeenCalledWith(mockHero3);
+			expect(catchFn).not.toHaveBeenCalled();
+
+			const getThenFn = vi.fn();
+			await service.getHero('test-hero3')
+				.then(getThenFn)
+				.catch(catchFn);
+
+			expect(getThenFn).toHaveBeenCalledWith(mockHero3);
+			expect(catchFn).not.toHaveBeenCalled();
+		});
+
+		test('saving a new hero will return that hero with subsequent get all - no prior', async () => {
+			const putThenFn = vi.fn();
+			await service.putHero(mockHero3)
+				.then(putThenFn)
+				.catch(catchFn);
+
+			expect(putThenFn).toHaveBeenCalledWith(mockHero3);
+			expect(catchFn).not.toHaveBeenCalled();
+
+			const getThenFn = vi.fn();
+			await service.getHeroes()
+				.then(getThenFn)
+				.catch(catchFn);
+
+			expect(getThenFn).toHaveBeenCalled();
+			const getResult = getThenFn.mock.lastCall ? getThenFn.mock.lastCall[0] : undefined;
+			expect(getResult).toBeDefined();
+			expect(getResult).toHaveLength(1);
+			expect(getResult).toContainEqual(mockHero3);
+			expect(catchFn).not.toHaveBeenCalled();
+		});
+
+		test('saving a new hero will return that hero with subsequent get all - with prior', async () => {
+			const existingData = [ mockHero1, mockHero2 ];
+			localforage.setItem<Hero[]>(DataStorageKeys.Heroes, existingData);
+
+			const putThenFn = vi.fn();
+			await service.putHero(mockHero3)
+				.then(putThenFn)
+				.catch(catchFn);
+
+			expect(putThenFn).toHaveBeenCalledWith(mockHero3);
+			expect(catchFn).not.toHaveBeenCalled();
+
+			const getThenFn = vi.fn();
+			await service.getHeroes()
+				.then(getThenFn)
+				.catch(catchFn);
+
+			expect(getThenFn).toHaveBeenCalled();
+			const getResult = getThenFn.mock.lastCall ? getThenFn.mock.lastCall[0] : undefined;
+			expect(getResult).toBeDefined();
+			expect(getResult).toHaveLength(3);
+			expect(getResult).toContainEqual(mockHero1);
+			expect(getResult).toContainEqual(mockHero2);
+			expect(getResult).toContainEqual(mockHero3);
+			expect(catchFn).not.toHaveBeenCalled();
+		});
+
+		test('saving an existing hero will update the existing entry', async () => {
+			const existingData = [ mockHero1, mockHero2 ];
+			localforage.setItem<Hero[]>(DataStorageKeys.Heroes, existingData);
+
+			const updatedHero1 = {
+				id: 'test-hero1',
+				name: 'new value'
+			} as Hero;
+
+			const putThenFn = vi.fn();
+			await service.putHero(updatedHero1)
+				.then(putThenFn)
+				.catch(catchFn);
+
+			expect(putThenFn).toHaveBeenCalledWith(updatedHero1);
+			expect(catchFn).not.toHaveBeenCalled();
+
+			const getThenFn = vi.fn();
+			await service.getHeroes()
+				.then(getThenFn)
+				.catch(catchFn);
+
+			expect(getThenFn).toHaveBeenCalled();
+			const getResult = getThenFn.mock.lastCall ? getThenFn.mock.lastCall[0] : undefined;
+			expect(getResult).toBeDefined();
+			expect(getResult).toHaveLength(2);
+			expect(getResult).toContainEqual(updatedHero1);
+			expect(getResult).toContainEqual(mockHero2);
+			expect(catchFn).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('deleteHero', () => {
+		beforeEach(() => {
+			// dirty mock of localforage that will return the last thing set when get is called
+			let lastSet: Hero[];
+			localforage.setItem = vi.fn().mockImplementation((_key: string, value: Hero[]) => { lastSet = value; });
+			localforage.getItem = vi.fn().mockImplementation(() => Promise.resolve(lastSet));
+		});
+
+		test('deleting a hero removes it from the set', async () => {
+			const existingData = [ mockHero1, mockHero2 ];
+			localforage.setItem<Hero[]>(DataStorageKeys.Heroes, existingData);
+
+			await service.deleteHero('test-hero1')
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(thenFn).toHaveBeenCalled();
+			expect(catchFn).not.toHaveBeenCalled();
+
+			const getThenFn = vi.fn();
+			await service.getHeroes()
+				.then(getThenFn)
+				.catch(catchFn);
+
+			expect(getThenFn).toHaveBeenCalled();
+			const getResult = getThenFn.mock.lastCall ? getThenFn.mock.lastCall[0] : undefined;
+			expect(getResult).toBeDefined();
+			expect(getResult).toHaveLength(1);
+			expect(getResult).toContainEqual(mockHero2);
+			expect(catchFn).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/src/services/storage/local-service.ts
+++ b/src/services/storage/local-service.ts
@@ -1,4 +1,6 @@
-import { StorageService } from '@/services/storage/storage-service';
+import { DataStorageKeys, StorageService } from '@/services/storage/storage-service';
+import { Hero } from '@/models/hero';
+import { Utils } from '@/utils/utils';
 import localforage from 'localforage';
 
 export class LocalService implements StorageService {
@@ -17,5 +19,50 @@ export class LocalService implements StorageService {
 
 	put<T>(key: string, value: T): Promise<T> {
 		return localforage.setItem<T>(key, value);
+	}
+
+	async getHeroes(): Promise<Hero[]> {
+		const heroes = await localforage.getItem<Hero[]>(DataStorageKeys.Heroes);
+		if (!heroes) {
+			return [];
+		}
+		return heroes;
+	}
+
+	async getHero(id: string): Promise<Hero | null> {
+		const heroes = await localforage.getItem<Hero[]>(DataStorageKeys.Heroes);
+		if (heroes) {
+			const found = heroes.find(h => h.id === id);
+			if (found) {
+				return found;
+			}
+		}
+		return null;
+	}
+
+	async putHero(hero: Hero): Promise<Hero> {
+		const heroes = await localforage.getItem<Hero[]>(DataStorageKeys.Heroes);
+		if (heroes) {
+			const copy = Utils.copy(heroes);
+			if (heroes.some(h => h.id === hero.id)) {
+				const list = copy.map(h => h.id === hero.id ? hero : h);
+				localforage.setItem<Hero[]>(DataStorageKeys.Heroes, list);
+			} else {
+				copy.push(hero);
+				localforage.setItem<Hero[]>(DataStorageKeys.Heroes, copy);
+			}
+		} else {
+			localforage.setItem<Hero[]>(DataStorageKeys.Heroes, [ hero ]);
+		}
+
+		return hero;
+	}
+
+	async deleteHero(id: string): Promise<void> {
+		const heroes = await localforage.getItem<Hero[]>(DataStorageKeys.Heroes);
+		if (heroes) {
+			const copy = Utils.copy(heroes.filter(h => h.id !== id));
+			localforage.setItem<Hero[]>(DataStorageKeys.Heroes, copy);
+		}
 	}
 };

--- a/src/services/storage/local-service.ts
+++ b/src/services/storage/local-service.ts
@@ -1,26 +1,23 @@
-import { DataStorageKeys, StorageService } from '@/services/storage/storage-service';
 import { Hero } from '@/models/hero';
+import { Session } from '@/models/session';
+import { Sourcebook } from '@/models/sourcebook';
+import { StorageService } from '@/services/storage/storage-service';
 import { Utils } from '@/utils/utils';
 import localforage from 'localforage';
+
+export enum DataStorageKeys {
+	Heroes = 'forgesteel-heroes',
+	Sourcebooks = 'forgesteel-homebrew-settings',
+	Session = 'forgesteel-session',
+	HiddenSourcebookIDs = 'forgesteel-hidden-setting-ids'
+};
 
 export class LocalService implements StorageService {
 	initialize(): Promise<boolean> {
 		return Promise.resolve(true);
 	}
 
-	get<T>(key: string): Promise<T | null> {
-		try {
-			return localforage.getItem<T>(key);
-		} catch (error) {
-			console.error(`Error getting ${key}`, error);
-			return Promise.resolve(null);
-		}
-	}
-
-	put<T>(key: string, value: T): Promise<T> {
-		return localforage.setItem<T>(key, value);
-	}
-
+	// #region Heroes
 	async getHeroes(): Promise<Hero[]> {
 		const heroes = await localforage.getItem<Hero[]>(DataStorageKeys.Heroes);
 		if (!heroes) {
@@ -64,5 +61,79 @@ export class LocalService implements StorageService {
 			const copy = Utils.copy(heroes.filter(h => h.id !== id));
 			localforage.setItem<Hero[]>(DataStorageKeys.Heroes, copy);
 		}
+	}
+	// #endregion
+
+	// #region Sourcebooks
+	async getSourcebooks(): Promise<Sourcebook[]> {
+		const sourcebooks = await localforage.getItem<Sourcebook[]>(DataStorageKeys.Sourcebooks);
+		if (!sourcebooks) {
+			return [];
+		}
+		return sourcebooks;
+	}
+
+	async getSourcebook(id: string): Promise<Sourcebook | null> {
+		const sourcebooks = await localforage.getItem<Sourcebook[]>(DataStorageKeys.Sourcebooks);
+		if (sourcebooks) {
+			const found = sourcebooks.find(h => h.id === id);
+			if (found) {
+				return found;
+			}
+		}
+		return null;
+	}
+
+	async putSourcebook(sourcebook: Sourcebook): Promise<Sourcebook> {
+		const sourcebooks = await localforage.getItem<Sourcebook[]>(DataStorageKeys.Sourcebooks);
+		if (sourcebooks) {
+			const copy = Utils.copy(sourcebooks);
+			if (sourcebooks.some(h => h.id === sourcebook.id)) {
+				const list = copy.map(h => h.id === sourcebook.id ? sourcebook : h);
+				localforage.setItem<Sourcebook[]>(DataStorageKeys.Sourcebooks, list);
+			} else {
+				copy.push(sourcebook);
+				localforage.setItem<Sourcebook[]>(DataStorageKeys.Sourcebooks, copy);
+			}
+		} else {
+			localforage.setItem<Sourcebook[]>(DataStorageKeys.Sourcebooks, [ sourcebook ]);
+		}
+
+		return sourcebook;
+	}
+
+	async deleteSourcebook(id: string): Promise<void> {
+		const sourcebooks = await localforage.getItem<Sourcebook[]>(DataStorageKeys.Sourcebooks);
+		if (sourcebooks) {
+			const copy = Utils.copy(sourcebooks.filter(h => h.id !== id));
+			localforage.setItem<Sourcebook[]>(DataStorageKeys.Sourcebooks, copy);
+		}
+	}
+	// #endregion
+
+	getSession(): Promise<Session | null> {
+		try {
+			return localforage.getItem<Session>(DataStorageKeys.Session);
+		} catch (error) {
+			console.error('Error getting Session', error);
+			return Promise.resolve(null);
+		}
+	}
+
+	putSession(session: Session): Promise<Session> {
+		return localforage.setItem<Session>(DataStorageKeys.Session, session);
+	}
+
+	getHiddenSourcebookIDs(): Promise<string[] | null> {
+		try {
+			return localforage.getItem<string[]>(DataStorageKeys.HiddenSourcebookIDs);
+		} catch (error) {
+			console.error('Error getting hidden sourcebook ids', error);
+			return Promise.resolve(null);
+		}
+	}
+
+	putHiddenSourcebookIDs(ids: string[]): Promise<string[]> {
+		return localforage.setItem<string[]>(DataStorageKeys.HiddenSourcebookIDs, ids);
 	}
 };

--- a/src/services/storage/storage-service.ts
+++ b/src/services/storage/storage-service.ts
@@ -1,19 +1,42 @@
 import { Hero } from '@/models/hero';
+import { Session } from '@/models/session';
+import { Sourcebook } from '@/models/sourcebook';
 
-export enum DataStorageKeys {
-	Heroes = 'forgesteel-heroes'
-};
-
+/**
+ * Interface for abstracting data storage between local vs remote.
+ *
+ * Be aware that adding to this interface will almost always
+ * require coordinating changes with the warehouse API
+*/
 export interface StorageService {
+	/**
+	 * Perform any initialization required for the StorageService
+	 * before it can manipulate data.
+	 *
+	 * This might be e.g. authentication with a backend, etc.
+	 *
+	 * @returns a Promise that resolves with a boolean indicating
+	 * whether initialization was successful
+	 */
 	initialize(): Promise<boolean>;
-
-	// generic storage
-	get<T>(key: string): Promise<T | null>;
-	put<T>(key: string, value: T): Promise<T>
 
 	// Hero storage
 	getHeroes(): Promise<Hero[]>;
 	getHero(id: string): Promise<Hero | null>;
 	putHero(hero: Hero): Promise<Hero>;
 	deleteHero(id: string): Promise<void>;
+
+	// Homebrew storage
+	getSourcebooks(): Promise<Sourcebook[]>;
+	getSourcebook(id: string): Promise<Sourcebook | null>;
+	putSourcebook(sourcebook: Sourcebook): Promise<Sourcebook>;
+	deleteSourcebook(id: string): Promise<void>;
+
+	// Session
+	getSession(): Promise<Session | null>;
+	putSession(session: Session): Promise<Session>;
+
+	// Hidden sourcebook IDs
+	getHiddenSourcebookIDs(): Promise<string[] | null>;
+	putHiddenSourcebookIDs(ids: string[]): Promise<string[]>;
 };

--- a/src/services/storage/storage-service.ts
+++ b/src/services/storage/storage-service.ts
@@ -1,6 +1,19 @@
+import { Hero } from '@/models/hero';
+
+export enum DataStorageKeys {
+	Heroes = 'forgesteel-heroes'
+};
+
 export interface StorageService {
 	initialize(): Promise<boolean>;
 
+	// generic storage
 	get<T>(key: string): Promise<T | null>;
 	put<T>(key: string, value: T): Promise<T>
+
+	// Hero storage
+	getHeroes(): Promise<Hero[]>;
+	getHero(id: string): Promise<Hero | null>;
+	putHero(hero: Hero): Promise<Hero>;
+	deleteHero(id: string): Promise<void>;
 };

--- a/src/services/storage/warehouse-service.test.ts
+++ b/src/services/storage/warehouse-service.test.ts
@@ -152,4 +152,230 @@ describe('WarehouseService', () => {
 			expect(thenFn).toHaveBeenCalledWith(mockData);
 		});
 	});
+
+	describe('getHeroes', () => {
+		test('calls the correct api endpoint with the correct authorization', async () => {
+			const mockHero = { id: 'test-hero' } as Hero;
+			const mockData = [ mockHero ];
+
+			mockAdapter.onGet('data/forgesteel-heroes').reply(config => {
+				expect(config.headers?.Authorization).toBe('Bearer fake_token');
+				return [ 200, { data: mockData } ];
+			});
+
+			const service = new WarehouseService(defaultSettings);
+			const connected = await service.initialize();
+			expect(connected).toBe(true);
+
+			await service.getHeroes()
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(catchFn).not.toHaveBeenCalled();
+			expect(thenFn).toHaveBeenCalledWith(mockData);
+		});
+
+		test('refreshes the token if it has expired', async () => {
+			const mockHero = { id: 'test-hero' } as Hero;
+			const mockData = [ mockHero ];
+
+			mockAdapter
+				.onGet('data/forgesteel-heroes')
+				.replyOnce(401, { msg: 'Token has expired' })
+				.onPost('http://test-fake-host/refresh')
+				.reply(config => {
+					expect(config.headers?.Authorization).toBe('Bearer refresh_token');
+					return [ 200, { access_token: 'new_token' } ];
+				})
+				.onGet('data/forgesteel-heroes')
+				.replyOnce(config => {
+					expect(config.headers?.Authorization).toBe('Bearer new_token');
+					return [ 200, { data: mockData } ];
+				});
+
+			const service = new WarehouseService(defaultSettings);
+			const connected = await service.initialize();
+			expect(connected).toBe(true);
+
+			await service.getHeroes()
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(catchFn).not.toHaveBeenCalled();
+			expect(thenFn).toHaveBeenCalledWith(mockData);
+		});
+	});
+
+	describe('getHero', () => {
+		test('calls the correct api endpoint with the correct authorization', async () => {
+			const mockHero = { id: 'test-hero' } as Hero;
+
+			mockAdapter.onGet('data/forgesteel-heroes/test-hero').reply(config => {
+				expect(config.headers?.Authorization).toBe('Bearer fake_token');
+				return [ 200, { data: mockHero } ];
+			});
+
+			const service = new WarehouseService(defaultSettings);
+			const connected = await service.initialize();
+			expect(connected).toBe(true);
+
+			await service.getHero('test-hero')
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(catchFn).not.toHaveBeenCalled();
+			expect(thenFn).toHaveBeenCalledWith(mockHero);
+		});
+
+		test('refreshes the token if it has expired', async () => {
+			const mockHero = { id: 'test-hero' } as Hero;
+
+			mockAdapter
+				.onGet('data/forgesteel-heroes/test-hero')
+				.replyOnce(401, { msg: 'Token has expired' })
+				.onPost('http://test-fake-host/refresh')
+				.reply(config => {
+					expect(config.headers?.Authorization).toBe('Bearer refresh_token');
+					return [ 200, { access_token: 'new_token' } ];
+				})
+				.onGet('data/forgesteel-heroes/test-hero')
+				.replyOnce(config => {
+					expect(config.headers?.Authorization).toBe('Bearer new_token');
+					return [ 200, { data: mockHero } ];
+				});
+
+			const service = new WarehouseService(defaultSettings);
+			const connected = await service.initialize();
+			expect(connected).toBe(true);
+
+			await service.getHero('test-hero')
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(catchFn).not.toHaveBeenCalled();
+			expect(thenFn).toHaveBeenCalledWith(mockHero);
+		});
+	});
+
+	describe('putHero', () => {
+		test('ensures a hero has an id', async () => {
+			const mockHero = { name: 'test-hero' } as Hero;
+
+			mockAdapter.onPut(new RegExp('/data/forgesteel-heroes/*')).reply(config => {
+				expect(config.headers?.Authorization).toBe('Bearer fake_token');
+				return [ 200, { data: config.data } ];
+			});
+
+			const service = new WarehouseService(defaultSettings);
+			const connected = await service.initialize();
+			expect(connected).toBe(true);
+
+			await service.putHero(mockHero)
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(thenFn).toHaveBeenCalled();
+			const result = thenFn.mock.lastCall ? thenFn.mock.lastCall[0] : undefined;
+			expect(result).toBeDefined();
+			expect(result.name).toEqual(mockHero.name);
+			expect(result.id).toBeDefined();
+			expect(catchFn).not.toHaveBeenCalled();
+		});
+
+		test('calls the correct api endpoint with the correct authorization', async () => {
+			const mockHero = { id: 'test-hero' } as Hero;
+
+			mockAdapter.onPut('data/forgesteel-heroes/test-hero').reply(config => {
+				expect(config.headers?.Authorization).toBe('Bearer fake_token');
+				return [ 200, { data: mockHero } ];
+			});
+
+			const service = new WarehouseService(defaultSettings);
+			const connected = await service.initialize();
+			expect(connected).toBe(true);
+
+			await service.putHero(mockHero)
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(catchFn).not.toHaveBeenCalled();
+			expect(thenFn).toHaveBeenCalledWith(mockHero);
+		});
+
+		test('refreshes the token if it has expired', async () => {
+			const mockHero = { id: 'test-hero' } as Hero;
+
+			mockAdapter
+				.onPut('data/forgesteel-heroes/test-hero')
+				.replyOnce(401, { msg: 'Token has expired' })
+				.onPost('http://test-fake-host/refresh')
+				.reply(config => {
+					expect(config.headers?.Authorization).toBe('Bearer refresh_token');
+					return [ 200, { access_token: 'new_token' } ];
+				})
+				.onPut('data/forgesteel-heroes/test-hero')
+				.replyOnce(config => {
+					expect(config.headers?.Authorization).toBe('Bearer new_token');
+					return [ 200, { data: mockHero } ];
+				});
+
+			const service = new WarehouseService(defaultSettings);
+			const connected = await service.initialize();
+			expect(connected).toBe(true);
+
+			await service.putHero(mockHero)
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(catchFn).not.toHaveBeenCalled();
+			expect(thenFn).toHaveBeenCalledWith(mockHero);
+		});
+	});
+
+	describe('deleteHero', () => {
+		test('calls the correct api endpoint with the correct authorization', async () => {
+			mockAdapter.onDelete('data/forgesteel-heroes/test-hero').reply(config => {
+				expect(config.headers?.Authorization).toBe('Bearer fake_token');
+				return [ 204, { } ];
+			});
+
+			const service = new WarehouseService(defaultSettings);
+			const connected = await service.initialize();
+			expect(connected).toBe(true);
+
+			await service.deleteHero('test-hero')
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(catchFn).not.toHaveBeenCalled();
+			expect(thenFn).toHaveBeenCalled();
+		});
+
+		test('refreshes the token if it has expired', async () => {
+			mockAdapter
+				.onDelete('data/forgesteel-heroes/test-hero')
+				.replyOnce(401, { msg: 'Token has expired' })
+				.onPost('http://test-fake-host/refresh')
+				.reply(config => {
+					expect(config.headers?.Authorization).toBe('Bearer refresh_token');
+					return [ 200, { access_token: 'new_token' } ];
+				})
+				.onDelete('data/forgesteel-heroes/test-hero')
+				.replyOnce(config => {
+					expect(config.headers?.Authorization).toBe('Bearer new_token');
+					return [ 200, { } ];
+				});
+
+			const service = new WarehouseService(defaultSettings);
+			const connected = await service.initialize();
+			expect(connected).toBe(true);
+
+			await service.deleteHero('test-hero')
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(catchFn).not.toHaveBeenCalled();
+			expect(thenFn).toHaveBeenCalled();
+		});
+	});
 });

--- a/src/services/storage/warehouse-service.test.ts
+++ b/src/services/storage/warehouse-service.test.ts
@@ -2,6 +2,8 @@ import { afterEach, describe, expect, test, vi } from 'vitest';
 import { ConnectionSettings } from '@/models/connection-settings';
 import { Hero } from '@/models/hero';
 import MockAdapter from 'axios-mock-adapter';
+import { Session } from '@/models/session';
+import { Sourcebook } from '@/models/sourcebook';
 import { WarehouseService } from '@/services/storage/warehouse-service';
 import axios from 'axios';
 
@@ -45,114 +47,7 @@ describe('WarehouseService', () => {
 		});
 	});
 
-	describe('get', () => {
-		test('calls the correct api endpoint with the correct authorization', async () => {
-			const mockHero = { id: 'test-hero' } as Hero;
-			const mockData = [ mockHero ];
-
-			mockAdapter.onGet('data/forgesteel-heroes').reply(config => {
-				expect(config.headers?.Authorization).toBe('Bearer fake_token');
-				return [ 200, { data: mockData } ];
-			});
-
-			const service = new WarehouseService(defaultSettings);
-			const connected = await service.initialize();
-			expect(connected).toBe(true);
-
-			await service.get<Hero[]>('forgesteel-heroes')
-				.then(thenFn)
-				.catch(catchFn);
-
-			expect(catchFn).not.toHaveBeenCalled();
-			expect(thenFn).toHaveBeenCalledWith(mockData);
-		});
-
-		test('refreshes the token if it has expired', async () => {
-			const mockHero = { id: 'test-hero' } as Hero;
-			const mockData = [ mockHero ];
-
-			mockAdapter
-				.onGet('data/forgesteel-heroes')
-				.replyOnce(401, { msg: 'Token has expired' })
-				.onPost('http://test-fake-host/refresh')
-				.reply(config => {
-					expect(config.headers?.Authorization).toBe('Bearer refresh_token');
-					return [ 200, { access_token: 'new_token' } ];
-				})
-				.onGet('data/forgesteel-heroes')
-				.replyOnce(config => {
-					expect(config.headers?.Authorization).toBe('Bearer new_token');
-					return [ 200, { data: mockData } ];
-				});
-
-			const service = new WarehouseService(defaultSettings);
-			const connected = await service.initialize();
-			expect(connected).toBe(true);
-
-			await service.get<Hero[]>('forgesteel-heroes')
-				.then(thenFn)
-				.catch(catchFn);
-
-			expect(catchFn).not.toHaveBeenCalled();
-			expect(thenFn).toHaveBeenCalledWith(mockData);
-		});
-	});
-
-	describe('put', () => {
-		test('calls the correct api endpoint with the correct authorization', async () => {
-			const mockHero = { id: 'test-hero' } as Hero;
-			const mockData = [ mockHero ];
-
-			mockAdapter.onPut('data/forgesteel-heroes').reply(config => {
-				expect(config.headers?.Authorization).toBe('Bearer fake_token');
-				expect(config.data).toBe(mockData);
-				return [ 204 ];
-			});
-
-			const service = new WarehouseService(defaultSettings);
-			const connected = await service.initialize();
-			expect(connected).toBe(true);
-
-			await service.put<Hero[]>('forgesteel-heroes', mockData)
-				.then(thenFn)
-				.catch(catchFn);
-
-			expect(catchFn).not.toHaveBeenCalled();
-			expect(thenFn).toHaveBeenCalledWith(mockData);
-		});
-
-		test('refreshes the token if it has expired', async () => {
-			const mockHero = { id: 'test-hero' } as Hero;
-			const mockData = [ mockHero ];
-
-			mockAdapter
-				.onPut('data/forgesteel-heroes')
-				.replyOnce(401, { msg: 'Token has expired' })
-				.onPost('http://test-fake-host/refresh')
-				.reply(config => {
-					expect(config.headers?.Authorization).toBe('Bearer refresh_token');
-					return [ 200, { access_token: 'new_token' } ];
-				})
-				.onPut('data/forgesteel-heroes')
-				.replyOnce(config => {
-					expect(config.headers?.Authorization).toBe('Bearer fake_token');
-					expect(config.data).toBe(mockData);
-					return [ 204 ];
-				});
-
-			const service = new WarehouseService(defaultSettings);
-			const connected = await service.initialize();
-			expect(connected).toBe(true);
-
-			await service.put<Hero[]>('forgesteel-heroes', mockData)
-				.then(thenFn)
-				.catch(catchFn);
-
-			expect(catchFn).not.toHaveBeenCalled();
-			expect(thenFn).toHaveBeenCalledWith(mockData);
-		});
-	});
-
+	// #region Heroes
 	describe('getHeroes', () => {
 		test('calls the correct api endpoint with the correct authorization', async () => {
 			const mockHero = { id: 'test-hero' } as Hero;
@@ -378,4 +273,431 @@ describe('WarehouseService', () => {
 			expect(thenFn).toHaveBeenCalled();
 		});
 	});
+	// #endregion
+
+	// #region Sourcebooks
+	describe('getSourcebooks', () => {
+		test('calls the correct api endpoint with the correct authorization', async () => {
+			const mockSourcebook = { id: 'test-Sourcebook' } as Sourcebook;
+			const mockData = [ mockSourcebook ];
+
+			mockAdapter.onGet('data/forgesteel-homebrew-settings').reply(config => {
+				expect(config.headers?.Authorization).toBe('Bearer fake_token');
+				return [ 200, { data: mockData } ];
+			});
+
+			const service = new WarehouseService(defaultSettings);
+			const connected = await service.initialize();
+			expect(connected).toBe(true);
+
+			await service.getSourcebooks()
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(catchFn).not.toHaveBeenCalled();
+			expect(thenFn).toHaveBeenCalledWith(mockData);
+		});
+
+		test('refreshes the token if it has expired', async () => {
+			const mockSourcebook = { id: 'test-Sourcebook' } as Sourcebook;
+			const mockData = [ mockSourcebook ];
+
+			mockAdapter
+				.onGet('data/forgesteel-homebrew-settings')
+				.replyOnce(401, { msg: 'Token has expired' })
+				.onPost('http://test-fake-host/refresh')
+				.reply(config => {
+					expect(config.headers?.Authorization).toBe('Bearer refresh_token');
+					return [ 200, { access_token: 'new_token' } ];
+				})
+				.onGet('data/forgesteel-homebrew-settings')
+				.replyOnce(config => {
+					expect(config.headers?.Authorization).toBe('Bearer new_token');
+					return [ 200, { data: mockData } ];
+				});
+
+			const service = new WarehouseService(defaultSettings);
+			const connected = await service.initialize();
+			expect(connected).toBe(true);
+
+			await service.getSourcebooks()
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(catchFn).not.toHaveBeenCalled();
+			expect(thenFn).toHaveBeenCalledWith(mockData);
+		});
+	});
+
+	describe('getSourcebook', () => {
+		test('calls the correct api endpoint with the correct authorization', async () => {
+			const mockSourcebook = { id: 'test-Sourcebook' } as Sourcebook;
+
+			mockAdapter.onGet('data/forgesteel-homebrew-settings/test-Sourcebook').reply(config => {
+				expect(config.headers?.Authorization).toBe('Bearer fake_token');
+				return [ 200, { data: mockSourcebook } ];
+			});
+
+			const service = new WarehouseService(defaultSettings);
+			const connected = await service.initialize();
+			expect(connected).toBe(true);
+
+			await service.getSourcebook('test-Sourcebook')
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(catchFn).not.toHaveBeenCalled();
+			expect(thenFn).toHaveBeenCalledWith(mockSourcebook);
+		});
+
+		test('refreshes the token if it has expired', async () => {
+			const mockSourcebook = { id: 'test-Sourcebook' } as Sourcebook;
+
+			mockAdapter
+				.onGet('data/forgesteel-homebrew-settings/test-Sourcebook')
+				.replyOnce(401, { msg: 'Token has expired' })
+				.onPost('http://test-fake-host/refresh')
+				.reply(config => {
+					expect(config.headers?.Authorization).toBe('Bearer refresh_token');
+					return [ 200, { access_token: 'new_token' } ];
+				})
+				.onGet('data/forgesteel-homebrew-settings/test-Sourcebook')
+				.replyOnce(config => {
+					expect(config.headers?.Authorization).toBe('Bearer new_token');
+					return [ 200, { data: mockSourcebook } ];
+				});
+
+			const service = new WarehouseService(defaultSettings);
+			const connected = await service.initialize();
+			expect(connected).toBe(true);
+
+			await service.getSourcebook('test-Sourcebook')
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(catchFn).not.toHaveBeenCalled();
+			expect(thenFn).toHaveBeenCalledWith(mockSourcebook);
+		});
+	});
+
+	describe('putSourcebook', () => {
+		test('ensures a Sourcebook has an id', async () => {
+			const mockSourcebook = { name: 'test-Sourcebook' } as Sourcebook;
+
+			mockAdapter.onPut(new RegExp('/data/forgesteel-homebrew-settings/*')).reply(config => {
+				expect(config.headers?.Authorization).toBe('Bearer fake_token');
+				return [ 200, { data: config.data } ];
+			});
+
+			const service = new WarehouseService(defaultSettings);
+			const connected = await service.initialize();
+			expect(connected).toBe(true);
+
+			await service.putSourcebook(mockSourcebook)
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(thenFn).toHaveBeenCalled();
+			const result = thenFn.mock.lastCall ? thenFn.mock.lastCall[0] : undefined;
+			expect(result).toBeDefined();
+			expect(result.name).toEqual(mockSourcebook.name);
+			expect(result.id).toBeDefined();
+			expect(catchFn).not.toHaveBeenCalled();
+		});
+
+		test('calls the correct api endpoint with the correct authorization', async () => {
+			const mockSourcebook = { id: 'test-Sourcebook' } as Sourcebook;
+
+			mockAdapter.onPut('data/forgesteel-homebrew-settings/test-Sourcebook').reply(config => {
+				expect(config.headers?.Authorization).toBe('Bearer fake_token');
+				return [ 200, { data: mockSourcebook } ];
+			});
+
+			const service = new WarehouseService(defaultSettings);
+			const connected = await service.initialize();
+			expect(connected).toBe(true);
+
+			await service.putSourcebook(mockSourcebook)
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(catchFn).not.toHaveBeenCalled();
+			expect(thenFn).toHaveBeenCalledWith(mockSourcebook);
+		});
+
+		test('refreshes the token if it has expired', async () => {
+			const mockSourcebook = { id: 'test-Sourcebook' } as Sourcebook;
+
+			mockAdapter
+				.onPut('data/forgesteel-homebrew-settings/test-Sourcebook')
+				.replyOnce(401, { msg: 'Token has expired' })
+				.onPost('http://test-fake-host/refresh')
+				.reply(config => {
+					expect(config.headers?.Authorization).toBe('Bearer refresh_token');
+					return [ 200, { access_token: 'new_token' } ];
+				})
+				.onPut('data/forgesteel-homebrew-settings/test-Sourcebook')
+				.replyOnce(config => {
+					expect(config.headers?.Authorization).toBe('Bearer new_token');
+					return [ 200, { data: mockSourcebook } ];
+				});
+
+			const service = new WarehouseService(defaultSettings);
+			const connected = await service.initialize();
+			expect(connected).toBe(true);
+
+			await service.putSourcebook(mockSourcebook)
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(catchFn).not.toHaveBeenCalled();
+			expect(thenFn).toHaveBeenCalledWith(mockSourcebook);
+		});
+	});
+
+	describe('deleteSourcebook', () => {
+		test('calls the correct api endpoint with the correct authorization', async () => {
+			mockAdapter.onDelete('data/forgesteel-homebrew-settings/test-Sourcebook').reply(config => {
+				expect(config.headers?.Authorization).toBe('Bearer fake_token');
+				return [ 204, { } ];
+			});
+
+			const service = new WarehouseService(defaultSettings);
+			const connected = await service.initialize();
+			expect(connected).toBe(true);
+
+			await service.deleteSourcebook('test-Sourcebook')
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(catchFn).not.toHaveBeenCalled();
+			expect(thenFn).toHaveBeenCalled();
+		});
+
+		test('refreshes the token if it has expired', async () => {
+			mockAdapter
+				.onDelete('data/forgesteel-homebrew-settings/test-Sourcebook')
+				.replyOnce(401, { msg: 'Token has expired' })
+				.onPost('http://test-fake-host/refresh')
+				.reply(config => {
+					expect(config.headers?.Authorization).toBe('Bearer refresh_token');
+					return [ 200, { access_token: 'new_token' } ];
+				})
+				.onDelete('data/forgesteel-homebrew-settings/test-Sourcebook')
+				.replyOnce(config => {
+					expect(config.headers?.Authorization).toBe('Bearer new_token');
+					return [ 200, { } ];
+				});
+
+			const service = new WarehouseService(defaultSettings);
+			const connected = await service.initialize();
+			expect(connected).toBe(true);
+
+			await service.deleteSourcebook('test-Sourcebook')
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(catchFn).not.toHaveBeenCalled();
+			expect(thenFn).toHaveBeenCalled();
+		});
+	});
+	// #endregion
+
+	// #region Session
+	const mockSession = { playerViewID: 'test-session' } as Session;
+	describe('getSession', () => {
+		test('calls the correct api endpoint with the correct authorization', async () => {
+			mockAdapter.onGet('data/forgesteel-session').reply(config => {
+				expect(config.headers?.Authorization).toBe('Bearer fake_token');
+				return [ 200, { data: mockSession } ];
+			});
+
+			const service = new WarehouseService(defaultSettings);
+			const connected = await service.initialize();
+			expect(connected).toBe(true);
+
+			await service.getSession()
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(catchFn).not.toHaveBeenCalled();
+			expect(thenFn).toHaveBeenCalledWith(mockSession);
+		});
+
+		test('refreshes the token if it has expired', async () => {
+			mockAdapter
+				.onGet('data/forgesteel-session')
+				.replyOnce(401, { msg: 'Token has expired' })
+				.onPost('http://test-fake-host/refresh')
+				.reply(config => {
+					expect(config.headers?.Authorization).toBe('Bearer refresh_token');
+					return [ 200, { access_token: 'new_token' } ];
+				})
+				.onGet('data/forgesteel-session')
+				.replyOnce(config => {
+					expect(config.headers?.Authorization).toBe('Bearer new_token');
+					return [ 200, { data: mockSession } ];
+				});
+
+			const service = new WarehouseService(defaultSettings);
+			const connected = await service.initialize();
+			expect(connected).toBe(true);
+
+			await service.getSession()
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(catchFn).not.toHaveBeenCalled();
+			expect(thenFn).toHaveBeenCalledWith(mockSession);
+		});
+	});
+
+	describe('putSession', () => {
+		test('calls the correct api endpoint with the correct authorization', async () => {
+			mockAdapter.onPut('data/forgesteel-session').reply(config => {
+				expect(config.headers?.Authorization).toBe('Bearer fake_token');
+				expect(config.data).toBe(mockSession);
+				return [ 204 ];
+			});
+
+			const service = new WarehouseService(defaultSettings);
+			const connected = await service.initialize();
+			expect(connected).toBe(true);
+
+			await service.putSession(mockSession)
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(catchFn).not.toHaveBeenCalled();
+			expect(thenFn).toHaveBeenCalledWith(mockSession);
+		});
+
+		test('refreshes the token if it has expired', async () => {
+			mockAdapter
+				.onPut('data/forgesteel-session')
+				.replyOnce(401, { msg: 'Token has expired' })
+				.onPost('http://test-fake-host/refresh')
+				.reply(config => {
+					expect(config.headers?.Authorization).toBe('Bearer refresh_token');
+					return [ 200, { access_token: 'new_token' } ];
+				})
+				.onPut('data/forgesteel-session')
+				.replyOnce(config => {
+					expect(config.headers?.Authorization).toBe('Bearer fake_token');
+					expect(config.data).toBe(mockSession);
+					return [ 204 ];
+				});
+
+			const service = new WarehouseService(defaultSettings);
+			const connected = await service.initialize();
+			expect(connected).toBe(true);
+
+			await service.putSession(mockSession)
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(catchFn).not.toHaveBeenCalled();
+			expect(thenFn).toHaveBeenCalledWith(mockSession);
+		});
+	});
+	// #endregion
+
+	// #region Hidden Sourcebook IDs
+	const testSourcebookIDs = [ 'test-sourcebook-x', 'test-sourcebook-y' ];
+	describe('getHiddenSourcebookIDs', () => {
+		test('calls the correct api endpoint with the correct authorization', async () => {
+			mockAdapter.onGet('data/forgesteel-hidden-setting-ids').reply(config => {
+				expect(config.headers?.Authorization).toBe('Bearer fake_token');
+				return [ 200, { data: testSourcebookIDs } ];
+			});
+
+			const service = new WarehouseService(defaultSettings);
+			const connected = await service.initialize();
+			expect(connected).toBe(true);
+
+			await service.getHiddenSourcebookIDs()
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(catchFn).not.toHaveBeenCalled();
+			expect(thenFn).toHaveBeenCalledWith(testSourcebookIDs);
+		});
+
+		test('refreshes the token if it has expired', async () => {
+			mockAdapter
+				.onGet('data/forgesteel-hidden-setting-ids')
+				.replyOnce(401, { msg: 'Token has expired' })
+				.onPost('http://test-fake-host/refresh')
+				.reply(config => {
+					expect(config.headers?.Authorization).toBe('Bearer refresh_token');
+					return [ 200, { access_token: 'new_token' } ];
+				})
+				.onGet('data/forgesteel-hidden-setting-ids')
+				.replyOnce(config => {
+					expect(config.headers?.Authorization).toBe('Bearer new_token');
+					return [ 200, { data: testSourcebookIDs } ];
+				});
+
+			const service = new WarehouseService(defaultSettings);
+			const connected = await service.initialize();
+			expect(connected).toBe(true);
+
+			await service.getHiddenSourcebookIDs()
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(catchFn).not.toHaveBeenCalled();
+			expect(thenFn).toHaveBeenCalledWith(testSourcebookIDs);
+		});
+	});
+
+	describe('putHiddenSourcebookIDs', () => {
+		test('calls the correct api endpoint with the correct authorization', async () => {
+			mockAdapter.onPut('data/forgesteel-hidden-setting-ids').reply(config => {
+				expect(config.headers?.Authorization).toBe('Bearer fake_token');
+				expect(config.data).toBe(testSourcebookIDs);
+				return [ 204 ];
+			});
+
+			const service = new WarehouseService(defaultSettings);
+			const connected = await service.initialize();
+			expect(connected).toBe(true);
+
+			await service.putHiddenSourcebookIDs(testSourcebookIDs)
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(catchFn).not.toHaveBeenCalled();
+			expect(thenFn).toHaveBeenCalledWith(testSourcebookIDs);
+		});
+
+		test('refreshes the token if it has expired', async () => {
+			mockAdapter
+				.onPut('data/forgesteel-hidden-setting-ids')
+				.replyOnce(401, { msg: 'Token has expired' })
+				.onPost('http://test-fake-host/refresh')
+				.reply(config => {
+					expect(config.headers?.Authorization).toBe('Bearer refresh_token');
+					return [ 200, { access_token: 'new_token' } ];
+				})
+				.onPut('data/forgesteel-hidden-setting-ids')
+				.replyOnce(config => {
+					expect(config.headers?.Authorization).toBe('Bearer fake_token');
+					expect(config.data).toBe(testSourcebookIDs);
+					return [ 204 ];
+				});
+
+			const service = new WarehouseService(defaultSettings);
+			const connected = await service.initialize();
+			expect(connected).toBe(true);
+
+			await service.putHiddenSourcebookIDs(testSourcebookIDs)
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(catchFn).not.toHaveBeenCalled();
+			expect(thenFn).toHaveBeenCalledWith(testSourcebookIDs);
+		});
+	});
+	// #endregion
 });

--- a/src/services/storage/warehouse-service.ts
+++ b/src/services/storage/warehouse-service.ts
@@ -160,9 +160,14 @@ export class WarehouseService implements StorageService {
 		}
 	}
 
+	// Will ONLY retrieve a partial object for the Heroes
 	async getHeroes(): Promise<Hero[]> {
 		try {
-			const response = await this.api.get('data/forgesteel-heroes');
+			const response = await this.api.get('data/forgesteel-heroes', {
+				params: {
+					fields: 'name,folder'
+				}
+			});
 			return response.data.data;
 		} catch (error) {
 			console.error('Error communicating with FS Warehouse', error);

--- a/src/services/storage/warehouse-service.ts
+++ b/src/services/storage/warehouse-service.ts
@@ -1,7 +1,9 @@
 import axios, { AxiosError, AxiosInstance } from 'axios';
 import { Config } from '@/utils/config';
 import { ConnectionSettings } from '@/models/connection-settings';
+import { Hero } from '@/models/hero';
 import { StorageService } from '@/services/storage/storage-service';
+import { Utils } from '@/utils/utils';
 
 export class WarehouseService implements StorageService {
 	readonly host: string;
@@ -152,6 +154,49 @@ export class WarehouseService implements StorageService {
 		try {
 			await this.api.put(`data/${key}`, value);
 			return value;
+		} catch (error) {
+			console.error('Error communicating with FS Warehouse', error);
+			throw new Error(this.getErrorMessage(error), { cause: error });
+		}
+	}
+
+	async getHeroes(): Promise<Hero[]> {
+		try {
+			const response = await this.api.get('data/forgesteel-heroes');
+			return response.data.data;
+		} catch (error) {
+			console.error('Error communicating with FS Warehouse', error);
+			throw new Error(this.getErrorMessage(error), { cause: error });
+		}
+	}
+
+	async getHero(id: string): Promise<Hero | null> {
+		try {
+			const response = await this.api.get(`data/forgesteel-heroes/${id}`);
+			return response.data.data;
+		} catch (error) {
+			console.error('Error communicating with FS Warehouse', error);
+			throw new Error(this.getErrorMessage(error), { cause: error });
+		}
+	}
+
+	async putHero(hero: Hero): Promise<Hero> {
+		try {
+			if (!hero.id?.length) {
+				hero.id = Utils.guid();
+			}
+			await this.api.put(`data/forgesteel-heroes/${hero.id}`, hero);
+			return hero;
+		} catch (error) {
+			console.error('Error communicating with FS Warehouse', error);
+			throw new Error(this.getErrorMessage(error), { cause: error });
+		}
+	}
+
+	async deleteHero(id: string): Promise<void> {
+		try {
+			const response = await this.api.delete(`data/forgesteel-heroes/${id}`);
+			return response.data.data;
 		} catch (error) {
 			console.error('Error communicating with FS Warehouse', error);
 			throw new Error(this.getErrorMessage(error), { cause: error });

--- a/src/services/storage/warehouse-service.ts
+++ b/src/services/storage/warehouse-service.ts
@@ -2,6 +2,8 @@ import axios, { AxiosError, AxiosInstance } from 'axios';
 import { Config } from '@/utils/config';
 import { ConnectionSettings } from '@/models/connection-settings';
 import { Hero } from '@/models/hero';
+import { Session } from '@/models/session';
+import { Sourcebook } from '@/models/sourcebook';
 import { StorageService } from '@/services/storage/storage-service';
 import { Utils } from '@/utils/utils';
 
@@ -140,27 +142,13 @@ export class WarehouseService implements StorageService {
 		return msg;
 	};
 
-	async get<T>(key: string): Promise<T | null> {
-		try {
-			const response = await this.api.get(`data/${key}`);
-			return response.data.data;
-		} catch (error) {
-			console.error('Error communicating with FS Warehouse', error);
-			throw new Error(this.getErrorMessage(error), { cause: error });
-		}
-	}
+	// #region Heroes
 
-	async put<T>(key: string, value: T): Promise<T> {
-		try {
-			await this.api.put(`data/${key}`, value);
-			return value;
-		} catch (error) {
-			console.error('Error communicating with FS Warehouse', error);
-			throw new Error(this.getErrorMessage(error), { cause: error });
-		}
-	}
-
-	// Will ONLY retrieve a partial object for the Heroes
+	/**
+	 * **IMPORTANT** Will ONLY retrieve a partial object for the Heroes.
+	 * As a result, you MUST call getHero() BEFORE you can save the returned result
+	 * TODO: should update the interface contract to return HeroOverview[]
+	 */
 	async getHeroes(): Promise<Hero[]> {
 		try {
 			const response = await this.api.get('data/forgesteel-heroes', {
@@ -202,6 +190,92 @@ export class WarehouseService implements StorageService {
 		try {
 			const response = await this.api.delete(`data/forgesteel-heroes/${id}`);
 			return response.data.data;
+		} catch (error) {
+			console.error('Error communicating with FS Warehouse', error);
+			throw new Error(this.getErrorMessage(error), { cause: error });
+		}
+	}
+	// #endregion
+
+	// #region Sourcebooks
+	async getSourcebooks(): Promise<Sourcebook[]> {
+		try {
+			const response = await this.api.get('data/forgesteel-homebrew-settings');
+			return response.data.data;
+		} catch (error) {
+			console.error('Error communicating with FS Warehouse', error);
+			throw new Error(this.getErrorMessage(error), { cause: error });
+		}
+	}
+
+	async getSourcebook(id: string): Promise<Sourcebook | null> {
+		try {
+			const response = await this.api.get(`data/forgesteel-homebrew-settings/${id}`);
+			return response.data.data;
+		} catch (error) {
+			console.error('Error communicating with FS Warehouse', error);
+			throw new Error(this.getErrorMessage(error), { cause: error });
+		}
+	}
+
+	async putSourcebook(sourcebook: Sourcebook): Promise<Sourcebook> {
+		try {
+			if (!sourcebook.id?.length) {
+				sourcebook.id = Utils.guid();
+			}
+			await this.api.put(`data/forgesteel-homebrew-settings/${sourcebook.id}`, sourcebook);
+			return sourcebook;
+		} catch (error) {
+			console.error('Error communicating with FS Warehouse', error);
+			throw new Error(this.getErrorMessage(error), { cause: error });
+		}
+	}
+
+	async deleteSourcebook(id: string): Promise<void> {
+		try {
+			const response = await this.api.delete(`data/forgesteel-homebrew-settings/${id}`);
+			return response.data.data;
+		} catch (error) {
+			console.error('Error communicating with FS Warehouse', error);
+			throw new Error(this.getErrorMessage(error), { cause: error });
+		}
+	}
+	// #endregion
+
+	async getSession(): Promise<Session | null> {
+		try {
+			const response = await this.api.get('data/forgesteel-session');
+			return response.data.data;
+		} catch (error) {
+			console.error('Error communicating with FS Warehouse', error);
+			throw new Error(this.getErrorMessage(error), { cause: error });
+		}
+	}
+
+	async putSession(value: Session): Promise<Session> {
+		try {
+			await this.api.put('data/forgesteel-session', value);
+			return value;
+		} catch (error) {
+			console.error('Error communicating with FS Warehouse', error);
+			throw new Error(this.getErrorMessage(error), { cause: error });
+		}
+	}
+
+	async getHiddenSourcebookIDs(): Promise<string[] | null> {
+		try {
+			const response = await this.api.get('data/forgesteel-hidden-setting-ids');
+			return response.data.data;
+		} catch (error) {
+			console.error('Error communicating with FS Warehouse', error);
+			throw new Error(this.getErrorMessage(error), { cause: error });
+		}
+	}
+
+	async putHiddenSourcebookIDs(value: string[]): Promise<string[]> {
+		try {
+			await this.api.put('data/forgesteel-hidden-setting-ids', value);
+			return value;
 		} catch (error) {
 			console.error('Error communicating with FS Warehouse', error);
 			throw new Error(this.getErrorMessage(error), { cause: error });

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,9 +1,9 @@
 import { Converter } from 'showdown';
-import { Random } from '@/utils/random';
 import { SheetPageSize } from '@/enums/sheet-page-size';
 import { domToImage } from 'modern-screenshot';
 import html2canvas from 'html2canvas';
 import jspdf from 'jspdf';
+import { v4 as uuidv4 } from 'uuid';
 
 export class Utils {
 	static showdownConverter = new Converter({ simpleLineBreaks: true, tables: true });
@@ -13,21 +13,7 @@ export class Utils {
 	};
 
 	static guid = () => {
-		const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890';
-		const sectionCount = 6;
-		const tokenLength = 5;
-
-		const sections = [];
-		while (sections.length < sectionCount) {
-			let id = '';
-			while (id.length < tokenLength) {
-				const n = Random.randomNumber(letters.length);
-				id += letters[n];
-			}
-			sections.push(id);
-		}
-
-		return sections.join('-');
+		return uuidv4();
 	};
 
 	// From: https://github.com/bryc/code/blob/master/jshash/experimental/cyrb53.js


### PR DESCRIPTION
Adds support for the new single-hero api endpoints available in forgesteel-warehouse `1.6`.

When using a remote warehouse, uses a 2-stage loading process for Heroes where an initial request retrieves just the IDs, then individual rest calls are made to get the full Hero object data. This method can also be done for homebrew sourcebooks in the future, but for now just Heroes are loaded this way.

In the initial data load, if there is an error thrown during the `updateSourcebook` or `updateHero` process, an error is added to the log, but the exception no longer halts the rest of the app load.

Added a dependency on `uuid` library to replace the custom `Utils.guid` implementation. RFC compliant uuidv4s are now generated instead.

