### PR TITLE
Add DataManager and data Contexts & Dispatchers

### DIFF
--- a/src/components/features/feature-data/ability-cost.tsx
+++ b/src/components/features/feature-data/ability-cost.tsx
@@ -6,7 +6,6 @@ import { Field } from '@/components/controls/field/field';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { Sourcebook } from '@/models/sourcebook';
 import { Utils } from '@/utils/utils';
 import { useState } from 'react';
@@ -16,7 +15,6 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoAbilityCost = (props: InfoProps) => {
@@ -28,7 +26,6 @@ export const InfoAbilityCost = (props: InfoProps) => {
 interface EditProps {
 	data: FeatureAbilityCostData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureAbilityCostData) => void;
 }
 

--- a/src/components/features/feature-data/ability-damage.tsx
+++ b/src/components/features/feature-data/ability-damage.tsx
@@ -9,7 +9,6 @@ import { FormatLogic } from '@/logic/format-logic';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { ModifierEditor } from '@/components/panels/edit/modifier-edit/modifier-edit-panel';
-import { Options } from '@/models/options';
 import { Sourcebook } from '@/models/sourcebook';
 import { Utils } from '@/utils/utils';
 import { useState } from 'react';
@@ -19,7 +18,6 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoAbilityDamage = (props: InfoProps) => {
@@ -31,7 +29,6 @@ export const InfoAbilityDamage = (props: InfoProps) => {
 interface EditProps {
 	data: FeatureAbilityDamageData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureAbilityDamageData) => void;
 }
 

--- a/src/components/features/feature-data/ability-distance.tsx
+++ b/src/components/features/feature-data/ability-distance.tsx
@@ -8,7 +8,6 @@ import { FormatLogic } from '@/logic/format-logic';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { ModifierEditor } from '@/components/panels/edit/modifier-edit/modifier-edit-panel';
-import { Options } from '@/models/options';
 import { Sourcebook } from '@/models/sourcebook';
 import { Utils } from '@/utils/utils';
 import { useState } from 'react';
@@ -18,7 +17,6 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoAbilityDistance = (props: InfoProps) => {
@@ -30,7 +28,6 @@ export const InfoAbilityDistance = (props: InfoProps) => {
 interface EditProps {
 	data: FeatureAbilityDistanceData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureAbilityDistanceData) => void;
 }
 

--- a/src/components/features/feature-data/ability.tsx
+++ b/src/components/features/feature-data/ability.tsx
@@ -2,7 +2,6 @@ import { Ability } from '@/models/ability';
 import { AbilityEditPanel } from '@/components/panels/edit/ability-edit/ability-edit-panel';
 import { Expander } from '@/components/controls/expander/expander';
 import { FeatureAbilityData } from '@/models/feature';
-import { Options } from '@/models/options';
 import { Sourcebook } from '@/models/sourcebook';
 import { Utils } from '@/utils/utils';
 import { useState } from 'react';
@@ -10,7 +9,6 @@ import { useState } from 'react';
 interface EditProps {
 	data: FeatureAbilityData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureAbilityData) => void;
 }
 

--- a/src/components/features/feature-data/addon.tsx
+++ b/src/components/features/feature-data/addon.tsx
@@ -3,7 +3,6 @@ import { FeatureAddOnData } from '@/models/feature';
 import { FeatureAddOnType } from '@/enums/feature-addon-type';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { Sourcebook } from '@/models/sourcebook';
 import { Utils } from '@/utils/utils';
 import { useState } from 'react';
@@ -11,7 +10,6 @@ import { useState } from 'react';
 interface EditProps {
 	data: FeatureAddOnData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureAddOnData) => void;
 }
 

--- a/src/components/features/feature-data/ancestry-choice.tsx
+++ b/src/components/features/feature-data/ancestry-choice.tsx
@@ -9,7 +9,6 @@ import { Hero } from '@/models/hero';
 import { InfoCircleOutlined } from '@ant-design/icons';
 import { Markdown } from '@/components/controls/markdown/markdown';
 import { Modal } from '@/components/modals/modal/modal';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Sourcebook } from '@/models/sourcebook';
 import { SourcebookLogic } from '@/logic/sourcebook-logic';
@@ -21,7 +20,6 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoAncestryChoice = (props: InfoProps) => {
@@ -33,7 +31,6 @@ export const InfoAncestryChoice = (props: InfoProps) => {
 		<AncestryPanel
 			ancestry={props.data.selected}
 			sourcebooks={props.sourcebooks || []}
-			options={props.options}
 		/>
 	);
 };
@@ -43,7 +40,6 @@ interface ConfigProps {
 	feature: Feature;
 	hero: Hero;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureAncestryChoiceData) => void;
 }
 
@@ -95,7 +91,7 @@ export const ConfigAncestryChoice = (props: ConfigProps) => {
 			}
 			<Drawer open={!!selectedAncestry} onClose={() => setSelectedAncestry(null)} closeIcon={null} size={500}>
 				<Modal
-					content={selectedAncestry ? <AncestryPanel ancestry={selectedAncestry} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} /> : null}
+					content={selectedAncestry ? <AncestryPanel ancestry={selectedAncestry} sourcebooks={props.sourcebooks} mode={PanelMode.Full} /> : null}
 					onClose={() => setSelectedAncestry(null)}
 				/>
 			</Drawer>

--- a/src/components/features/feature-data/ancestry-feature-choice.tsx
+++ b/src/components/features/feature-data/ancestry-feature-choice.tsx
@@ -10,7 +10,6 @@ import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { HeroLogic } from '@/logic/hero-logic';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { Sourcebook } from '@/models/sourcebook';
 import { SourcebookLogic } from '@/logic/sourcebook-logic';
 import { Toggle } from '@/components/controls/toggle/toggle';
@@ -22,7 +21,6 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoAncestryFeatureChoice = (props: InfoProps) => {
@@ -38,7 +36,6 @@ export const InfoAncestryFeatureChoice = (props: InfoProps) => {
 interface EditProps {
 	data: FeatureAncestryFeatureChoiceData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureAncestryFeatureChoiceData) => void;
 }
 
@@ -82,7 +79,6 @@ interface ConfigProps {
 	feature: Feature;
 	hero: Hero;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureAncestryFeatureChoiceData) => void;
 }
 
@@ -140,7 +136,7 @@ export const ConfigAncestryFeatureChoice = (props: ConfigProps) => {
 			/>
 			{
 				props.data.selected ?
-					<FeaturePanel feature={props.data.selected} options={props.options} />
+					<FeaturePanel feature={props.data.selected} />
 					: null
 			}
 		</Space>

--- a/src/components/features/feature-data/bonus.tsx
+++ b/src/components/features/feature-data/bonus.tsx
@@ -7,7 +7,6 @@ import { FormatLogic } from '@/logic/format-logic';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { ModifierEditor } from '@/components/panels/edit/modifier-edit/modifier-edit-panel';
-import { Options } from '@/models/options';
 import { Sourcebook } from '@/models/sourcebook';
 import { Utils } from '@/utils/utils';
 import { useState } from 'react';
@@ -17,7 +16,6 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoBonus = (props: InfoProps) => {
@@ -29,7 +27,6 @@ export const InfoBonus = (props: InfoProps) => {
 interface EditProps {
 	data: FeatureBonusData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureBonusData) => void;
 }
 

--- a/src/components/features/feature-data/characteristic-bonus.tsx
+++ b/src/components/features/feature-data/characteristic-bonus.tsx
@@ -5,7 +5,6 @@ import { Field } from '@/components/controls/field/field';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { Sourcebook } from '@/models/sourcebook';
 import { Utils } from '@/utils/utils';
 import { useState } from 'react';
@@ -15,7 +14,6 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoCharacteristicBonus = (props: InfoProps) => {
@@ -27,7 +25,6 @@ export const InfoCharacteristicBonus = (props: InfoProps) => {
 interface EditProps {
 	data: FeatureCharacteristicBonusData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureCharacteristicBonusData) => void;
 }
 

--- a/src/components/features/feature-data/choice.tsx
+++ b/src/components/features/feature-data/choice.tsx
@@ -17,7 +17,6 @@ import { HeroLogic } from '@/logic/hero-logic';
 import { Markdown } from '@/components/controls/markdown/markdown';
 import { Modal } from '@/components/modals/modal/modal';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Sourcebook } from '@/models/sourcebook';
 import { Toggle } from '@/components/controls/toggle/toggle';
@@ -29,14 +28,13 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoChoice = (props: InfoProps) => {
 	if (props.data.selected.length > 0) {
 		return (
 			<Space orientation='vertical' style={{ width: '100%', padding: '0 20px', borderLeft: '5px solid rgb(200 200 200)' }}>
-				{props.data.selected.map(f => <FeaturePanel key={f.id} feature={f} options={props.options} mode={PanelMode.Full} />)}
+				{props.data.selected.map(f => <FeaturePanel key={f.id} feature={f} mode={PanelMode.Full} />)}
 			</Space>
 		);
 	}
@@ -60,7 +58,7 @@ export const InfoChoice = (props: InfoProps) => {
 				{
 					props.data.options.map(o => (
 						<Expander key={o.feature.id} title={o.feature.name}>
-							<FeaturePanel feature={o.feature} options={props.options} cost={showCosts ? o.value : undefined} mode={PanelMode.Full} />
+							<FeaturePanel feature={o.feature} cost={showCosts ? o.value : undefined} mode={PanelMode.Full} />
 						</Expander>
 					))
 				}
@@ -72,7 +70,6 @@ export const InfoChoice = (props: InfoProps) => {
 interface EditProps {
 	data: FeatureChoiceData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureChoiceData) => void;
 }
 
@@ -159,7 +156,6 @@ export const EditChoice = (props: EditProps) => {
 							<FeatureEditPanel
 								feature={option.feature}
 								sourcebooks={props.sourcebooks}
-								options={props.options}
 								onChange={f => setChoiceFeature(data, n, f)}
 							/>
 							<NumberSpin min={1} value={option.value} onChange={value => setChoiceValue(data, n, value)} />
@@ -195,7 +191,6 @@ interface ConfigProps {
 	feature: Feature;
 	hero: Hero;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureChoiceData) => void;
 }
 
@@ -319,7 +314,6 @@ export const ConfigChoice = (props: ConfigProps) => {
 					features={sortedOptions}
 					hero={props.hero}
 					sourcebooks={props.sourcebooks}
-					options={props.options}
 					onSelect={feature => {
 						setChoiceSelectorOpen(false);
 
@@ -332,7 +326,7 @@ export const ConfigChoice = (props: ConfigProps) => {
 			</Drawer>
 			<Drawer open={!!selectedFeature} onClose={() => setSelectedFeature(null)} closeIcon={null} size={500}>
 				<Modal
-					content={selectedFeature ? <FeaturePanel style={{ padding: '0 20px 20px 20px' }} feature={selectedFeature} options={props.options} mode={PanelMode.Full} /> : null}
+					content={selectedFeature ? <FeaturePanel style={{ padding: '0 20px 20px 20px' }} feature={selectedFeature} mode={PanelMode.Full} /> : null}
 					onClose={() => setSelectedFeature(null)}
 				/>
 			</Drawer>

--- a/src/components/features/feature-data/class-ability.tsx
+++ b/src/components/features/feature-data/class-ability.tsx
@@ -14,7 +14,6 @@ import { HeroClass } from '@/models/class';
 import { HeroLogic } from '@/logic/hero-logic';
 import { Markdown } from '@/components/controls/markdown/markdown';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Sourcebook } from '@/models/sourcebook';
 import { SourcebookLogic } from '@/logic/sourcebook-logic';
@@ -27,7 +26,6 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoClassAbility = (props: InfoProps) => {
@@ -78,7 +76,6 @@ export const InfoClassAbility = (props: InfoProps) => {
 interface EditProps {
 	data: FeatureClassAbilityData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureClassAbilityData) => void;
 }
 
@@ -212,7 +209,6 @@ interface ConfigProps {
 	feature: Feature;
 	hero: Hero;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureClassAbilityData) => void;
 }
 

--- a/src/components/features/feature-data/companion.tsx
+++ b/src/components/features/feature-data/companion.tsx
@@ -10,7 +10,6 @@ import { MonsterModal } from '@/components/modals/monster/monster-modal';
 import { MonsterPanel } from '@/components/panels/elements/monster-panel/monster-panel';
 import { MonsterSelectModal } from '@/components/modals/select/monster-select/monster-select-modal';
 import { NameSuggestions } from '@/components/panels/name-suggestions/name-suggestions';
-import { Options } from '@/models/options';
 import { Sourcebook } from '@/models/sourcebook';
 import { SourcebookLogic } from '@/logic/sourcebook-logic';
 import { TextInput } from '@/components/controls/text-input/text-input';
@@ -22,7 +21,6 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoCompanion = (props: InfoProps) => {
@@ -34,7 +32,7 @@ export const InfoCompanion = (props: InfoProps) => {
 		);
 	}
 
-	return <MonsterPanel monster={props.data.selected} sourcebooks={props.sourcebooks || []} options={props.options} />;
+	return <MonsterPanel monster={props.data.selected} sourcebooks={props.sourcebooks || []} />;
 };
 
 interface ConfigProps {
@@ -42,7 +40,6 @@ interface ConfigProps {
 	feature: Feature;
 	hero: Hero;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureCompanionData) => void;
 }
 
@@ -108,7 +105,6 @@ export const ConfigCompanion = (props: ConfigProps) => {
 				<MonsterSelectModal
 					monsters={SourcebookLogic.getMonsters(props.sourcebooks)}
 					sourcebooks={props.sourcebooks}
-					options={props.options}
 					onSelect={monster => {
 						setMonsterSelectorOpen(false);
 
@@ -126,7 +122,6 @@ export const ConfigCompanion = (props: ConfigProps) => {
 						<MonsterModal
 							monster={selectedMonster}
 							sourcebooks={props.sourcebooks}
-							options={props.options}
 							onClose={() => setSelectedMonster(null)}
 						/>
 						: null

--- a/src/components/features/feature-data/condition-immunity.tsx
+++ b/src/components/features/feature-data/condition-immunity.tsx
@@ -4,7 +4,6 @@ import { ConditionType } from '@/enums/condition-type';
 import { Field } from '@/components/controls/field/field';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
-import { Options } from '@/models/options';
 import { Sourcebook } from '@/models/sourcebook';
 import { Utils } from '@/utils/utils';
 import { useState } from 'react';
@@ -14,7 +13,6 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoConditionImmunity = (props: InfoProps) => {
@@ -26,7 +24,6 @@ export const InfoConditionImmunity = (props: InfoProps) => {
 interface EditProps {
 	data: FeatureConditionImmunityData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureConditionImmunityData) => void;
 }
 

--- a/src/components/features/feature-data/damage-modifier.tsx
+++ b/src/components/features/feature-data/damage-modifier.tsx
@@ -11,7 +11,6 @@ import { FormatLogic } from '@/logic/format-logic';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { ModifierEditor } from '@/components/panels/edit/modifier-edit/modifier-edit-panel';
-import { Options } from '@/models/options';
 import { PlusOutlined } from '@ant-design/icons';
 import { RadioGroup } from '@/components/controls/radio-group/radio-group';
 import { Sourcebook } from '@/models/sourcebook';
@@ -23,7 +22,6 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoDamageModifier = (props: InfoProps) => {
@@ -37,7 +35,6 @@ export const InfoDamageModifier = (props: InfoProps) => {
 interface EditProps {
 	data: FeatureDamageModifierData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureDamageModifierData) => void;
 }
 

--- a/src/components/features/feature-data/domain-feature.tsx
+++ b/src/components/features/feature-data/domain-feature.tsx
@@ -6,7 +6,6 @@ import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { HeroLogic } from '@/logic/hero-logic';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Sourcebook } from '@/models/sourcebook';
 import { Utils } from '@/utils/utils';
@@ -17,7 +16,6 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoDomainFeature = (props: InfoProps) => {
@@ -28,7 +26,7 @@ export const InfoDomainFeature = (props: InfoProps) => {
 	return (
 		<Space orientation='vertical' style={{ width: '100%' }}>
 			{
-				props.data.selected.map(f => <FeaturePanel key={f.id} feature={f} options={props.options} />)
+				props.data.selected.map(f => <FeaturePanel key={f.id} feature={f} />)
 			}
 		</Space>
 	);
@@ -37,7 +35,6 @@ export const InfoDomainFeature = (props: InfoProps) => {
 interface EditProps {
 	data: FeatureDomainFeatureData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureDomainFeatureData) => void;
 }
 
@@ -73,7 +70,6 @@ interface ConfigProps {
 	feature: Feature;
 	hero: Hero;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureDomainFeatureData) => void;
 }
 
@@ -130,7 +126,7 @@ export const ConfigDomainFeature = (props: ConfigProps) => {
 			/>
 			{
 				props.data.selected.map(f => (
-					<FeaturePanel key={f.id} feature={f} options={props.options} hero={props.hero} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
+					<FeaturePanel key={f.id} feature={f} hero={props.hero} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
 				))
 			}
 		</Space>

--- a/src/components/features/feature-data/domain.tsx
+++ b/src/components/features/feature-data/domain.tsx
@@ -13,7 +13,6 @@ import { InfoCircleOutlined } from '@ant-design/icons';
 import { Markdown } from '@/components/controls/markdown/markdown';
 import { Modal } from '@/components/modals/modal/modal';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Sourcebook } from '@/models/sourcebook';
 import { SourcebookLogic } from '@/logic/sourcebook-logic';
@@ -25,7 +24,6 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoDomain = (props: InfoProps) => {
@@ -33,7 +31,7 @@ export const InfoDomain = (props: InfoProps) => {
 		return (
 			<Space orientation='vertical' style={{ width: '100%' }}>
 				{
-					props.data.selected.map(d => <DomainPanel key={d.id} domain={d} sourcebooks={props.sourcebooks || []} options={props.options} />)
+					props.data.selected.map(d => <DomainPanel key={d.id} domain={d} sourcebooks={props.sourcebooks || []} />)
 				}
 			</Space>
 		);
@@ -47,7 +45,6 @@ export const InfoDomain = (props: InfoProps) => {
 interface EditProps {
 	data: FeatureDomainData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureDomainData) => void;
 }
 
@@ -105,7 +102,6 @@ interface ConfigProps {
 	feature: Feature;
 	hero: Hero;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureDomainData) => void;
 }
 
@@ -175,7 +171,7 @@ export const ConfigDomain = (props: ConfigProps) => {
 			}
 			<Drawer open={!!selectedDomain} onClose={() => setSelectedDomain(null)} closeIcon={null} size={500}>
 				<Modal
-					content={selectedDomain ? <DomainPanel domain={selectedDomain} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} /> : null}
+					content={selectedDomain ? <DomainPanel domain={selectedDomain} sourcebooks={props.sourcebooks} mode={PanelMode.Full} /> : null}
 					onClose={() => setSelectedDomain(null)}
 				/>
 			</Drawer>

--- a/src/components/features/feature-data/fixture.tsx
+++ b/src/components/features/feature-data/fixture.tsx
@@ -4,7 +4,6 @@ import { Fixture } from '@/models/fixture';
 import { FixtureEditPanel } from '@/components/panels/edit/fixture-edit/fixture-edit-panel';
 import { FixturePanel } from '@/components/panels/elements/fixture-panel/fixture-panel';
 import { Hero } from '@/models/hero';
-import { Options } from '@/models/options';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
 import { Sourcebook } from '@/models/sourcebook';
 import { Utils } from '@/utils/utils';
@@ -15,13 +14,12 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoFixture = (props: InfoProps) => {
 	return (
 		<SelectablePanel key={props.data.fixture.id}>
-			<FixturePanel fixture={props.data.fixture} sourcebooks={props.sourcebooks} hero={props.hero} options={props.options} />
+			<FixturePanel fixture={props.data.fixture} sourcebooks={props.sourcebooks} hero={props.hero} />
 		</SelectablePanel>
 	);
 };
@@ -29,7 +27,6 @@ export const InfoFixture = (props: InfoProps) => {
 interface EditProps {
 	data: FeatureFixtureData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureFixtureData) => void;
 }
 
@@ -49,7 +46,6 @@ export const EditFixture = (props: EditProps) => {
 				<FixtureEditPanel
 					fixture={data.fixture}
 					sourcebooks={props.sourcebooks}
-					options={props.options}
 					onChange={setFixture}
 				/>
 			</Expander>

--- a/src/components/features/feature-data/heroic-resource-gain.tsx
+++ b/src/components/features/feature-data/heroic-resource-gain.tsx
@@ -2,7 +2,6 @@ import { Feature, FeatureHeroicResourceGainData } from '@/models/feature';
 import { Flex, Select, Space } from 'antd';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
-import { Options } from '@/models/options';
 import { Pill } from '@/components/controls/pill/pill';
 import { Sourcebook } from '@/models/sourcebook';
 import { TextInput } from '@/components/controls/text-input/text-input';
@@ -14,7 +13,6 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoHeroicResourceGain = (props: InfoProps) => {
@@ -32,7 +30,6 @@ export const InfoHeroicResourceGain = (props: InfoProps) => {
 interface EditProps {
 	data: FeatureHeroicResourceGainData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureHeroicResourceGainData) => void;
 }
 

--- a/src/components/features/feature-data/heroic-resource.tsx
+++ b/src/components/features/feature-data/heroic-resource.tsx
@@ -10,7 +10,6 @@ import { Format } from '@/utils/format';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { HeroLogic } from '@/logic/hero-logic';
-import { Options } from '@/models/options';
 import { Pill } from '@/components/controls/pill/pill';
 import { Sourcebook } from '@/models/sourcebook';
 import { TextInput } from '@/components/controls/text-input/text-input';
@@ -23,7 +22,6 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoHeroicResource = (props: InfoProps) => {
@@ -56,7 +54,6 @@ export const InfoHeroicResource = (props: InfoProps) => {
 interface EditProps {
 	data: FeatureHeroicResourceData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureHeroicResourceData) => void;
 }
 

--- a/src/components/features/feature-data/item-choice.tsx
+++ b/src/components/features/feature-data/item-choice.tsx
@@ -12,7 +12,6 @@ import { ItemType } from '@/enums/item-type';
 import { Markdown } from '@/components/controls/markdown/markdown';
 import { Modal } from '@/components/modals/modal/modal';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { Sourcebook } from '@/models/sourcebook';
 import { Utils } from '@/utils/utils';
 import { useState } from 'react';
@@ -22,7 +21,6 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoItemChoice = (props: InfoProps) => {
@@ -30,7 +28,7 @@ export const InfoItemChoice = (props: InfoProps) => {
 		return (
 			<Space orientation='vertical' style={{ width: '100%' }}>
 				{
-					props.data.selected.map(i => <ItemPanel key={i.id} item={i} sourcebooks={props.sourcebooks || []} options={props.options} />)
+					props.data.selected.map(i => <ItemPanel key={i.id} item={i} sourcebooks={props.sourcebooks || []} />)
 				}
 			</Space>
 		);
@@ -54,7 +52,6 @@ export const InfoItemChoice = (props: InfoProps) => {
 interface EditProps {
 	data: FeatureItemChoiceData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureItemChoiceData) => void;
 }
 
@@ -100,7 +97,6 @@ interface ConfigProps {
 	feature: Feature;
 	hero: Hero;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureItemChoiceData) => void;
 }
 
@@ -156,7 +152,6 @@ export const ConfigItemChoice = (props: ConfigProps) => {
 					types={props.data.types}
 					sourcebooks={props.sourcebooks}
 					hero={props.hero}
-					options={props.options}
 					onSelect={item => {
 						setItemSelectorOpen(false);
 
@@ -171,7 +166,7 @@ export const ConfigItemChoice = (props: ConfigProps) => {
 			</Drawer>
 			<Drawer open={!!selectedItem} onClose={() => setSelectedItem(null)} closeIcon={null} size={500}>
 				<Modal
-					content={selectedItem ? <ItemPanel item={selectedItem} sourcebooks={props.sourcebooks} options={props.options} /> : null}
+					content={selectedItem ? <ItemPanel item={selectedItem} sourcebooks={props.sourcebooks} /> : null}
 					onClose={() => setSelectedItem(null)}
 				/>
 			</Drawer>

--- a/src/components/features/feature-data/kit.tsx
+++ b/src/components/features/feature-data/kit.tsx
@@ -13,7 +13,6 @@ import { KitSelectModal } from '@/components/modals/select/kit-select/kit-select
 import { Markdown } from '@/components/controls/markdown/markdown';
 import { Modal } from '@/components/modals/modal/modal';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Sourcebook } from '@/models/sourcebook';
 import { SourcebookLogic } from '@/logic/sourcebook-logic';
@@ -25,7 +24,6 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoKit = (props: InfoProps) => {
@@ -33,7 +31,7 @@ export const InfoKit = (props: InfoProps) => {
 		return (
 			<Space orientation='vertical' style={{ width: '100%' }}>
 				{
-					props.data.selected.map(k => <KitPanel key={k.id} kit={k} sourcebooks={props.sourcebooks || []} options={props.options} />)
+					props.data.selected.map(k => <KitPanel key={k.id} kit={k} sourcebooks={props.sourcebooks || []} />)
 				}
 			</Space>
 		);
@@ -47,7 +45,6 @@ export const InfoKit = (props: InfoProps) => {
 interface EditProps {
 	data: FeatureKitData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureKitData) => void;
 }
 
@@ -93,7 +90,6 @@ interface ConfigProps {
 	feature: Feature;
 	hero: Hero;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureKitData) => void;
 }
 
@@ -163,7 +159,6 @@ export const ConfigKit = (props: ConfigProps) => {
 					kits={sortedKits}
 					hero={props.hero}
 					sourcebooks={props.sourcebooks}
-					options={props.options}
 					onSelect={kit => {
 						setKitSelectorOpen(false);
 
@@ -178,7 +173,7 @@ export const ConfigKit = (props: ConfigProps) => {
 			</Drawer>
 			<Drawer open={!!selectedKit} onClose={() => setSelectedKit(null)} closeIcon={null} size={500}>
 				<Modal
-					content={selectedKit ? <KitPanel kit={selectedKit} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} /> : null}
+					content={selectedKit ? <KitPanel kit={selectedKit} sourcebooks={props.sourcebooks} mode={PanelMode.Full} /> : null}
 					onClose={() => setSelectedKit(null)}
 				/>
 			</Drawer>

--- a/src/components/features/feature-data/language-choice.tsx
+++ b/src/components/features/feature-data/language-choice.tsx
@@ -8,7 +8,6 @@ import { Hero } from '@/models/hero';
 import { HeroLogic } from '@/logic/hero-logic';
 import { LanguageSelectModal } from '@/components/modals/select/language-select/language-select-modal';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { Sourcebook } from '@/models/sourcebook';
 import { SourcebookLogic } from '@/logic/sourcebook-logic';
 import { Utils } from '@/utils/utils';
@@ -19,7 +18,6 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoLanguageChoice = (props: InfoProps) => {
@@ -37,7 +35,6 @@ export const InfoLanguageChoice = (props: InfoProps) => {
 interface EditProps {
 	data: FeatureLanguageChoiceData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureLanguageChoiceData) => void;
 }
 
@@ -105,7 +102,6 @@ interface ConfigProps {
 	feature: Feature;
 	hero: Hero;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureLanguageChoiceData) => void;
 }
 

--- a/src/components/features/feature-data/language.tsx
+++ b/src/components/features/feature-data/language.tsx
@@ -3,7 +3,6 @@ import { Select, Space } from 'antd';
 import { Field } from '@/components/controls/field/field';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
-import { Options } from '@/models/options';
 import { Sourcebook } from '@/models/sourcebook';
 import { SourcebookLogic } from '@/logic/sourcebook-logic';
 import { Utils } from '@/utils/utils';
@@ -14,7 +13,6 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoLanguage = (props: InfoProps) => {
@@ -26,7 +24,6 @@ export const InfoLanguage = (props: InfoProps) => {
 interface EditProps {
 	data: FeatureLanguageData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureLanguageData) => void;
 }
 

--- a/src/components/features/feature-data/malice-ability.tsx
+++ b/src/components/features/feature-data/malice-ability.tsx
@@ -4,7 +4,6 @@ import { Expander } from '@/components/controls/expander/expander';
 import { FeatureMaliceAbilityData } from '@/models/feature';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { Sourcebook } from '@/models/sourcebook';
 import { Space } from 'antd';
 import { Utils } from '@/utils/utils';
@@ -13,7 +12,6 @@ import { useState } from 'react';
 interface EditProps {
 	data: FeatureMaliceAbilityData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureMaliceAbilityData) => void;
 }
 

--- a/src/components/features/feature-data/malice.tsx
+++ b/src/components/features/feature-data/malice.tsx
@@ -11,7 +11,6 @@ import { FactoryLogic } from '@/logic/factory-logic';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { PowerRoll } from '@/models/power-roll';
 import { PowerRollPanel } from '@/components/panels/power-roll/power-roll-panel';
 import { Sourcebook } from '@/models/sourcebook';
@@ -25,7 +24,6 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoMalice = (props: InfoProps) => {
@@ -45,7 +43,6 @@ export const InfoMalice = (props: InfoProps) => {
 interface EditProps {
 	data: FeatureMaliceData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureMaliceData) => void;
 }
 

--- a/src/components/features/feature-data/movement-mode.tsx
+++ b/src/components/features/feature-data/movement-mode.tsx
@@ -1,7 +1,6 @@
 import { Feature, FeatureMovementModeData } from '@/models/feature';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
-import { Options } from '@/models/options';
 import { Sourcebook } from '@/models/sourcebook';
 import { Space } from 'antd';
 import { TextInput } from '@/components/controls/text-input/text-input';
@@ -13,7 +12,6 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoMovementMode = (props: InfoProps) => {
@@ -27,7 +25,6 @@ export const InfoMovementMode = (props: InfoProps) => {
 interface EditProps {
 	data: FeatureMovementModeData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureMovementModeData) => void;
 }
 

--- a/src/components/features/feature-data/multiple.tsx
+++ b/src/components/features/feature-data/multiple.tsx
@@ -3,7 +3,6 @@ import { Expander } from '@/components/controls/expander/expander';
 import { FeatureListEditPanel } from '@/components/panels/edit/feature-list-edit/feature-list-edit-panel';
 import { FeaturePanel } from '@/components/panels/elements/feature-panel/feature-panel';
 import { Hero } from '@/models/hero';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Sourcebook } from '@/models/sourcebook';
 import { Utils } from '@/utils/utils';
@@ -14,7 +13,6 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoMultiple = (props: InfoProps) => {
@@ -25,7 +23,7 @@ export const InfoMultiple = (props: InfoProps) => {
 	if (props.feature.description) {
 		return (
 			<Expander title='Features'>
-				{props.data.features.map(f => <FeaturePanel key={f.id} feature={f} options={props.options} mode={PanelMode.Full} />)}
+				{props.data.features.map(f => <FeaturePanel key={f.id} feature={f} mode={PanelMode.Full} />)}
 			</Expander>
 		);
 	}
@@ -35,7 +33,7 @@ export const InfoMultiple = (props: InfoProps) => {
 			{
 				props.data.features.map(f => (
 					<div key={f.id} className='container'>
-						<FeaturePanel feature={f} options={props.options} mode={PanelMode.Full} />
+						<FeaturePanel feature={f} mode={PanelMode.Full} />
 					</div>
 				))
 			}
@@ -46,7 +44,6 @@ export const InfoMultiple = (props: InfoProps) => {
 interface EditProps {
 	data: FeatureMultipleData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureMultipleData) => void;
 }
 
@@ -65,7 +62,6 @@ export const EditMultiple = (props: EditProps) => {
 			title='Features'
 			features={data.features}
 			sourcebooks={props.sourcebooks}
-			options={props.options}
 			onChange={onChange}
 		/>
 	);

--- a/src/components/features/feature-data/package-content.tsx
+++ b/src/components/features/feature-data/package-content.tsx
@@ -1,6 +1,5 @@
 import { FeaturePackageContentData } from '@/models/feature';
 import { HeaderText } from '@/components/controls/header-text/header-text';
-import { Options } from '@/models/options';
 import { Sourcebook } from '@/models/sourcebook';
 import { Space } from 'antd';
 import { TextInput } from '@/components/controls/text-input/text-input';
@@ -10,7 +9,6 @@ import { useState } from 'react';
 interface EditProps {
 	data: FeaturePackageContentData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeaturePackageContentData) => void;
 }
 

--- a/src/components/features/feature-data/package.tsx
+++ b/src/components/features/feature-data/package.tsx
@@ -5,7 +5,6 @@ import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { HeroLogic } from '@/logic/hero-logic';
 import { Markdown } from '@/components/controls/markdown/markdown';
-import { Options } from '@/models/options';
 import { Sourcebook } from '@/models/sourcebook';
 import { Space } from 'antd';
 import { TextInput } from '@/components/controls/text-input/text-input';
@@ -17,7 +16,6 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoPackage = (props: InfoProps) => {
@@ -43,7 +41,6 @@ export const InfoPackage = (props: InfoProps) => {
 interface EditProps {
 	data: FeaturePackageData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeaturePackageData) => void;
 }
 

--- a/src/components/features/feature-data/perk.tsx
+++ b/src/components/features/feature-data/perk.tsx
@@ -11,7 +11,6 @@ import { HeroLogic } from '@/logic/hero-logic';
 import { Markdown } from '@/components/controls/markdown/markdown';
 import { Modal } from '@/components/modals/modal/modal';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Perk } from '@/models/perk';
 import { PerkList } from '@/enums/perk-list';
@@ -27,7 +26,6 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoPerk = (props: InfoProps) => {
@@ -35,7 +33,7 @@ export const InfoPerk = (props: InfoProps) => {
 		return (
 			<Space orientation='vertical' style={{ width: '100%' }}>
 				{
-					props.data.selected.map(p => <PerkPanel key={p.id} perk={p} sourcebooks={props.sourcebooks || []} options={props.options} />)
+					props.data.selected.map(p => <PerkPanel key={p.id} perk={p} sourcebooks={props.sourcebooks || []} />)
 				}
 			</Space>
 		);
@@ -49,7 +47,6 @@ export const InfoPerk = (props: InfoProps) => {
 interface EditProps {
 	data: FeaturePerkData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeaturePerkData) => void;
 }
 
@@ -95,7 +92,6 @@ interface ConfigProps {
 	feature: Feature;
 	hero: Hero;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeaturePerkData) => void;
 }
 
@@ -170,7 +166,6 @@ export const ConfigPerk = (props: ConfigProps) => {
 					perks={sortedPerks.filter(p => !currentPerkIDs.includes(p.id))}
 					hero={props.hero}
 					sourcebooks={props.sourcebooks}
-					options={props.options}
 					onSelect={perk => {
 						setPerkSelectorOpen(false);
 
@@ -183,7 +178,7 @@ export const ConfigPerk = (props: ConfigProps) => {
 			</Drawer>
 			<Drawer open={!!selectedPerk} onClose={() => setSelectedPerk(null)} closeIcon={null} size={500}>
 				<Modal
-					content={selectedPerk ? <PerkPanel perk={selectedPerk} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} /> : null}
+					content={selectedPerk ? <PerkPanel perk={selectedPerk} sourcebooks={props.sourcebooks} mode={PanelMode.Full} /> : null}
 					onClose={() => setSelectedPerk(null)}
 				/>
 			</Drawer>

--- a/src/components/features/feature-data/proficiency.tsx
+++ b/src/components/features/feature-data/proficiency.tsx
@@ -5,7 +5,6 @@ import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { KitArmor } from '@/enums/kit-armor';
 import { KitWeapon } from '@/enums/kit-weapon';
-import { Options } from '@/models/options';
 import { Sourcebook } from '@/models/sourcebook';
 import { Utils } from '@/utils/utils';
 import { useState } from 'react';
@@ -15,7 +14,6 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoProficiency = (props: InfoProps) => {
@@ -30,7 +28,6 @@ export const InfoProficiency = (props: InfoProps) => {
 interface EditProps {
 	data: FeatureProficiencyData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureProficiencyData) => void;
 }
 

--- a/src/components/features/feature-data/retainer.tsx
+++ b/src/components/features/feature-data/retainer.tsx
@@ -11,7 +11,6 @@ import { MonsterInfo } from '@/components/panels/token/token';
 import { MonsterModal } from '@/components/modals/monster/monster-modal';
 import { MonsterPanel } from '@/components/panels/elements/monster-panel/monster-panel';
 import { NameSuggestions } from '@/components/panels/name-suggestions/name-suggestions';
-import { Options } from '@/models/options';
 import { RetainerSelectModal } from '@/components/modals/select/retainer-select/retainer-select-modal';
 import { Sourcebook } from '@/models/sourcebook';
 import { SourcebookLogic } from '@/logic/sourcebook-logic';
@@ -24,7 +23,6 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoRetainer = (props: InfoProps) => {
@@ -36,7 +34,7 @@ export const InfoRetainer = (props: InfoProps) => {
 		);
 	}
 
-	return <MonsterPanel monster={props.data.selected} sourcebooks={props.sourcebooks || []} options={props.options} />;
+	return <MonsterPanel monster={props.data.selected} sourcebooks={props.sourcebooks || []} />;
 };
 
 interface ConfigProps {
@@ -44,7 +42,6 @@ interface ConfigProps {
 	feature: Feature;
 	hero: Hero;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureRetainerData) => void;
 }
 
@@ -117,7 +114,6 @@ export const ConfigRetainer = (props: ConfigProps) => {
 									<FeatureConfigPanel
 										key={lvl.level}
 										feature={lvl.feature}
-										options={props.options}
 										hero={props.hero}
 										sourcebooks={props.sourcebooks}
 										setData={(fID, d) => {
@@ -140,7 +136,6 @@ export const ConfigRetainer = (props: ConfigProps) => {
 				<RetainerSelectModal
 					monsters={SourcebookLogic.getMonsters(props.sourcebooks)}
 					sourcebooks={props.sourcebooks}
-					options={props.options}
 					onSelect={monster => {
 						setMonsterSelectorOpen(false);
 
@@ -162,7 +157,6 @@ export const ConfigRetainer = (props: ConfigProps) => {
 						<MonsterModal
 							monster={selectedMonster}
 							sourcebooks={props.sourcebooks}
-							options={props.options}
 							onClose={() => setSelectedMonster(null)}
 						/>
 						: null

--- a/src/components/features/feature-data/save-threshold.tsx
+++ b/src/components/features/feature-data/save-threshold.tsx
@@ -3,7 +3,6 @@ import { Field } from '@/components/controls/field/field';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { Sourcebook } from '@/models/sourcebook';
 import { Space } from 'antd';
 import { Utils } from '@/utils/utils';
@@ -14,7 +13,6 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoSaveThreshold = (props: InfoProps) => {
@@ -26,7 +24,6 @@ export const InfoSaveThreshold = (props: InfoProps) => {
 interface EditProps {
 	data: FeatureSaveThresholdData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureSaveThresholdData) => void;
 }
 

--- a/src/components/features/feature-data/size.tsx
+++ b/src/components/features/feature-data/size.tsx
@@ -5,7 +5,6 @@ import { FormatLogic } from '@/logic/format-logic';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { Sourcebook } from '@/models/sourcebook';
 import { Utils } from '@/utils/utils';
 import { useState } from 'react';
@@ -15,7 +14,6 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoSize = (props: InfoProps) => {
@@ -27,7 +25,6 @@ export const InfoSize = (props: InfoProps) => {
 interface EditProps {
 	data: FeatureSizeData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureSizeData) => void;
 }
 

--- a/src/components/features/feature-data/skill-choice.tsx
+++ b/src/components/features/feature-data/skill-choice.tsx
@@ -8,7 +8,6 @@ import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { HeroLogic } from '@/logic/hero-logic';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { SkillList } from '@/enums/skill-list';
 import { SkillSelectModal } from '@/components/modals/select/skill-select/skill-select-modal';
 import { Sourcebook } from '@/models/sourcebook';
@@ -21,7 +20,6 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoSkillChoice = (props: InfoProps) => {
@@ -49,7 +47,6 @@ export const InfoSkillChoice = (props: InfoProps) => {
 interface EditProps {
 	data: FeatureSkillChoiceData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureSkillChoiceData) => void;
 }
 
@@ -135,7 +132,6 @@ interface ConfigProps {
 	feature: Feature;
 	hero: Hero;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureSkillChoiceData) => void;
 }
 

--- a/src/components/features/feature-data/speed.tsx
+++ b/src/components/features/feature-data/speed.tsx
@@ -3,7 +3,6 @@ import { Field } from '@/components/controls/field/field';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { Sourcebook } from '@/models/sourcebook';
 import { Space } from 'antd';
 import { Utils } from '@/utils/utils';
@@ -14,7 +13,6 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoSpeed = (props: InfoProps) => {
@@ -26,7 +24,6 @@ export const InfoSpeed = (props: InfoProps) => {
 interface EditProps {
 	data: FeatureSpeedData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureSpeedData) => void;
 }
 

--- a/src/components/features/feature-data/summon-choice.tsx
+++ b/src/components/features/feature-data/summon-choice.tsx
@@ -16,7 +16,6 @@ import { MonsterOrganizationType } from '@/enums/monster-organization-type';
 import { MonsterPanel } from '@/components/panels/elements/monster-panel/monster-panel';
 import { MonsterRoleType } from '@/enums/monster-role-type';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
 import { Sourcebook } from '@/models/sourcebook';
@@ -32,14 +31,13 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoSummonChoice = (props: InfoProps) => {
 	if (props.data.selected.length > 0) {
 		return (
 			<Space orientation='vertical' style={{ width: '100%' }}>
-				{props.data.selected.map(s => <SelectablePanel key={s.id}><MonsterPanel monster={s.monster} summon={s.info} sourcebooks={props.sourcebooks || []} options={props.options} mode={PanelMode.Full} /></SelectablePanel>)}
+				{props.data.selected.map(s => <SelectablePanel key={s.id}><MonsterPanel monster={s.monster} summon={s.info} sourcebooks={props.sourcebooks || []} mode={PanelMode.Full} /></SelectablePanel>)}
 			</Space>
 		);
 	}
@@ -51,7 +49,7 @@ export const InfoSummonChoice = (props: InfoProps) => {
 				{
 					props.data.options.map(s => (
 						<Expander key={s.id} title={s.monster.name}>
-							<MonsterPanel monster={s.monster} summon={s.info} sourcebooks={props.sourcebooks || []} options={props.options} mode={PanelMode.Full} />
+							<MonsterPanel monster={s.monster} summon={s.info} sourcebooks={props.sourcebooks || []} mode={PanelMode.Full} />
 						</Expander>
 					))
 				}
@@ -63,7 +61,6 @@ export const InfoSummonChoice = (props: InfoProps) => {
 interface EditProps {
 	data: FeatureSummonChoiceData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureSummonChoiceData) => void;
 }
 
@@ -173,7 +170,6 @@ export const EditSummonChoice = (props: EditProps) => {
 						<MonsterEditPanel
 							monster={summon.monster}
 							sourcebooks={props.sourcebooks}
-							options={props.options}
 							onChange={m => setSummonChoiceMonster(data, n, m)}
 						/>
 					</Expander>
@@ -195,7 +191,6 @@ interface ConfigProps {
 	feature: Feature;
 	hero: Hero;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureSummonChoiceData) => void;
 }
 
@@ -250,7 +245,6 @@ export const ConfigSummonChoice = (props: ConfigProps) => {
 					summons={props.data.options}
 					hero={props.hero}
 					sourcebooks={props.sourcebooks}
-					options={props.options}
 					onSelect={summon => {
 						setMonsterSelectorOpen(false);
 
@@ -270,7 +264,6 @@ export const ConfigSummonChoice = (props: ConfigProps) => {
 							monster={SummonLogic.getSummonedMonster(selectedSummon, props.hero)}
 							summon={selectedSummon.info}
 							sourcebooks={props.sourcebooks}
-							options={props.options}
 							onClose={() => setSelectedSummon(null)}
 						/>
 						: null

--- a/src/components/features/feature-data/summon.tsx
+++ b/src/components/features/feature-data/summon.tsx
@@ -14,7 +14,6 @@ import { MonsterOrganizationType } from '@/enums/monster-organization-type';
 import { MonsterPanel } from '@/components/panels/elements/monster-panel/monster-panel';
 import { MonsterRoleType } from '@/enums/monster-role-type';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
 import { Sourcebook } from '@/models/sourcebook';
@@ -27,14 +26,13 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoSummon = (props: InfoProps) => {
 	if (props.data.summons.length > 0) {
 		return (
 			<Space orientation='vertical' style={{ width: '100%' }}>
-				{props.data.summons.map(s => <SelectablePanel key={s.id}><MonsterPanel monster={s.monster} summon={s.info} sourcebooks={props.sourcebooks || []} options={props.options} mode={PanelMode.Full} /></SelectablePanel>)}
+				{props.data.summons.map(s => <SelectablePanel key={s.id}><MonsterPanel monster={s.monster} summon={s.info} sourcebooks={props.sourcebooks || []} mode={PanelMode.Full} /></SelectablePanel>)}
 			</Space>
 		);
 	}
@@ -45,7 +43,6 @@ export const InfoSummon = (props: InfoProps) => {
 interface EditProps {
 	data: FeatureSummonData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureSummonData) => void;
 }
 
@@ -150,7 +147,6 @@ export const EditSummon = (props: EditProps) => {
 						<MonsterEditPanel
 							monster={summon.monster}
 							sourcebooks={props.sourcebooks}
-							options={props.options}
 							onChange={m => setSummonMonster(data, n, m)}
 						/>
 					</Expander>

--- a/src/components/features/feature-data/switch-options.tsx
+++ b/src/components/features/feature-data/switch-options.tsx
@@ -16,7 +16,6 @@ import { Hero } from '@/models/hero';
 import { HeroLogic } from '@/logic/hero-logic';
 import { InfoFeature } from '../feature';
 import { Markdown } from '@/components/controls/markdown/markdown';
-import { Options } from '@/models/options';
 import { Sourcebook } from '@/models/sourcebook';
 import { TextInput } from '@/components/controls/text-input/text-input';
 import { Toggle } from '@/components/controls/toggle/toggle';
@@ -28,7 +27,6 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoSwitchOptions = (props: InfoProps) => {
@@ -37,7 +35,7 @@ export const InfoSwitchOptions = (props: InfoProps) => {
 			case FeatureType.Text:
 				return <Markdown text={feature.description} />;
 			default:
-				return <InfoFeature feature={feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+				return <InfoFeature feature={feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 		}
 	};
 
@@ -80,7 +78,6 @@ export const InfoSwitchOptions = (props: InfoProps) => {
 interface EditProps {
 	data: FeatureSwitchOptionsData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureSwitchOptionsData) => void;
 }
 
@@ -195,7 +192,6 @@ export const EditSwitchOptions = (props: EditProps) => {
 								feature={f.feature}
 								allowedTypes={FeatureLogic.getSelectableFeatureTypes()}
 								sourcebooks={props.sourcebooks}
-								options={props.options}
 								onChange={feature => changeFeature(n, feature)}
 							/>
 						</Expander>
@@ -219,7 +215,6 @@ export const EditSwitchOptions = (props: EditProps) => {
 						feature={data.defaultOption}
 						allowedTypes={FeatureLogic.getSelectableFeatureTypes()}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 						onChange={changeDefaultOption}
 					/>
 					: null

--- a/src/components/features/feature-data/switch-value.tsx
+++ b/src/components/features/feature-data/switch-value.tsx
@@ -2,7 +2,6 @@ import { Feature, FeatureSwitchValueData } from '@/models/feature';
 import { Field } from '@/components/controls/field/field';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
-import { Options } from '@/models/options';
 import { Sourcebook } from '@/models/sourcebook';
 import { Space } from 'antd';
 import { TextInput } from '@/components/controls/text-input/text-input';
@@ -14,7 +13,6 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoSwitchValue = (props: InfoProps) => {
@@ -26,7 +24,6 @@ export const InfoSwitchValue = (props: InfoProps) => {
 interface EditProps {
 	data: FeatureSwitchValueData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureSwitchValueData) => void;
 }
 

--- a/src/components/features/feature-data/tagged-feature-choice.tsx
+++ b/src/components/features/feature-data/tagged-feature-choice.tsx
@@ -9,7 +9,6 @@ import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { HeroLogic } from '@/logic/hero-logic';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Sourcebook } from '@/models/sourcebook';
 import { TextInput } from '@/components/controls/text-input/text-input';
@@ -21,7 +20,6 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoTaggedFeatureChoice = (props: InfoProps) => {
@@ -29,7 +27,7 @@ export const InfoTaggedFeatureChoice = (props: InfoProps) => {
 		return (
 			<Space orientation='vertical' style={{ width: '100%' }}>
 				{
-					props.data.selected.map(f => <FeaturePanel key={f.id} feature={f} options={props.options} />)
+					props.data.selected.map(f => <FeaturePanel key={f.id} feature={f} />)
 				}
 			</Space>
 		);
@@ -43,7 +41,6 @@ export const InfoTaggedFeatureChoice = (props: InfoProps) => {
 interface EditProps {
 	data: FeatureTaggedFeatureChoiceData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureTaggedFeatureChoiceData) => void;
 }
 
@@ -85,7 +82,6 @@ interface ConfigProps {
 	feature: Feature;
 	hero: Hero;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureTaggedFeatureChoiceData) => void;
 }
 
@@ -143,7 +139,7 @@ export const ConfigTaggedFeatureChoice = (props: ConfigProps) => {
 			{
 				props.data.selected.map(feature => {
 					return (
-						<FeaturePanel key={feature.id} feature={feature} options={props.options} hero={props.hero} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
+						<FeaturePanel key={feature.id} feature={feature} hero={props.hero} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
 					);
 				})
 			}

--- a/src/components/features/feature-data/tagged-feature.tsx
+++ b/src/components/features/feature-data/tagged-feature.tsx
@@ -4,7 +4,6 @@ import { FeatureEditPanel } from '@/components/panels/edit/feature-edit/feature-
 import { FeaturePanel } from '@/components/panels/elements/feature-panel/feature-panel';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
-import { Options } from '@/models/options';
 import { Sourcebook } from '@/models/sourcebook';
 import { Space } from 'antd';
 import { TextInput } from '@/components/controls/text-input/text-input';
@@ -16,19 +15,17 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoTaggedFeature = (props: InfoProps) => {
 	return (
-		<FeaturePanel key={props.data.feature.id} feature={props.data.feature} options={props.options} />
+		<FeaturePanel key={props.data.feature.id} feature={props.data.feature} />
 	);
 };
 
 interface EditProps {
 	data: FeatureTaggedFeatureData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureTaggedFeatureData) => void;
 }
 
@@ -63,7 +60,6 @@ export const EditTaggedFeature = (props: EditProps) => {
 				<FeatureEditPanel
 					feature={data.feature}
 					sourcebooks={props.sourcebooks}
-					options={props.options}
 					onChange={setTaggedFeature}
 				/>
 			</Expander>

--- a/src/components/features/feature-data/title-choice.tsx
+++ b/src/components/features/feature-data/title-choice.tsx
@@ -7,7 +7,6 @@ import { Hero } from '@/models/hero';
 import { Markdown } from '@/components/controls/markdown/markdown';
 import { Modal } from '@/components/modals/modal/modal';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Sourcebook } from '@/models/sourcebook';
 import { Title } from '@/models/title';
@@ -21,7 +20,6 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoTitleChoice = (props: InfoProps) => {
@@ -29,7 +27,7 @@ export const InfoTitleChoice = (props: InfoProps) => {
 		return (
 			<Space orientation='vertical' style={{ width: '100%' }}>
 				{
-					props.data.selected.map(t => <TitlePanel key={t.id} title={t} sourcebooks={props.sourcebooks || []} options={props.options} />)
+					props.data.selected.map(t => <TitlePanel key={t.id} title={t} sourcebooks={props.sourcebooks || []} />)
 				}
 			</Space>
 		);
@@ -43,7 +41,6 @@ export const InfoTitleChoice = (props: InfoProps) => {
 interface EditProps {
 	data: FeatureTitleChoiceData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureTitleChoiceData) => void;
 }
 
@@ -70,7 +67,6 @@ interface ConfigProps {
 	feature: Feature;
 	hero: Hero;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureTitleChoiceData) => void;
 }
 
@@ -136,7 +132,6 @@ export const ConfigTitleChoice = (props: ConfigProps) => {
 				<TitleSelectModal
 					hero={props.hero}
 					sourcebooks={props.sourcebooks}
-					options={props.options}
 					onSelect={title => {
 						setTitleSelectorOpen(false);
 
@@ -153,7 +148,6 @@ export const ConfigTitleChoice = (props: ConfigProps) => {
 						selectedTitle ?
 							<TitlePanel
 								title={selectedTitle}
-								options={props.options}
 								sourcebooks={props.sourcebooks}
 								mode={PanelMode.Full}
 								onChange={title => {

--- a/src/components/features/feature-data/toggle.tsx
+++ b/src/components/features/feature-data/toggle.tsx
@@ -8,7 +8,6 @@ import { FeatureEditPanel } from '@/components/panels/edit/feature-edit/feature-
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { InfoFeature } from '../feature';
-import { Options } from '@/models/options';
 import { PlusOutlined } from '@ant-design/icons';
 import { Sourcebook } from '@/models/sourcebook';
 import { TextInput } from '@/components/controls/text-input/text-input';
@@ -21,7 +20,6 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoToggle = (props: InfoProps) => {
@@ -31,7 +29,7 @@ export const InfoToggle = (props: InfoProps) => {
 			{
 				props.data.featureChecked ?
 					<Expander title={props.data.featureChecked.name || 'Feature'}>
-						<InfoFeature feature={props.data.featureChecked} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />
+						<InfoFeature feature={props.data.featureChecked} hero={props.hero} sourcebooks={props.sourcebooks} />
 					</Expander>
 					:
 					<Empty />
@@ -41,7 +39,7 @@ export const InfoToggle = (props: InfoProps) => {
 					<>
 						<div className='ds-text'>Otherwise:</div>
 						<Expander title={props.data.featureUnchecked.name || 'Feature'}>
-							<InfoFeature feature={props.data.featureUnchecked} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />
+							<InfoFeature feature={props.data.featureUnchecked} hero={props.hero} sourcebooks={props.sourcebooks} />
 						</Expander>
 					</>
 					: null
@@ -53,7 +51,6 @@ export const InfoToggle = (props: InfoProps) => {
 interface EditProps {
 	data: FeatureToggleData;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureToggleData) => void;
 }
 
@@ -117,7 +114,6 @@ export const EditToggle = (props: EditProps) => {
 						<FeatureEditPanel
 							feature={data.featureChecked}
 							sourcebooks={props.sourcebooks}
-							options={props.options}
 							onChange={setFeatureChecked}
 						/>
 					</Expander>
@@ -150,7 +146,6 @@ export const EditToggle = (props: EditProps) => {
 						<FeatureEditPanel
 							feature={data.featureUnchecked}
 							sourcebooks={props.sourcebooks}
-							options={props.options}
 							onChange={setFeatureUnchecked}
 						/>
 					</Expander>
@@ -166,7 +161,6 @@ interface ConfigProps {
 	feature: Feature;
 	hero: Hero;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureToggleData) => void;
 }
 
@@ -185,14 +179,14 @@ export const ConfigToggle = (props: ConfigProps) => {
 			{
 				props.data.checked && props.data.featureChecked ?
 					<Expander title={props.data.featureChecked.name || 'Feature'}>
-						<InfoFeature feature={props.data.featureChecked} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />
+						<InfoFeature feature={props.data.featureChecked} hero={props.hero} sourcebooks={props.sourcebooks} />
 					</Expander>
 					: null
 			}
 			{
 				!props.data.checked && props.data.featureUnchecked ?
 					<Expander title={props.data.featureUnchecked.name || 'Feature'}>
-						<InfoFeature feature={props.data.featureUnchecked} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />
+						<InfoFeature feature={props.data.featureUnchecked} hero={props.hero} sourcebooks={props.sourcebooks} />
 					</Expander>
 					: null
 			}

--- a/src/components/features/feature.tsx
+++ b/src/components/features/feature.tsx
@@ -1,7 +1,6 @@
 import { Feature, FeatureData } from '@/models/feature';
 import { FeatureType } from '@/enums/feature-type';
 import { Hero } from '@/models/hero';
-import { Options } from '@/models/options';
 import { Sourcebook } from '@/models/sourcebook';
 
 import { ConfigAncestryChoice, InfoAncestryChoice } from '@/components/features/feature-data/ancestry-choice';
@@ -53,91 +52,90 @@ interface InfoProps {
 	feature: Feature;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
-	options: Options;
 }
 
 export const InfoFeature = (props: InfoProps) => {
 	switch (props.feature.type) {
 		case FeatureType.AbilityCost:
-			return <InfoAbilityCost data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+			return <InfoAbilityCost data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 		case FeatureType.AbilityDamage:
-			return <InfoAbilityDamage data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+			return <InfoAbilityDamage data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 		case FeatureType.AbilityDistance:
-			return <InfoAbilityDistance data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+			return <InfoAbilityDistance data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 		case FeatureType.AncestryChoice:
-			return <InfoAncestryChoice data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+			return <InfoAncestryChoice data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 		case FeatureType.AncestryFeatureChoice:
-			return <InfoAncestryFeatureChoice data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+			return <InfoAncestryFeatureChoice data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 		case FeatureType.Bonus:
-			return <InfoBonus data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+			return <InfoBonus data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 		case FeatureType.CharacteristicBonus:
-			return <InfoCharacteristicBonus data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+			return <InfoCharacteristicBonus data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 		case FeatureType.Choice:
-			return <InfoChoice data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+			return <InfoChoice data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 		case FeatureType.ClassAbility:
-			return <InfoClassAbility data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+			return <InfoClassAbility data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 		case FeatureType.Companion:
-			return <InfoCompanion data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+			return <InfoCompanion data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 		case FeatureType.ConditionImmunity:
-			return <InfoConditionImmunity data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+			return <InfoConditionImmunity data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 		case FeatureType.DamageModifier:
-			return <InfoDamageModifier data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+			return <InfoDamageModifier data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 		case FeatureType.Domain:
-			return <InfoDomain data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+			return <InfoDomain data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 		case FeatureType.DomainFeature:
-			return <InfoDomainFeature data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+			return <InfoDomainFeature data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 		case FeatureType.Fixture:
-			return <InfoFixture data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+			return <InfoFixture data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 		case FeatureType.HeroicResource:
-			return <InfoHeroicResource data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+			return <InfoHeroicResource data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 		case FeatureType.HeroicResourceGain:
-			return <InfoHeroicResourceGain data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+			return <InfoHeroicResourceGain data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 		case FeatureType.ItemChoice:
-			return <InfoItemChoice data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+			return <InfoItemChoice data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 		case FeatureType.Kit:
-			return <InfoKit data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+			return <InfoKit data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 		case FeatureType.Language:
-			return <InfoLanguage data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+			return <InfoLanguage data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 		case FeatureType.LanguageChoice:
-			return <InfoLanguageChoice data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+			return <InfoLanguageChoice data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 		case FeatureType.Malice:
-			return <InfoMalice data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+			return <InfoMalice data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 		case FeatureType.MovementMode:
-			return <InfoMovementMode data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+			return <InfoMovementMode data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 		case FeatureType.Multiple:
-			return <InfoMultiple data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+			return <InfoMultiple data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 		case FeatureType.Package:
-			return <InfoPackage data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+			return <InfoPackage data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 		case FeatureType.Perk:
-			return <InfoPerk data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+			return <InfoPerk data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 		case FeatureType.Proficiency:
-			return <InfoProficiency data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+			return <InfoProficiency data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 		case FeatureType.Retainer:
-			return <InfoRetainer data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+			return <InfoRetainer data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 		case FeatureType.SaveThreshold:
-			return <InfoSaveThreshold data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+			return <InfoSaveThreshold data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 		case FeatureType.Size:
-			return <InfoSize data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+			return <InfoSize data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 		case FeatureType.SkillChoice:
-			return <InfoSkillChoice data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+			return <InfoSkillChoice data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 		case FeatureType.Speed:
-			return <InfoSpeed data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+			return <InfoSpeed data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 		case FeatureType.Summon:
-			return <InfoSummon data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+			return <InfoSummon data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 		case FeatureType.SummonChoice:
-			return <InfoSummonChoice data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+			return <InfoSummonChoice data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 		case FeatureType.SwitchOptions:
-			return <InfoSwitchOptions data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+			return <InfoSwitchOptions data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 		case FeatureType.SwitchValue:
-			return <InfoSwitchValue data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+			return <InfoSwitchValue data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 		case FeatureType.TaggedFeature:
-			return <InfoTaggedFeature data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+			return <InfoTaggedFeature data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 		case FeatureType.TaggedFeatureChoice:
-			return <InfoTaggedFeatureChoice data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+			return <InfoTaggedFeatureChoice data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 		case FeatureType.TitleChoice:
-			return <InfoTitleChoice data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+			return <InfoTitleChoice data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 		case FeatureType.Toggle:
-			return <InfoToggle data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />;
+			return <InfoToggle data={props.feature.data} feature={props.feature} hero={props.hero} sourcebooks={props.sourcebooks} />;
 	}
 
 	return null;
@@ -146,94 +144,93 @@ export const InfoFeature = (props: InfoProps) => {
 interface EditProps {
 	feature: Feature;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureData) => void;
 }
 
 export const EditFeature = (props: EditProps) => {
 	switch (props.feature.type) {
 		case FeatureType.Ability:
-			return <EditAbilityData data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditAbilityData data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.AbilityCost:
-			return <EditAbilityCost data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditAbilityCost data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.AbilityDamage:
-			return <EditAbilityDamage data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditAbilityDamage data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.AbilityDistance:
-			return <EditAbilityDistance data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditAbilityDistance data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.AddOn:
-			return <EditAddOn data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditAddOn data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.AncestryFeatureChoice:
-			return <EditAncestryFeatureChoice data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditAncestryFeatureChoice data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.Bonus:
-			return <EditBonus data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditBonus data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.CharacteristicBonus:
-			return <EditCharacteristicBonus data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditCharacteristicBonus data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.Choice:
-			return <EditChoice data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditChoice data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.ClassAbility:
-			return <EditClassAbility data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditClassAbility data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.ConditionImmunity:
-			return <EditConditionImmunity data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditConditionImmunity data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.DamageModifier:
-			return <EditDamageModifier data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditDamageModifier data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.Domain:
-			return <EditDomain data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditDomain data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.DomainFeature:
-			return <EditDomainFeature data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditDomainFeature data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.Fixture:
-			return <EditFixture data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditFixture data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.HeroicResource:
-			return <EditHeroicResource data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditHeroicResource data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.HeroicResourceGain:
-			return <EditHeroicResourceGain data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditHeroicResourceGain data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.ItemChoice:
-			return <EditItemChoice data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditItemChoice data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.Kit:
-			return <EditKit data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditKit data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.Language:
-			return <EditLanguage data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditLanguage data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.LanguageChoice:
-			return <EditLanguageChoice data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditLanguageChoice data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.Malice:
-			return <EditMalice data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditMalice data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.MaliceAbility:
-			return <EditMaliceAbility data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditMaliceAbility data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.MovementMode:
-			return <EditMovementMode data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditMovementMode data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.Multiple:
-			return <EditMultiple data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditMultiple data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.Package:
-			return <EditPackage data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditPackage data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.PackageContent:
-			return <EditPackageContent data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditPackageContent data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.Perk:
-			return <EditPerk data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditPerk data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.Proficiency:
-			return <EditProficiency data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditProficiency data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.SaveThreshold:
-			return <EditSaveThreshold data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditSaveThreshold data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.Size:
-			return <EditSize data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditSize data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.SkillChoice:
-			return <EditSkillChoice data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditSkillChoice data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.Speed:
-			return <EditSpeed data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditSpeed data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.Summon:
-			return <EditSummon data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditSummon data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.SummonChoice:
-			return <EditSummonChoice data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditSummonChoice data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.SwitchOptions:
-			return <EditSwitchOptions data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditSwitchOptions data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.SwitchValue:
-			return <EditSwitchValue data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditSwitchValue data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.TaggedFeature:
-			return <EditTaggedFeature data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditTaggedFeature data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.TaggedFeatureChoice:
-			return <EditTaggedFeatureChoice data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditTaggedFeatureChoice data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.TitleChoice:
-			return <EditTitleChoice data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditTitleChoice data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.Toggle:
-			return <EditToggle data={props.feature.data} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <EditToggle data={props.feature.data} sourcebooks={props.sourcebooks} setData={props.setData} />;
 	}
 
 	return null;
@@ -243,46 +240,45 @@ interface ConfigProps {
 	feature: Feature;
 	hero: Hero;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setData: (data: FeatureData) => void;
 }
 
 export const ConfigFeature = (props: ConfigProps) => {
 	switch (props.feature.type) {
 		case FeatureType.AncestryChoice:
-			return <ConfigAncestryChoice data={props.feature.data} hero={props.hero} feature={props.feature} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <ConfigAncestryChoice data={props.feature.data} hero={props.hero} feature={props.feature} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.AncestryFeatureChoice:
-			return <ConfigAncestryFeatureChoice data={props.feature.data} hero={props.hero} feature={props.feature} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <ConfigAncestryFeatureChoice data={props.feature.data} hero={props.hero} feature={props.feature} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.Choice:
-			return <ConfigChoice data={props.feature.data} hero={props.hero} feature={props.feature} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <ConfigChoice data={props.feature.data} hero={props.hero} feature={props.feature} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.ClassAbility:
-			return <ConfigClassAbility data={props.feature.data} hero={props.hero} feature={props.feature} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <ConfigClassAbility data={props.feature.data} hero={props.hero} feature={props.feature} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.Companion:
-			return <ConfigCompanion data={props.feature.data} hero={props.hero} feature={props.feature} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <ConfigCompanion data={props.feature.data} hero={props.hero} feature={props.feature} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.Domain:
-			return <ConfigDomain data={props.feature.data} hero={props.hero} feature={props.feature} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <ConfigDomain data={props.feature.data} hero={props.hero} feature={props.feature} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.DomainFeature:
-			return <ConfigDomainFeature data={props.feature.data} hero={props.hero} feature={props.feature} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <ConfigDomainFeature data={props.feature.data} hero={props.hero} feature={props.feature} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.ItemChoice:
-			return <ConfigItemChoice data={props.feature.data} hero={props.hero} feature={props.feature} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <ConfigItemChoice data={props.feature.data} hero={props.hero} feature={props.feature} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.Kit:
-			return <ConfigKit data={props.feature.data} hero={props.hero} feature={props.feature} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <ConfigKit data={props.feature.data} hero={props.hero} feature={props.feature} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.LanguageChoice:
-			return <ConfigLanguageChoice data={props.feature.data} hero={props.hero} feature={props.feature} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <ConfigLanguageChoice data={props.feature.data} hero={props.hero} feature={props.feature} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.Perk:
-			return <ConfigPerk data={props.feature.data} hero={props.hero} feature={props.feature} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <ConfigPerk data={props.feature.data} hero={props.hero} feature={props.feature} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.Retainer:
-			return <ConfigRetainer data={props.feature.data} hero={props.hero} feature={props.feature} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <ConfigRetainer data={props.feature.data} hero={props.hero} feature={props.feature} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.SkillChoice:
-			return <ConfigSkillChoice data={props.feature.data} hero={props.hero} feature={props.feature} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <ConfigSkillChoice data={props.feature.data} hero={props.hero} feature={props.feature} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.SummonChoice:
-			return <ConfigSummonChoice data={props.feature.data} hero={props.hero} feature={props.feature} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <ConfigSummonChoice data={props.feature.data} hero={props.hero} feature={props.feature} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.TaggedFeatureChoice:
-			return <ConfigTaggedFeatureChoice data={props.feature.data} hero={props.hero} feature={props.feature} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <ConfigTaggedFeatureChoice data={props.feature.data} hero={props.hero} feature={props.feature} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.TitleChoice:
-			return <ConfigTitleChoice data={props.feature.data} hero={props.hero} feature={props.feature} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <ConfigTitleChoice data={props.feature.data} hero={props.hero} feature={props.feature} sourcebooks={props.sourcebooks} setData={props.setData} />;
 		case FeatureType.Toggle:
-			return <ConfigToggle data={props.feature.data} hero={props.hero} feature={props.feature} sourcebooks={props.sourcebooks} options={props.options} setData={props.setData} />;
+			return <ConfigToggle data={props.feature.data} hero={props.hero} feature={props.feature} sourcebooks={props.sourcebooks} setData={props.setData} />;
 	}
 
 	return null;

--- a/src/components/main/main.tsx
+++ b/src/components/main/main.tsx
@@ -1,6 +1,5 @@
 import { Feature, FeatureCompanion, FeatureRetainer } from '@/models/feature';
 import { Navigate, Route, Routes } from 'react-router';
-import { OptionsActionKind, useOptions, useOptionsDispatch } from '@/contexts/data-context';
 import { ReactNode, useState } from 'react';
 import { Sourcebook, SourcebookElementKind } from '@/models/sourcebook';
 import { Spin, notification } from 'antd';
@@ -73,7 +72,6 @@ import { MonsterGroup } from '@/models/monster-group';
 import { MonsterModal } from '@/components/modals/monster/monster-modal';
 import { Montage } from '@/models/montage';
 import { Negotiation } from '@/models/negotiation';
-import { Options } from '@/models/options';
 import { PartyModal } from '@/components/modals/party/party-modal';
 import { Perk } from '@/models/perk';
 import { PlayerViewModal } from '@/components/modals/player-view/player-view-modal';
@@ -104,6 +102,7 @@ import { WelcomePage } from '@/components/pages/welcome/welcome-page';
 import localforage from 'localforage';
 import { useErrorListener } from '@/hooks/use-error-listener';
 import { useNavigation } from '@/hooks/use-navigation';
+import { useOptions } from '@/contexts/data-context';
 import { useSyncStatus } from '@/hooks/use-sync-status';
 
 import './main.scss';
@@ -113,7 +112,6 @@ interface Props {
 	session: Session;
 	homebrewSourcebooks: Sourcebook[];
 	hiddenSourcebookIDs: string[];
-	options: Options;
 	connectionSettings: ConnectionSettings;
 	dataService: DataService;
 }
@@ -258,18 +256,6 @@ export const Main = (props: Props) => {
 					});
 				}
 			);
-	};
-
-	const optionsDispatch = useOptionsDispatch();
-	const persistOptions = (options: Options) => {
-		return dataService
-			.saveOptions(options)
-			.then(options => {
-				optionsDispatch({
-					type: OptionsActionKind.UPDATE,
-					payload: options
-				});
-			});
 	};
 
 	const persistConnectionSettings = (connectionSettings: ConnectionSettings) => {
@@ -1507,7 +1493,6 @@ export const Main = (props: Props) => {
 		setDrawer(
 			<SettingsModal
 				heroes={heroes}
-				setOptions={persistOptions}
 				connectionSettings={connectionSettings}
 				dataService={dataService}
 				setConnectionSettings={persistConnectionSettings}
@@ -1842,7 +1827,6 @@ export const Main = (props: Props) => {
 		showAbout: showAbout,
 		showSettings: showSettings,
 		showErrors: showErrors,
-		setOptions: persistOptions,
 		connectionSettings: connectionSettings
 	};
 
@@ -1878,7 +1862,6 @@ export const Main = (props: Props) => {
 								<HeroListPage
 									heroes={heroes.map(HeroLogic.createOverview)}
 									sourcebooks={SourcebookLogic.getSourcebooks(homebrewSourcebooks)}
-									options={props.options}
 									params={footerParams}
 									addHero={newHero}
 									importHero={importHero}
@@ -1946,7 +1929,6 @@ export const Main = (props: Props) => {
 								<HeroSheetPreviewPage
 									heroes={heroes}
 									sourcebooks={SourcebookLogic.getSourcebooks(homebrewSourcebooks)}
-									setOptions={persistOptions}
 								/>
 							}
 						/>

--- a/src/components/main/main.tsx
+++ b/src/components/main/main.tsx
@@ -3,7 +3,7 @@ import { Navigate, Route, Routes } from 'react-router';
 import { ReactNode, useState } from 'react';
 import { Sourcebook, SourcebookElementKind } from '@/models/sourcebook';
 import { Spin, notification } from 'antd';
-import { useDataManager, useOptions, useSession } from '@/contexts/data-context';
+import { useDataManager, useHeroes, useOptions, useSession } from '@/contexts/data-context';
 import { Ability } from '@/models/ability';
 import { AbilityModal } from '@/components/modals/ability/ability-modal';
 import { AboutModal } from '@/components/modals/about/about-modal';
@@ -108,7 +108,6 @@ import { useSyncStatus } from '@/hooks/use-sync-status';
 import './main.scss';
 
 interface Props {
-	heroes: Hero[];
 	homebrewSourcebooks: Sourcebook[];
 	connectionSettings: ConnectionSettings;
 	dataService: DataService;
@@ -118,10 +117,10 @@ export const Main = (props: Props) => {
 	const navigation = useNavigation();
 	const [ notify, notifyContext ] = notification.useNotification();
 	const { triggerSyncOnChange } = useSyncStatus();
-	const [ heroes, setHeroes ] = useState<Hero[]>(props.heroes);
 	const [ homebrewSourcebooks, setHomebrewSourcebooks ] = useState<Sourcebook[]>(props.homebrewSourcebooks);
 	const options = useOptions();
 	const session = useSession();
+	const heroes = useHeroes();
 	const dataManager = useDataManager();
 
 	const [ connectionSettings, setConnectionSettings ] = useState<ConnectionSettings>(props.connectionSettings);
@@ -137,25 +136,8 @@ export const Main = (props: Props) => {
 	// #region Persistence
 
 	const persistHero = (hero: Hero) => {
-		let newHeroes: Hero[];
-		if (heroes.some(h => h.id === hero.id)) {
-			Analytics.logHeroEdited(hero);
-
-			const copy = Utils.copy(heroes);
-			const list = copy.map(h => h.id === hero.id ? hero : h);
-			newHeroes = list;
-		} else {
-			Analytics.logHeroCreated(hero);
-
-			const copy = Utils.copy(heroes);
-			copy.push(hero);
-			Collections.sort(copy, h => h.name);
-			newHeroes = copy;
-		}
-
-		return dataService
+		return dataManager
 			.saveHero(hero)
-			.then(() => setHeroes(newHeroes))
 			.catch(err => {
 				console.error(err);
 				notify.error({
@@ -275,13 +257,11 @@ export const Main = (props: Props) => {
 	};
 
 	const deleteHero = (hero: Hero) => {
-		const copy = Utils.copy(heroes.filter(h => h.id !== hero.id));
-		const stayInFolder = copy.some(h => h.folder === hero.folder);
+		const stayInFolder = heroes.some(h => h.id !== hero.id && h.folder === hero.folder);
 		navigation.goToHeroList(stayInFolder ? hero.folder : undefined);
 
-		return dataService.deleteHero(hero.id)
+		return dataManager.deleteHero(hero)
 			.then(() => {
-				setHeroes(copy);
 				navigation.goToHeroList(stayInFolder ? hero.folder : undefined);
 			})
 			.catch(err => {
@@ -1471,7 +1451,6 @@ export const Main = (props: Props) => {
 	const showSettings = () => {
 		setDrawer(
 			<SettingsModal
-				heroes={heroes}
 				connectionSettings={connectionSettings}
 				dataService={dataService}
 				setConnectionSettings={persistConnectionSettings}
@@ -1761,7 +1740,6 @@ export const Main = (props: Props) => {
 	const showSourcebooks = () => {
 		setDrawer(
 			<SourcebooksModal
-				heroes={heroes}
 				officialSourcebooks={SourcebookLogic.getSourcebooks()}
 				homebrewSourcebooks={homebrewSourcebooks}
 				onClose={() => setDrawer(null)}
@@ -1836,7 +1814,6 @@ export const Main = (props: Props) => {
 							path=':folder?'
 							element={
 								<HeroListPage
-									heroes={heroes.map(HeroLogic.createOverview)}
 									sourcebooks={SourcebookLogic.getSourcebooks(homebrewSourcebooks)}
 									params={footerParams}
 									addHero={newHero}
@@ -1849,7 +1826,6 @@ export const Main = (props: Props) => {
 							path='view/:heroID'
 							element={
 								<HeroViewPage
-									heroes={heroes}
 									sourcebooks={SourcebookLogic.getSourcebooks(homebrewSourcebooks)}
 									params={footerParams}
 									exportHeroData={exportHeroData}
@@ -1891,7 +1867,6 @@ export const Main = (props: Props) => {
 							path='edit/:heroID/:page'
 							element={
 								<HeroEditPage
-									heroes={heroes}
 									sourcebooks={SourcebookLogic.getSourcebooks(homebrewSourcebooks)}
 									params={footerParams}
 									saveChanges={saveHero}
@@ -1903,7 +1878,6 @@ export const Main = (props: Props) => {
 							path='sheet/:heroID'
 							element={
 								<HeroSheetPreviewPage
-									heroes={heroes}
 									sourcebooks={SourcebookLogic.getSourcebooks(homebrewSourcebooks)}
 								/>
 							}
@@ -1918,7 +1892,6 @@ export const Main = (props: Props) => {
 							path=':kind/:elementID?'
 							element={
 								<LibraryListPage
-									heroes={heroes}
 									sourcebooks={SourcebookLogic.getSourcebooks(homebrewSourcebooks)}
 									params={footerParams}
 									showSourcebooks={showSourcebooks}
@@ -1942,7 +1915,6 @@ export const Main = (props: Props) => {
 							path='edit/:kind/:sourcebookID/:elementID/:subElementID?'
 							element={
 								<LibraryEditPage
-									heroes={heroes}
 									sourcebooks={SourcebookLogic.getSourcebooks(homebrewSourcebooks)}
 									params={footerParams}
 									showMonster={(monster, monsterGroup) => onSelectMonster(undefined, monster, monsterGroup, undefined)}
@@ -1955,7 +1927,6 @@ export const Main = (props: Props) => {
 							path='print/:kind/:sourcebookID/:elementID'
 							element={
 								<LibraryPrintPage
-									heroes={heroes}
 									sourcebooks={SourcebookLogic.getSourcebooks(homebrewSourcebooks)}
 								/>
 							}
@@ -1970,7 +1941,6 @@ export const Main = (props: Props) => {
 							path='director'
 							element={
 								<SessionDirectorPage
-									heroes={heroes}
 									sourcebooks={SourcebookLogic.getSourcebooks(homebrewSourcebooks)}
 									params={footerParams}
 									showPlayerView={showPlayerView}
@@ -1994,7 +1964,6 @@ export const Main = (props: Props) => {
 							path='player'
 							element={
 								<SessionPlayerPage
-									heroes={heroes}
 									sourcebooks={SourcebookLogic.getSourcebooks(homebrewSourcebooks)}
 									params={footerParams}
 								/>
@@ -2017,7 +1986,6 @@ export const Main = (props: Props) => {
 						index={true}
 						element={
 							<BackupPage
-								heroes={heroes}
 								homebrewSourcebooks={homebrewSourcebooks}
 							/>
 						}

--- a/src/components/main/main.tsx
+++ b/src/components/main/main.tsx
@@ -3,7 +3,7 @@ import { Navigate, Route, Routes } from 'react-router';
 import { ReactNode, useState } from 'react';
 import { Sourcebook, SourcebookElementKind } from '@/models/sourcebook';
 import { Spin, notification } from 'antd';
-import { useDataManager, useHeroes, useOptions, useSession } from '@/contexts/data-context';
+import { useDataManager, useHeroes, useHomebrewSourcebooks, useOptions, useSession } from '@/contexts/data-context';
 import { Ability } from '@/models/ability';
 import { AbilityModal } from '@/components/modals/ability/ability-modal';
 import { AboutModal } from '@/components/modals/about/about-modal';
@@ -108,7 +108,6 @@ import { useSyncStatus } from '@/hooks/use-sync-status';
 import './main.scss';
 
 interface Props {
-	homebrewSourcebooks: Sourcebook[];
 	connectionSettings: ConnectionSettings;
 	dataService: DataService;
 }
@@ -117,10 +116,10 @@ export const Main = (props: Props) => {
 	const navigation = useNavigation();
 	const [ notify, notifyContext ] = notification.useNotification();
 	const { triggerSyncOnChange } = useSyncStatus();
-	const [ homebrewSourcebooks, setHomebrewSourcebooks ] = useState<Sourcebook[]>(props.homebrewSourcebooks);
 	const options = useOptions();
 	const session = useSession();
 	const heroes = useHeroes();
+	const homebrewSourcebooks = useHomebrewSourcebooks();
 	const dataManager = useDataManager();
 
 	const [ connectionSettings, setConnectionSettings ] = useState<ConnectionSettings>(props.connectionSettings);
@@ -173,21 +172,9 @@ export const Main = (props: Props) => {
 	};
 
 	const persistHomebrewSourcebook = (homebrew: Sourcebook) => {
-		let newHomebrew: Sourcebook[];
-		if (homebrewSourcebooks.some(h => h.id === homebrew.id)) {
-			const copy = Utils.copy(homebrewSourcebooks);
-			const list = copy.map(h => h.id === homebrew.id ? homebrew : h);
-			newHomebrew = list;
-		} else {
-			const copy = Utils.copy(homebrewSourcebooks);
-			copy.push(homebrew);
-			Collections.sort(copy, h => h.name);
-			newHomebrew = copy;
-		}
-
-		return dataService
+		return dataManager
 			.saveSourcebook(homebrew)
-			.then(() => setHomebrewSourcebooks(newHomebrew))
+			// .then(() => setHomebrewSourcebooks(newHomebrew))
 			.catch(err => {
 				console.error(err);
 				notify.error({
@@ -203,12 +190,7 @@ export const Main = (props: Props) => {
 	};
 
 	const deleteHomebrewSourcebook = (homebrew: Sourcebook) => {
-		const copy = Utils.copy(homebrewSourcebooks.filter(h => h.id !== homebrew.id));
-
-		return dataService.deleteSourcebook(homebrew.id)
-			.then(() => {
-				setHomebrewSourcebooks(copy);
-			})
+		return dataManager.deleteSourcebook(homebrew)
 			.catch(err => {
 				console.error(err);
 				notify.error({

--- a/src/components/main/main.tsx
+++ b/src/components/main/main.tsx
@@ -1,5 +1,6 @@
 import { Feature, FeatureCompanion, FeatureRetainer } from '@/models/feature';
 import { Navigate, Route, Routes } from 'react-router';
+import { OptionsActionKind, useOptions, useOptionsDispatch } from '@/contexts/data-context';
 import { ReactNode, useState } from 'react';
 import { Sourcebook, SourcebookElementKind } from '@/models/sourcebook';
 import { Spin, notification } from 'antd';
@@ -102,7 +103,6 @@ import { Utils } from '@/utils/utils';
 import { WelcomePage } from '@/components/pages/welcome/welcome-page';
 import localforage from 'localforage';
 import { useErrorListener } from '@/hooks/use-error-listener';
-import { useIsSmall } from '@/hooks/use-is-small';
 import { useNavigation } from '@/hooks/use-navigation';
 import { useSyncStatus } from '@/hooks/use-sync-status';
 
@@ -119,7 +119,6 @@ interface Props {
 }
 
 export const Main = (props: Props) => {
-	const isSmall = useIsSmall();
 	const navigation = useNavigation();
 	const [ notify, notifyContext ] = notification.useNotification();
 	const { triggerSyncOnChange } = useSyncStatus();
@@ -127,13 +126,8 @@ export const Main = (props: Props) => {
 	const [ session, setSession ] = useState<Session>(props.session);
 	const [ homebrewSourcebooks, setHomebrewSourcebooks ] = useState<Sourcebook[]>(props.homebrewSourcebooks);
 	const [ hiddenSourcebookIDs, setHiddenSourcebookIDs ] = useState<string[]>(props.hiddenSourcebookIDs);
-	const [ options, setOptions ] = useState<Options>(() => {
-		const opts = Utils.copy(props.options);
-		if (isSmall) {
-			opts.compactView = true;
-		}
-		return opts;
-	});
+	const options = useOptions();
+
 	const [ connectionSettings, setConnectionSettings ] = useState<ConnectionSettings>(props.connectionSettings);
 	const [ dataService, setDataService ] = useState<DataService>(props.dataService);
 
@@ -266,20 +260,16 @@ export const Main = (props: Props) => {
 			);
 	};
 
+	const optionsDispatch = useOptionsDispatch();
 	const persistOptions = (options: Options) => {
 		return dataService
 			.saveOptions(options)
-			.then(
-				setOptions,
-				err => {
-					console.error(err);
-					notify.error({
-						title: 'Error saving options',
-						description: Utils.getErrorMessage(err),
-						placement: 'top'
-					});
-				}
-			);
+			.then(options => {
+				optionsDispatch({
+					type: OptionsActionKind.UPDATE,
+					payload: options
+				});
+			});
 	};
 
 	const persistConnectionSettings = (connectionSettings: ConnectionSettings) => {
@@ -456,7 +446,6 @@ export const Main = (props: Props) => {
 			<MonsterModal
 				monster={monster}
 				sourcebooks={SourcebookLogic.getSourcebooks(homebrewSourcebooks)}
-				options={options}
 				onClose={() => setDrawer(null)}
 				updateMonster={monster => {
 					const copy = Utils.copy(hero);
@@ -1509,7 +1498,6 @@ export const Main = (props: Props) => {
 	const showAbout = () => {
 		setDrawer(
 			<AboutModal
-				options={options}
 				onClose={() => setDrawer(null)}
 			/>
 		);
@@ -1518,7 +1506,6 @@ export const Main = (props: Props) => {
 	const showSettings = () => {
 		setDrawer(
 			<SettingsModal
-				options={options}
 				heroes={heroes}
 				setOptions={persistOptions}
 				connectionSettings={connectionSettings}
@@ -1547,7 +1534,6 @@ export const Main = (props: Props) => {
 				category={category}
 				element={element}
 				sourcebooks={sourcebooks}
-				options={options}
 				onClose={() => setDrawer(null)}
 			/>
 		);
@@ -1562,7 +1548,6 @@ export const Main = (props: Props) => {
 				monsterGroup={monsterGroup}
 				summon={summon}
 				sourcebooks={sourcebooks}
-				options={options}
 				onChange={
 					hero ?
 						monster => {
@@ -1605,7 +1590,6 @@ export const Main = (props: Props) => {
 			<FollowerModal
 				follower={follower}
 				sourcebooks={sourcebooks}
-				options={options}
 				onChange={follower => {
 					const heroCopy = Utils.copy(hero);
 					const feature = HeroLogic.getFeatures(heroCopy)
@@ -1629,7 +1613,6 @@ export const Main = (props: Props) => {
 			<FixtureModal
 				fixture={fixture}
 				sourcebooks={sourcebooks}
-				options={options}
 				onClose={() => setDrawer(null)}
 			/>
 		);
@@ -1654,7 +1637,6 @@ export const Main = (props: Props) => {
 				feature={feature}
 				hero={hero}
 				sourcebooks={sourcebooks}
-				options={options}
 				onClose={() => setDrawer(null)}
 				updateHero={persistHero}
 			/>
@@ -1694,7 +1676,6 @@ export const Main = (props: Props) => {
 					<HeroResourcesModal
 						hero={hero}
 						sourcebooks={sourcebooks}
-						options={options}
 						onClose={() => setDrawer(null)}
 						onChange={persistHero}
 					/>
@@ -1715,7 +1696,6 @@ export const Main = (props: Props) => {
 					<HeroInventoryModal
 						hero={hero}
 						sourcebooks={sourcebooks}
-						options={options}
 						onClose={() => setDrawer(null)}
 						onChange={persistHero}
 						onCustomize={() => onShowHeroState(hero, HeroModalType.Customize)}
@@ -1727,7 +1707,6 @@ export const Main = (props: Props) => {
 					<HeroProjectsModal
 						hero={hero}
 						sourcebooks={sourcebooks}
-						options={options}
 						onClose={() => setDrawer(null)}
 						onChange={persistHero}
 						onCustomize={() => onShowHeroState(hero, HeroModalType.Customize)}
@@ -1739,7 +1718,6 @@ export const Main = (props: Props) => {
 					<HeroTitlesModal
 						hero={hero}
 						sourcebooks={sourcebooks}
-						options={options}
 						onClose={() => setDrawer(null)}
 						onChange={persistHero}
 						onCustomize={() => onShowHeroState(hero, HeroModalType.Customize)}
@@ -1751,7 +1729,6 @@ export const Main = (props: Props) => {
 					<HeroRespiteModal
 						hero={hero}
 						sourcebooks={sourcebooks}
-						options={options}
 						onTakeRespite={takeRespite}
 						onChange={hero => persistHero(hero)}
 						onClose={() => setDrawer(null)}
@@ -1763,7 +1740,6 @@ export const Main = (props: Props) => {
 					<HeroCustomizeModal
 						hero={hero}
 						sourcebooks={sourcebooks}
-						options={options}
 						onClose={() => setDrawer(null)}
 						onChange={persistHero}
 					/>
@@ -1786,7 +1762,6 @@ export const Main = (props: Props) => {
 						hero={hero}
 						sourcebooks={sourcebooks}
 						allSourcebooks={SourcebookLogic.getSourcebooks(homebrewSourcebooks)}
-						options={options}
 						onClose={() => setDrawer(null)}
 						onImportSourcebook={persistHomebrewSourcebook}
 						onChange={persistHero}
@@ -1801,7 +1776,6 @@ export const Main = (props: Props) => {
 			<PartyModal
 				heroes={heroes.filter(h => h.folder === folder)}
 				sourcebooks={SourcebookLogic.getSourcebooks(homebrewSourcebooks)}
-				options={options}
 				onClose={() => setDrawer(null)}
 			/>
 		);
@@ -1842,7 +1816,6 @@ export const Main = (props: Props) => {
 					<EncounterToolsModal
 						encounter={encounter}
 						sourcebooks={SourcebookLogic.getSourcebooks(homebrewSourcebooks)}
-						options={options}
 						onClose={() => setDrawer(null)}
 					/>
 				);
@@ -1890,7 +1863,6 @@ export const Main = (props: Props) => {
 						element={
 							<WelcomePage
 								sourcebooks={SourcebookLogic.getSourcebooks(homebrewSourcebooks)}
-								options={options}
 								params={footerParams}
 								onNewHero={() => newHero('')}
 								onPregen={hero => importHero(hero, '')}
@@ -1920,7 +1892,6 @@ export const Main = (props: Props) => {
 								<HeroViewPage
 									heroes={heroes}
 									sourcebooks={SourcebookLogic.getSourcebooks(homebrewSourcebooks)}
-									options={options}
 									params={footerParams}
 									exportHeroData={exportHeroData}
 									exportHeroImage={exportHeroImage}
@@ -1963,7 +1934,6 @@ export const Main = (props: Props) => {
 								<HeroEditPage
 									heroes={heroes}
 									sourcebooks={SourcebookLogic.getSourcebooks(homebrewSourcebooks)}
-									options={options}
 									params={footerParams}
 									saveChanges={saveHero}
 									importSourcebook={persistHomebrewSourcebook}
@@ -1976,7 +1946,6 @@ export const Main = (props: Props) => {
 								<HeroSheetPreviewPage
 									heroes={heroes}
 									sourcebooks={SourcebookLogic.getSourcebooks(homebrewSourcebooks)}
-									options={options}
 									setOptions={persistOptions}
 								/>
 							}
@@ -1993,7 +1962,6 @@ export const Main = (props: Props) => {
 								<LibraryListPage
 									heroes={heroes}
 									sourcebooks={SourcebookLogic.getSourcebooks(homebrewSourcebooks)}
-									options={options}
 									hiddenSourcebookIDs={hiddenSourcebookIDs}
 									params={footerParams}
 									showSourcebooks={showSourcebooks}
@@ -2019,7 +1987,6 @@ export const Main = (props: Props) => {
 								<LibraryEditPage
 									heroes={heroes}
 									sourcebooks={SourcebookLogic.getSourcebooks(homebrewSourcebooks)}
-									options={options}
 									params={footerParams}
 									showMonster={(monster, monsterGroup) => onSelectMonster(undefined, monster, monsterGroup, undefined)}
 									showTerrain={onSelectTerrain}
@@ -2033,7 +2000,6 @@ export const Main = (props: Props) => {
 								<LibraryPrintPage
 									heroes={heroes}
 									sourcebooks={SourcebookLogic.getSourcebooks(homebrewSourcebooks)}
-									options={options}
 								/>
 							}
 						/>
@@ -2050,7 +2016,6 @@ export const Main = (props: Props) => {
 									heroes={heroes}
 									sourcebooks={SourcebookLogic.getSourcebooks(homebrewSourcebooks)}
 									session={session}
-									options={options}
 									params={footerParams}
 									showPlayerView={showPlayerView}
 									startEncounter={startEncounter}
@@ -2076,7 +2041,6 @@ export const Main = (props: Props) => {
 									heroes={heroes}
 									sourcebooks={SourcebookLogic.getSourcebooks(homebrewSourcebooks)}
 									session={session}
-									options={options}
 									params={footerParams}
 								/>
 							}
@@ -2087,7 +2051,6 @@ export const Main = (props: Props) => {
 						element={
 							<AuthPage
 								connectionSettings={connectionSettings}
-								options={options}
 								params={footerParams}
 								setConnectionSettings={persistConnectionSettings}
 							/>
@@ -2101,7 +2064,6 @@ export const Main = (props: Props) => {
 							<BackupPage
 								heroes={heroes}
 								homebrewSourcebooks={homebrewSourcebooks}
-								options={options}
 							/>
 						}
 					/>
@@ -2112,7 +2074,6 @@ export const Main = (props: Props) => {
 						element={
 							<TransferPage
 								connectionSettings={connectionSettings}
-								options={options}
 							/>
 						}
 					/>
@@ -2122,7 +2083,6 @@ export const Main = (props: Props) => {
 						index={true}
 						element={
 							<ClocktowerPage
-								options={options}
 								params={footerParams}
 							/>
 						}

--- a/src/components/main/main.tsx
+++ b/src/components/main/main.tsx
@@ -3,6 +3,7 @@ import { Navigate, Route, Routes } from 'react-router';
 import { ReactNode, useState } from 'react';
 import { Sourcebook, SourcebookElementKind } from '@/models/sourcebook';
 import { Spin, notification } from 'antd';
+import { useDataManager, useOptions, useSession } from '@/contexts/data-context';
 import { Ability } from '@/models/ability';
 import { AbilityModal } from '@/components/modals/ability/ability-modal';
 import { AboutModal } from '@/components/modals/about/about-modal';
@@ -102,14 +103,12 @@ import { WelcomePage } from '@/components/pages/welcome/welcome-page';
 import localforage from 'localforage';
 import { useErrorListener } from '@/hooks/use-error-listener';
 import { useNavigation } from '@/hooks/use-navigation';
-import { useOptions } from '@/contexts/data-context';
 import { useSyncStatus } from '@/hooks/use-sync-status';
 
 import './main.scss';
 
 interface Props {
 	heroes: Hero[];
-	session: Session;
 	homebrewSourcebooks: Sourcebook[];
 	connectionSettings: ConnectionSettings;
 	dataService: DataService;
@@ -120,9 +119,10 @@ export const Main = (props: Props) => {
 	const [ notify, notifyContext ] = notification.useNotification();
 	const { triggerSyncOnChange } = useSyncStatus();
 	const [ heroes, setHeroes ] = useState<Hero[]>(props.heroes);
-	const [ session, setSession ] = useState<Session>(props.session);
 	const [ homebrewSourcebooks, setHomebrewSourcebooks ] = useState<Sourcebook[]>(props.homebrewSourcebooks);
 	const options = useOptions();
+	const session = useSession();
+	const dataManager = useDataManager();
 
 	const [ connectionSettings, setConnectionSettings ] = useState<ConnectionSettings>(props.connectionSettings);
 	const [ dataService, setDataService ] = useState<DataService>(props.dataService);
@@ -171,19 +171,16 @@ export const Main = (props: Props) => {
 	};
 
 	const persistSession = (session: Session) => {
-		return dataService
+		return dataManager
 			.saveSession(session)
-			.then(
-				setSession,
-				err => {
-					console.error(err);
-					notify.error({
-						title: 'Error saving session',
-						description: Utils.getErrorMessage(err),
-						placement: 'top'
-					});
-				}
-			)
+			.catch(err => {
+				console.error(err);
+				notify.error({
+					title: 'Error saving session',
+					description: Utils.getErrorMessage(err),
+					placement: 'top'
+				});
+			})
 			.then(() => {
 				if (playerView) {
 					playerView.location.reload();
@@ -1791,7 +1788,6 @@ export const Main = (props: Props) => {
 	const showPlayerView = () => {
 		setDrawer(
 			<PlayerViewModal
-				session={session}
 				updateSession={persistSession}
 				openPlayerView={setPlayerView}
 				onClose={() => setDrawer(null)}
@@ -1976,7 +1972,6 @@ export const Main = (props: Props) => {
 								<SessionDirectorPage
 									heroes={heroes}
 									sourcebooks={SourcebookLogic.getSourcebooks(homebrewSourcebooks)}
-									session={session}
 									params={footerParams}
 									showPlayerView={showPlayerView}
 									startEncounter={startEncounter}
@@ -2001,7 +1996,6 @@ export const Main = (props: Props) => {
 								<SessionPlayerPage
 									heroes={heroes}
 									sourcebooks={SourcebookLogic.getSourcebooks(homebrewSourcebooks)}
-									session={session}
 									params={footerParams}
 								/>
 							}

--- a/src/components/main/main.tsx
+++ b/src/components/main/main.tsx
@@ -111,7 +111,6 @@ interface Props {
 	heroes: Hero[];
 	session: Session;
 	homebrewSourcebooks: Sourcebook[];
-	hiddenSourcebookIDs: string[];
 	connectionSettings: ConnectionSettings;
 	dataService: DataService;
 }
@@ -123,7 +122,6 @@ export const Main = (props: Props) => {
 	const [ heroes, setHeroes ] = useState<Hero[]>(props.heroes);
 	const [ session, setSession ] = useState<Session>(props.session);
 	const [ homebrewSourcebooks, setHomebrewSourcebooks ] = useState<Sourcebook[]>(props.homebrewSourcebooks);
-	const [ hiddenSourcebookIDs, setHiddenSourcebookIDs ] = useState<string[]>(props.hiddenSourcebookIDs);
 	const options = useOptions();
 
 	const [ connectionSettings, setConnectionSettings ] = useState<ConnectionSettings>(props.connectionSettings);
@@ -240,22 +238,6 @@ export const Main = (props: Props) => {
 					placement: 'top'
 				});
 			});
-	};
-
-	const persistHiddenSourcebookIDs = (ids: string[]) => {
-		return dataService
-			.saveHiddenSourcebookIDs(ids)
-			.then(
-				setHiddenSourcebookIDs,
-				err => {
-					console.error(err);
-					notify.error({
-						title: 'Error saving hidden sourcebooks',
-						description: Utils.getErrorMessage(err),
-						placement: 'top'
-					});
-				}
-			);
 	};
 
 	const persistConnectionSettings = (connectionSettings: ConnectionSettings) => {
@@ -1785,11 +1767,9 @@ export const Main = (props: Props) => {
 				heroes={heroes}
 				officialSourcebooks={SourcebookLogic.getSourcebooks()}
 				homebrewSourcebooks={homebrewSourcebooks}
-				hiddenSourcebookIDs={hiddenSourcebookIDs}
 				onClose={() => setDrawer(null)}
 				onHomebrewSourcebookChange={persistHomebrewSourcebook}
 				onHomebrewSourcebookDelete={deleteHomebrewSourcebook}
-				onHiddenSourcebookIDsChange={persistHiddenSourcebookIDs}
 			/>
 		);
 	};
@@ -1944,7 +1924,6 @@ export const Main = (props: Props) => {
 								<LibraryListPage
 									heroes={heroes}
 									sourcebooks={SourcebookLogic.getSourcebooks(homebrewSourcebooks)}
-									hiddenSourcebookIDs={hiddenSourcebookIDs}
 									params={footerParams}
 									showSourcebooks={showSourcebooks}
 									showMonster={monster => onSelectMonster(undefined, monster, undefined, undefined)}

--- a/src/components/modals/about/about-modal.tsx
+++ b/src/components/modals/about/about-modal.tsx
@@ -1,7 +1,6 @@
 import { Space, Tag } from 'antd';
 import { LogoPanel } from '@/components/panels/logo/logo-panel';
 import { Modal } from '@/components/modals/modal/modal';
-import { Options } from '@/models/options';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
 
 import pbds from '@/assets/powered-by-draw-steel.png';
@@ -10,7 +9,6 @@ import pkg from '../../../../package.json';
 import './about-modal.scss';
 
 interface Props {
-	options: Options;
 	onClose: () => void;
 }
 

--- a/src/components/modals/element/element-modal.tsx
+++ b/src/components/modals/element/element-modal.tsx
@@ -20,7 +20,6 @@ import { KitPanel } from '@/components/panels/elements/kit-panel/kit-panel';
 import { Modal } from '@/components/modals/modal/modal';
 import { MonsterGroup } from '@/models/monster-group';
 import { MonsterGroupPanel } from '@/components/panels/elements/monster-group-panel/monster-group-panel';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Perk } from '@/models/perk';
 import { PerkPanel } from '@/components/panels/elements/perk-panel/perk-panel';
@@ -38,7 +37,6 @@ interface Props {
 	category: string;
 	element: Element;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	onClose: () => void;
 }
 
@@ -50,7 +48,6 @@ export const ElementModal = (props: Props) => {
 					<AncestryPanel
 						ancestry={props.element as Ancestry}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 						mode={PanelMode.Full}
 					/>
 				);
@@ -59,7 +56,6 @@ export const ElementModal = (props: Props) => {
 					<CareerPanel
 						career={props.element as Career}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 						mode={PanelMode.Full}
 					/>
 				);
@@ -68,7 +64,6 @@ export const ElementModal = (props: Props) => {
 					<ClassPanel
 						heroClass={props.element as HeroClass}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 						mode={PanelMode.Full}
 					/>
 				);
@@ -77,7 +72,6 @@ export const ElementModal = (props: Props) => {
 					<ComplicationPanel
 						complication={props.element as Complication}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 						mode={PanelMode.Full}
 					/>
 				);
@@ -86,7 +80,6 @@ export const ElementModal = (props: Props) => {
 					<CulturePanel
 						culture={props.element as Culture}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 						mode={PanelMode.Full}
 					/>
 				);
@@ -95,7 +88,6 @@ export const ElementModal = (props: Props) => {
 					<DomainPanel
 						domain={props.element as Domain}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 						mode={PanelMode.Full}
 					/>
 				);
@@ -104,7 +96,6 @@ export const ElementModal = (props: Props) => {
 					<ImbuementPanel
 						imbuement={props.element as Imbuement}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 						mode={PanelMode.Full}
 					/>
 				);
@@ -113,7 +104,6 @@ export const ElementModal = (props: Props) => {
 					<ItemPanel
 						item={props.element as Item}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 						mode={PanelMode.Full}
 					/>
 				);
@@ -122,7 +112,6 @@ export const ElementModal = (props: Props) => {
 					<KitPanel
 						kit={props.element as Kit}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 						mode={PanelMode.Full}
 					/>
 				);
@@ -131,7 +120,6 @@ export const ElementModal = (props: Props) => {
 					<MonsterGroupPanel
 						monsterGroup={props.element as MonsterGroup}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 						mode={PanelMode.Full}
 					/>
 				);
@@ -140,7 +128,6 @@ export const ElementModal = (props: Props) => {
 					<PerkPanel
 						perk={props.element as Perk}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 						mode={PanelMode.Full}
 					/>
 				);
@@ -149,7 +136,6 @@ export const ElementModal = (props: Props) => {
 					<SubclassPanel
 						subclass={props.element as SubClass}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 						mode={PanelMode.Full}
 					/>
 				);
@@ -167,7 +153,6 @@ export const ElementModal = (props: Props) => {
 					<TitlePanel
 						title={props.element as Title}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 						mode={PanelMode.Full}
 					/>
 				);

--- a/src/components/modals/encounter-tools/encounter-tools-modal.tsx
+++ b/src/components/modals/encounter-tools/encounter-tools-modal.tsx
@@ -9,7 +9,6 @@ import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Modal } from '@/components/modals/modal/modal';
 import { Monster } from '@/models/monster';
 import { MonsterLogic } from '@/logic/monster-logic';
-import { Options } from '@/models/options';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
 import { Sourcebook } from '@/models/sourcebook';
 import { SourcebookLogic } from '@/logic/sourcebook-logic';
@@ -19,7 +18,6 @@ import './encounter-tools-modal.scss';
 interface Props {
 	encounter: Encounter;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	onClose: () => void;
 }
 

--- a/src/components/modals/feature/feature-modal.tsx
+++ b/src/components/modals/feature/feature-modal.tsx
@@ -5,7 +5,6 @@ import { FeaturePanel } from '@/components/panels/elements/feature-panel/feature
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { MarkdownEditor } from '@/components/controls/markdown/markdown';
 import { Modal } from '@/components/modals/modal/modal';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Segmented } from 'antd';
 import { Sourcebook } from '@/models/sourcebook';
@@ -18,7 +17,6 @@ import './feature-modal.scss';
 interface Props {
 	feature: Feature;
 	hero: Hero;
-	options: Options;
 	sourcebooks: Sourcebook[];
 	onClose: () => void;
 	updateHero?: (hero: Hero) => void;
@@ -101,7 +99,6 @@ export const FeatureModal = (props: Props) => {
 					<div className='feature-section'>
 						<FeaturePanel
 							feature={props.feature}
-							options={props.options}
 							hero={props.hero}
 							sourcebooks={props.sourcebooks}
 							mode={PanelMode.Full}

--- a/src/components/modals/fixture/fixture-modal.tsx
+++ b/src/components/modals/fixture/fixture-modal.tsx
@@ -1,7 +1,6 @@
 import { Fixture } from '@/models/fixture';
 import { FixturePanel } from '@/components/panels/elements/fixture-panel/fixture-panel';
 import { Modal } from '@/components/modals/modal/modal';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Sourcebook } from '@/models/sourcebook';
 
@@ -10,7 +9,6 @@ import './fixture-modal.scss';
 interface Props {
 	fixture: Fixture;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	onClose: () => void;
 }
 
@@ -19,7 +17,7 @@ export const FixtureModal = (props: Props) => {
 		<Modal
 			content={
 				<div className='fixture-modal'>
-					<FixturePanel fixture={props.fixture} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} />
+					<FixturePanel fixture={props.fixture} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
 				</div>
 			}
 			onClose={props.onClose}

--- a/src/components/modals/follower/follower-modal.tsx
+++ b/src/components/modals/follower/follower-modal.tsx
@@ -3,7 +3,6 @@ import { Follower } from '@/models/follower';
 import { FollowerEditPanel } from '@/components/panels/edit/follower-edit/follower-edit-panel';
 import { FollowerPanel } from '@/components/panels/elements/follower-panel/follower-panel';
 import { Modal } from '@/components/modals/modal/modal';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Sourcebook } from '@/models/sourcebook';
 import { Utils } from '@/utils/utils';
@@ -14,7 +13,6 @@ import './follower-modal.scss';
 interface Props {
 	follower: Follower;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	onChange: (follower: Follower) => void;
 	onClose: () => void;
 }
@@ -36,7 +34,6 @@ export const FollowerModal = (props: Props) => {
 							<FollowerEditPanel
 								follower={follower}
 								sourcebooks={props.sourcebooks}
-								options={props.options}
 								onChange={onChange}
 							/>
 						</Expander>

--- a/src/components/modals/hero-customize/hero-customize-modal.tsx
+++ b/src/components/modals/hero-customize/hero-customize-modal.tsx
@@ -26,7 +26,6 @@ import { KitWeapon } from '@/enums/kit-weapon';
 import { Modal } from '@/components/modals/modal/modal';
 import { ModifierEditor } from '@/components/panels/edit/modifier-edit/modifier-edit-panel';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { PerkList } from '@/enums/perk-list';
 import { PlusOutlined } from '@ant-design/icons';
 import { Sourcebook } from '@/models/sourcebook';
@@ -40,7 +39,6 @@ import './hero-customize-modal.scss';
 interface Props {
 	hero: Hero;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	onChange: (hero: Hero) => void;
 	onClose: () => void;
 }
@@ -628,7 +626,7 @@ export const HeroCustomizeModal = (props: Props) => {
 			case FeatureType.Follower:
 				return (
 					<Expander title='Customize'>
-						<FollowerEditPanel follower={feature.data.follower} sourcebooks={props.sourcebooks} options={props.options} onChange={setFollower} />
+						<FollowerEditPanel follower={feature.data.follower} sourcebooks={props.sourcebooks} onChange={setFollower} />
 					</Expander>
 				);
 			case FeatureType.MovementMode:
@@ -717,7 +715,6 @@ export const HeroCustomizeModal = (props: Props) => {
 												feature={f}
 												hero={props.hero}
 												sourcebooks={props.sourcebooks}
-												options={props.options}
 												setData={data => setFeatureData(f.id, data)}
 											/>
 										</Expander>

--- a/src/components/modals/hero-inventory/hero-inventory-modal.tsx
+++ b/src/components/modals/hero-inventory/hero-inventory-modal.tsx
@@ -13,7 +13,6 @@ import { ItemPanel } from '@/components/panels/elements/item-panel/item-panel';
 import { ItemSelectModal } from '@/components/modals/select/item-select/item-select-modal';
 import { ItemType } from '@/enums/item-type';
 import { Modal } from '@/components/modals/modal/modal';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Sourcebook } from '@/models/sourcebook';
 import { Utils } from '@/utils/utils';
@@ -24,7 +23,6 @@ import './hero-inventory-modal.scss';
 interface Props {
 	hero: Hero;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	onClose: () => void;
 	onChange: (hero: Hero) => void;
 	onCustomize: () => void;
@@ -115,7 +113,6 @@ export const HeroInventoryModal = (props: Props) => {
 											>
 												<ItemPanel
 													item={i.item}
-													options={props.options}
 													wielder={hero}
 													sourcebooks={props.sourcebooks}
 													mode={PanelMode.Full}
@@ -132,7 +129,6 @@ export const HeroInventoryModal = (props: Props) => {
 											>
 												<ItemPanel
 													item={i.item}
-													options={props.options}
 													wielder={hero}
 													sourcebooks={props.sourcebooks}
 													mode={PanelMode.Full}
@@ -152,7 +148,6 @@ export const HeroInventoryModal = (props: Props) => {
 						<ItemSelectModal
 							types={[ ItemType.Artifact, ItemType.Consumable1st, ItemType.Consumable2nd, ItemType.Consumable3rd, ItemType.Consumable4th, ItemType.ImbuedArmor, ItemType.ImbuedImplement, ItemType.ImbuedWeapon, ItemType.Leveled, ItemType.LeveledArmor, ItemType.LeveledImplement, ItemType.LeveledWeapon, ItemType.Trinket1st, ItemType.Trinket2nd, ItemType.Trinket3rd, ItemType.Trinket4th ]}
 							sourcebooks={props.sourcebooks}
-							options={props.options}
 							hero={hero}
 							onSelect={addItem}
 							onCustomize={props.onCustomize}

--- a/src/components/modals/hero-level-up/hero-level-up-modal.tsx
+++ b/src/components/modals/hero-level-up/hero-level-up-modal.tsx
@@ -7,10 +7,10 @@ import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { HeroLogic } from '@/logic/hero-logic';
 import { Modal } from '@/components/modals/modal/modal';
-import { Options } from '@/models/options';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
 import { Sourcebook } from '@/models/sourcebook';
 import { Utils } from '@/utils/utils';
+import { useOptions } from '@/contexts/data-context';
 import { useState } from 'react';
 
 import './hero-level-up-modal.scss';
@@ -18,16 +18,16 @@ import './hero-level-up-modal.scss';
 interface Props {
 	hero: Hero;
 	soucebooks: Sourcebook[];
-	options: Options;
 	onAccept: (hero: Hero) => void;
 	onClose: () => void;
 }
 
 export const HeroLevelUpModal = (props: Props) => {
+	const options = useOptions();
 	const [ hero, setHero ] = useState<Hero>(() => {
 		const copy = Utils.copy(props.hero);
-		if (HeroLogic.canLevelUp(copy, props.options)) {
-			HeroLogic.setLevel(copy, props.options, copy.class!.level + 1);
+		if (HeroLogic.canLevelUp(copy, options)) {
+			HeroLogic.setLevel(copy, options, copy.class!.level + 1);
 		}
 		return copy;
 	});
@@ -51,7 +51,6 @@ export const HeroLevelUpModal = (props: Props) => {
 					feature={feature}
 					hero={hero}
 					sourcebooks={props.soucebooks}
-					options={props.options}
 					setData={setData}
 				/>
 			</SelectablePanel>

--- a/src/components/modals/hero-projects/hero-projects-modal.tsx
+++ b/src/components/modals/hero-projects/hero-projects-modal.tsx
@@ -11,7 +11,6 @@ import { HeroLogic } from '@/logic/hero-logic';
 import { Item } from '@/models/item';
 import { Modal } from '@/components/modals/modal/modal';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Project } from '@/models/project';
 import { ProjectLogic } from '@/logic/project-logic';
@@ -26,7 +25,6 @@ import './hero-projects-modal.scss';
 interface Props {
 	hero: Hero;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	onClose: () => void;
 	onChange: (hero: Hero) => void;
 	onCustomize: () => void;

--- a/src/components/modals/hero-resources/hero-resources-modal.tsx
+++ b/src/components/modals/hero-resources/hero-resources-modal.tsx
@@ -12,12 +12,12 @@ import { HeroLogic } from '@/logic/hero-logic';
 import { Modal } from '@/components/modals/modal/modal';
 import { Monster } from '@/models/monster';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { Random } from '@/utils/random';
 import { RetainerSelectModal } from '@/components/modals/select/retainer-select/retainer-select-modal';
 import { Sourcebook } from '@/models/sourcebook';
 import { SourcebookLogic } from '@/logic/sourcebook-logic';
 import { Utils } from '@/utils/utils';
+import { useOptions } from '@/contexts/data-context';
 import { useState } from 'react';
 
 import './hero-resources-modal.scss';
@@ -34,7 +34,6 @@ interface Expression {
 interface Props {
 	hero: Hero;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	onClose: () => void;
 	onChange: (hero: Hero) => void;
 }
@@ -44,6 +43,7 @@ export const HeroResourcesModal = (props: Props) => {
 	const [ expression, setExpression ] = useState<Expression | null>(null);
 	const [ showLevelUp, setShowLevelUp ] = useState<boolean>(false);
 	const [ showRetainers, setShowRetainers ] = useState<boolean>(false);
+	const options = useOptions();
 
 	const getHeroicResourceSection = () => {
 		const setHeroicResource = (featureID: string, value: number) => {
@@ -367,7 +367,6 @@ export const HeroResourcesModal = (props: Props) => {
 					<RetainerSelectModal
 						monsters={SourcebookLogic.getMonsters(props.sourcebooks)}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 						onSelect={monster => {
 							setShowRetainers(false);
 
@@ -394,22 +393,22 @@ export const HeroResourcesModal = (props: Props) => {
 			props.onChange(copy);
 		};
 
-		const minXP = HeroLogic.getMinXP(hero.class!.level, props.options);
+		const minXP = HeroLogic.getMinXP(hero.class!.level, options);
 
 		return (
 			<Space orientation='vertical' style={{ width: '100%' }}>
 				<HeaderText>XP</HeaderText>
 				<NumberSpin
 					min={minXP}
-					suffix={`/ ${props.options.xpPerLevel * hero.class!.level}`}
+					suffix={`/ ${options.xpPerLevel * hero.class!.level}`}
 					value={hero.state.xp}
 					onChange={setXP}
 				/>
 				<Flex justify='center'>
-					<Progress percent={100 * (hero.state.xp - minXP) / props.options.xpPerLevel} steps={props.options.xpPerLevel} showInfo={false} />
+					<Progress percent={100 * (hero.state.xp - minXP) / options.xpPerLevel} steps={options.xpPerLevel} showInfo={false} />
 				</Flex>
 				{
-					HeroLogic.canLevelUp(hero, props.options) ?
+					HeroLogic.canLevelUp(hero, options) ?
 						<Alert
 							type='info'
 							showIcon={true}
@@ -522,7 +521,6 @@ export const HeroResourcesModal = (props: Props) => {
 								<HeroLevelUpModal
 									hero={hero}
 									soucebooks={props.sourcebooks}
-									options={props.options}
 									onAccept={h => {
 										setShowLevelUp(false);
 										setHero(h);

--- a/src/components/modals/hero-respite/hero-respite-modal.tsx
+++ b/src/components/modals/hero-respite/hero-respite-modal.tsx
@@ -7,7 +7,6 @@ import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { HeroLogic } from '@/logic/hero-logic';
 import { Modal } from '@/components/modals/modal/modal';
-import { Options } from '@/models/options';
 import { Sourcebook } from '@/models/sourcebook';
 import { Utils } from '@/utils/utils';
 import { useState } from 'react';
@@ -17,7 +16,6 @@ import './hero-respite-modal.scss';
 interface Props {
 	hero: Hero;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	onTakeRespite: () => void;
 	onChange: (hero: Hero) => void;
 	onClose: () => void;
@@ -88,7 +86,6 @@ export const HeroRespiteModal = (props: Props) => {
 													feature={f}
 													hero={hero}
 													sourcebooks={props.sourcebooks}
-													options={props.options}
 													setData={(featureID, data) => {
 														const copy = Utils.copy(hero);
 														const feature = HeroLogic.getFeatures(copy)

--- a/src/components/modals/hero-sourcebooks/hero-sourcebooks-modal.tsx
+++ b/src/components/modals/hero-sourcebooks/hero-sourcebooks-modal.tsx
@@ -2,7 +2,6 @@ import { ErrorBoundary } from '@/components/controls/error-boundary/error-bounda
 import { Hero } from '@/models/hero';
 import { HeroSourcebooksPanel } from '@/components/panels/hero-sourcebooks/hero-sourcebooks-panel';
 import { Modal } from '@/components/modals/modal/modal';
-import { Options } from '@/models/options';
 import { Sourcebook } from '@/models/sourcebook';
 import { Utils } from '@/utils/utils';
 import { useState } from 'react';
@@ -13,7 +12,6 @@ interface Props {
 	hero: Hero;
 	sourcebooks: Sourcebook[];
 	allSourcebooks: Sourcebook[];
-	options: Options;
 	onChange: (hero: Hero) => void;
 	onImportSourcebook: (sourcebook: Sourcebook) => void;
 	onClose: () => void;
@@ -24,7 +22,7 @@ export const HeroSourcebooksModal = (props: Props) => {
 
 	const onChange = (sourcebookIDs: string[]) => {
 		const heroCopy = Utils.copy(hero);
-		heroCopy.settingIDs = sourcebookIDs;
+		heroCopy.sourcebookIDs = sourcebookIDs;
 		setHero(heroCopy);
 		props.onChange(heroCopy);
 	};
@@ -36,7 +34,7 @@ export const HeroSourcebooksModal = (props: Props) => {
 					<div className='hero-sourcebooks-modal'>
 						<HeroSourcebooksPanel
 							sourcebooks={props.allSourcebooks}
-							sourcebookIDs={props.hero.settingIDs}
+							sourcebookIDs={props.hero.sourcebookIDs}
 							onImportSourcebook={props.onImportSourcebook}
 							onChange={onChange}
 						/>

--- a/src/components/modals/hero-titles/hero-titles-modal.tsx
+++ b/src/components/modals/hero-titles/hero-titles-modal.tsx
@@ -8,7 +8,6 @@ import { Expander } from '@/components/controls/expander/expander';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { Modal } from '@/components/modals/modal/modal';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Sourcebook } from '@/models/sourcebook';
 import { SourcebookLogic } from '@/logic/sourcebook-logic';
@@ -23,7 +22,6 @@ import './hero-titles-modal.scss';
 interface Props {
 	hero: Hero;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	onClose: () => void;
 	onChange: (hero: Hero) => void;
 	onCustomize: () => void;
@@ -116,7 +114,6 @@ export const HeroTitlesModal = (props: Props) => {
 										title={title}
 										hero={hero}
 										sourcebooks={props.sourcebooks}
-										options={props.options}
 										mode={PanelMode.Full}
 										onChange={changeTitle}
 									/>
@@ -133,7 +130,6 @@ export const HeroTitlesModal = (props: Props) => {
 						<TitleSelectModal
 							hero={hero}
 							sourcebooks={props.sourcebooks}
-							options={props.options}
 							onSelect={addTitle}
 							onCustomize={props.onCustomize}
 							onClose={() => setTitlesVisible(false)}

--- a/src/components/modals/monster/monster-modal.tsx
+++ b/src/components/modals/monster/monster-modal.tsx
@@ -13,7 +13,6 @@ import { MonsterLogic } from '@/logic/monster-logic';
 import { MonsterPanel } from '@/components/panels/elements/monster-panel/monster-panel';
 import { MonsterToken } from '@/components/panels/token/token';
 import { NameDescEditPanel } from '@/components/panels/edit/name-desc-edit/name-desc-edit-panel';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Sourcebook } from '@/models/sourcebook';
 import { SummoningInfo } from '@/models/summon';
@@ -29,7 +28,6 @@ interface Props {
 	encounter?: Encounter;
 	summon?: SummoningInfo;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	onChange?: (monster: Monster) => void;
 	onClose: () => void;
 	updateMonster?: (monster: Monster) => void;
@@ -156,7 +154,6 @@ export const MonsterModal = (props: Props) => {
 							monsterGroup={props.monsterGroup}
 							summon={props.summon}
 							sourcebooks={props.sourcebooks}
-							options={props.options}
 							mode={PanelMode.Full}
 						/>
 					</>
@@ -169,7 +166,6 @@ export const MonsterModal = (props: Props) => {
 								.map(malice => (
 									<MalicePanel
 										malice={malice}
-										options={props.options}
 										currentMalice={encounter ? encounter.malice : undefined}
 										updateCurrentMalice={
 											encounter ?

--- a/src/components/modals/party/party-modal.tsx
+++ b/src/components/modals/party/party-modal.tsx
@@ -6,7 +6,6 @@ import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { HeroLogic } from '@/logic/hero-logic';
 import { Modal } from '@/components/modals/modal/modal';
-import { Options } from '@/models/options';
 import { Sourcebook } from '@/models/sourcebook';
 import { SourcebookLogic } from '@/logic/sourcebook-logic';
 
@@ -15,7 +14,6 @@ import './party-modal.scss';
 interface Props {
 	heroes: Hero[];
 	sourcebooks: Sourcebook[];
-	options: Options;
 	onClose: () => void;
 }
 

--- a/src/components/modals/player-view/player-view-modal.tsx
+++ b/src/components/modals/player-view/player-view-modal.tsx
@@ -5,19 +5,19 @@ import { Modal } from '@/components/modals/modal/modal';
 import { Session } from '@/models/session';
 import { Toggle } from '@/components/controls/toggle/toggle';
 import { Utils } from '@/utils/utils';
+import { useSession } from '@/contexts/data-context';
 import { useState } from 'react';
 
 import './player-view-modal.scss';
 
 interface Props {
-	session: Session;
 	updateSession: (session: Session) => void;
 	openPlayerView: (playerView: Window | null) => void;
 	onClose: () => void;
 }
 
 export const PlayerViewModal = (props: Props) => {
-	const [ session, setSession ] = useState<Session>(Utils.copy(props.session));
+	const [ session, setSession ] = useState<Session>(useSession());
 
 	const setPlayerViewID = (value: string | null) => {
 		const copy = Utils.copy(session);

--- a/src/components/modals/select/feature-select/feature-select-modal.tsx
+++ b/src/components/modals/select/feature-select/feature-select-modal.tsx
@@ -3,7 +3,6 @@ import { Feature } from '@/models/feature';
 import { FeaturePanel } from '@/components/panels/elements/feature-panel/feature-panel';
 import { Hero } from '@/models/hero';
 import { Modal } from '@/components/modals/modal/modal';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { SearchBox } from '@/components/controls/text-input/text-input';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
@@ -18,7 +17,6 @@ interface Props {
 	features: { feature: Feature, value: number }[];
 	hero?: Hero;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	onClose: () => void;
 	onSelect: (feature: Feature) => void;
 }
@@ -53,7 +51,6 @@ export const FeatureSelectModal = (props: Props) => {
 										cost={showCosts ? f.value : undefined}
 										hero={props.hero}
 										sourcebooks={props.sourcebooks}
-										options={props.options}
 										mode={PanelMode.Full}
 									/>
 								</SelectablePanel>

--- a/src/components/modals/select/hero-select/hero-select-modal.tsx
+++ b/src/components/modals/select/hero-select/hero-select-modal.tsx
@@ -12,12 +12,12 @@ import { PlusOutlined } from '@ant-design/icons';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
 import { Sourcebook } from '@/models/sourcebook';
 import { TextInput } from '@/components/controls/text-input/text-input';
+import { useHeroes } from '@/contexts/data-context';
 import { useState } from 'react';
 
 import './hero-select-modal.scss';
 
 interface Props {
-	heroes: Hero[];
 	sourcebooks: Sourcebook[];
 	onClose: () => void;
 	onSelect: (heroes: Hero[]) => void;
@@ -26,12 +26,13 @@ interface Props {
 export const HeroSelectModal = (props: Props) => {
 	const [ mode, setMode ] = useState<string>('folder');
 	const [ heroName, setHeroName ] = useState<string>('');
+	const heroes = useHeroes();
 
 	const getContent = () => {
 		switch (mode) {
 			case 'folder': {
 				const folders = Collections
-					.distinct(props.heroes.map(h => h.folder), f => f)
+					.distinct(heroes.map(h => h.folder), f => f)
 					.sort()
 					.filter(f => !!f);
 
@@ -52,12 +53,12 @@ export const HeroSelectModal = (props: Props) => {
 							folders.map(f => (
 								<SelectablePanel
 									key={f}
-									onSelect={() => props.onSelect(props.heroes.filter(h => h.folder === f))}
+									onSelect={() => props.onSelect(heroes.filter(h => h.folder === f))}
 								>
 									<HeaderText level={1}>{f}</HeaderText>
 									<Space orientation='vertical' style={{ width: '100%' }}>
 										{
-											props.heroes
+											heroes
 												.filter(h => h.folder === f)
 												.sort()
 												.map(h => <HeroInfo key={h.id} hero={h} />)
@@ -70,8 +71,6 @@ export const HeroSelectModal = (props: Props) => {
 				);
 			}
 			case 'hero': {
-				const heroes = props.heroes;
-
 				if (heroes.length === 0) {
 					return (
 						<Empty text='No heroes' />

--- a/src/components/modals/select/hero-select/hero-select-modal.tsx
+++ b/src/components/modals/select/hero-select/hero-select-modal.tsx
@@ -8,7 +8,6 @@ import { HeroInfo } from '@/components/panels/token/token';
 import { HeroLogic } from '@/logic/hero-logic';
 import { HeroOverviewPanel } from '@/components/panels/hero-overview/hero-overview-panel';
 import { Modal } from '@/components/modals/modal/modal';
-import { Options } from '@/models/options';
 import { PlusOutlined } from '@ant-design/icons';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
 import { Sourcebook } from '@/models/sourcebook';
@@ -20,7 +19,6 @@ import './hero-select-modal.scss';
 interface Props {
 	heroes: Hero[];
 	sourcebooks: Sourcebook[];
-	options: Options;
 	onClose: () => void;
 	onSelect: (heroes: Hero[]) => void;
 }

--- a/src/components/modals/select/item-select/item-select-modal.tsx
+++ b/src/components/modals/select/item-select/item-select-modal.tsx
@@ -8,7 +8,6 @@ import { Item } from '@/models/item';
 import { ItemPanel } from '@/components/panels/elements/item-panel/item-panel';
 import { ItemType } from '@/enums/item-type';
 import { Modal } from '@/components/modals/modal/modal';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { PlusOutlined } from '@ant-design/icons';
 import { SearchBox } from '@/components/controls/text-input/text-input';
@@ -23,7 +22,6 @@ import './item-select-modal.scss';
 interface Props {
 	types: ItemType[];
 	sourcebooks: Sourcebook[];
-	options: Options;
 	hero: Hero;
 	onClose: () => void;
 	onSelect: (item: Item) => void;
@@ -113,7 +111,7 @@ export const ItemSelectModal = (props: Props) => {
 										/>
 									]}
 								>
-									<ItemPanel item={item} sourcebooks={props.sourcebooks} options={props.options} wielder={props.hero} mode={PanelMode.Full} />
+									<ItemPanel item={item} sourcebooks={props.sourcebooks} wielder={props.hero} mode={PanelMode.Full} />
 								</Expander>
 							))
 						}

--- a/src/components/modals/select/kit-select/kit-select-modal.tsx
+++ b/src/components/modals/select/kit-select/kit-select-modal.tsx
@@ -3,7 +3,6 @@ import { Hero } from '@/models/hero';
 import { Kit } from '@/models/kit';
 import { KitPanel } from '@/components/panels/elements/kit-panel/kit-panel';
 import { Modal } from '@/components/modals/modal/modal';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { SearchBox } from '@/components/controls/text-input/text-input';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
@@ -18,7 +17,6 @@ interface Props {
 	kits: Kit[];
 	hero: Hero;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	onClose: () => void;
 	onSelect: (kits: Kit) => void;
 }
@@ -46,7 +44,7 @@ export const KitSelectModal = (props: Props) => {
 									key={k.id}
 									onSelect={() => props.onSelect(k)}
 								>
-									<KitPanel kit={k} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} />
+									<KitPanel kit={k} hero={props.hero} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
 								</SelectablePanel>
 							))
 						}

--- a/src/components/modals/select/monster-select/monster-select-modal.tsx
+++ b/src/components/modals/select/monster-select/monster-select-modal.tsx
@@ -9,7 +9,6 @@ import { MonsterFilter } from '@/models/filter';
 import { MonsterFilterPanel } from '@/components/panels/monster-filter/monster-filter-panel';
 import { MonsterLogic } from '@/logic/monster-logic';
 import { MonsterPanel } from '@/components/panels/elements/monster-panel/monster-panel';
-import { Options } from '@/models/options';
 import { SearchBox } from '@/components/controls/text-input/text-input';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
 import { Sourcebook } from '@/models/sourcebook';
@@ -22,7 +21,6 @@ import './monster-select-modal.scss';
 interface Props {
 	monsters: Monster[];
 	sourcebooks: Sourcebook[];
-	options: Options;
 	onClose: () => void;
 	onSelect: (monster: Monster) => void;
 }
@@ -66,7 +64,7 @@ export const MonsterSelectModal = (props: Props) => {
 									key={m.id}
 									onSelect={() => props.onSelect(m)}
 								>
-									<MonsterPanel monster={m} sourcebooks={props.sourcebooks} options={props.options} />
+									<MonsterPanel monster={m} sourcebooks={props.sourcebooks} />
 								</SelectablePanel>
 							))
 						}

--- a/src/components/modals/select/perk-select/perk-select-modal.tsx
+++ b/src/components/modals/select/perk-select/perk-select-modal.tsx
@@ -2,7 +2,6 @@ import { Empty } from '@/components/controls/empty/empty';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { Modal } from '@/components/modals/modal/modal';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Perk } from '@/models/perk';
 import { PerkList } from '@/enums/perk-list';
@@ -20,7 +19,6 @@ interface Props {
 	perks: Perk[];
 	hero: Hero;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	onClose: () => void;
 	onSelect: (perk: Perk) => void;
 }
@@ -54,7 +52,7 @@ export const PerkSelectModal = (props: Props) => {
 									{
 										subset.map((p, n) => (
 											<SelectablePanel key={n} onSelect={() => props.onSelect(p)}>
-												<PerkPanel perk={p} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} />
+												<PerkPanel perk={p} hero={props.hero} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
 											</SelectablePanel>
 										))
 									}

--- a/src/components/modals/select/retainer-select/retainer-select-modal.tsx
+++ b/src/components/modals/select/retainer-select/retainer-select-modal.tsx
@@ -10,7 +10,6 @@ import { MonsterFilterPanel } from '@/components/panels/monster-filter/monster-f
 import { MonsterLogic } from '@/logic/monster-logic';
 import { MonsterOrganizationType } from '@/enums/monster-organization-type';
 import { MonsterPanel } from '@/components/panels/elements/monster-panel/monster-panel';
-import { Options } from '@/models/options';
 import { SearchBox } from '@/components/controls/text-input/text-input';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
 import { Sourcebook } from '@/models/sourcebook';
@@ -23,7 +22,6 @@ import './retainer-select-modal.scss';
 interface Props {
 	monsters: Monster[];
 	sourcebooks: Sourcebook[];
-	options: Options;
 	onClose: () => void;
 	onSelect: (monster: Monster) => void;
 }
@@ -68,7 +66,7 @@ export const RetainerSelectModal = (props: Props) => {
 									key={m.id}
 									onSelect={() => props.onSelect(Utils.copy(m))}
 								>
-									<MonsterPanel monster={m} sourcebooks={props.sourcebooks} options={props.options} />
+									<MonsterPanel monster={m} sourcebooks={props.sourcebooks} />
 								</SelectablePanel>
 							))
 						}

--- a/src/components/modals/select/subclass-select/subclass-select-modal.tsx
+++ b/src/components/modals/select/subclass-select/subclass-select-modal.tsx
@@ -3,7 +3,6 @@ import { Collections } from '@/utils/collections';
 import { Empty } from '@/components/controls/empty/empty';
 import { Expander } from '@/components/controls/expander/expander';
 import { Modal } from '@/components/modals/modal/modal';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { SearchBox } from '@/components/controls/text-input/text-input';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
@@ -19,7 +18,6 @@ interface Props {
 	subClasses: SubClass[];
 	classID: string;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	onClose: () => void;
 	onSelect: (subClass: SubClass) => void;
 }
@@ -66,7 +64,7 @@ export const SubClassSelectModal = (props: Props) => {
 									key={sc.id}
 									onSelect={() => props.onSelect(sc)}
 								>
-									<SubclassPanel subclass={sc} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Compact} />
+									<SubclassPanel subclass={sc} sourcebooks={props.sourcebooks} mode={PanelMode.Compact} />
 								</SelectablePanel>
 							))
 						}
@@ -87,7 +85,7 @@ export const SubClassSelectModal = (props: Props) => {
 														key={sc.id}
 														onSelect={() => props.onSelect(sc)}
 													>
-														<SubclassPanel subclass={sc} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Compact} />
+														<SubclassPanel subclass={sc} sourcebooks={props.sourcebooks} mode={PanelMode.Compact} />
 													</SelectablePanel>
 												))
 											}
@@ -113,7 +111,7 @@ export const SubClassSelectModal = (props: Props) => {
 														key={sc.id}
 														onSelect={() => props.onSelect(sc)}
 													>
-														<SubclassPanel subclass={sc} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Compact} />
+														<SubclassPanel subclass={sc} sourcebooks={props.sourcebooks} mode={PanelMode.Compact} />
 													</SelectablePanel>
 												))
 											}

--- a/src/components/modals/select/summon-select/summon-select-modal.tsx
+++ b/src/components/modals/select/summon-select/summon-select-modal.tsx
@@ -4,7 +4,6 @@ import { Hero } from '@/models/hero';
 import { Modal } from '@/components/modals/modal/modal';
 import { MonsterLogic } from '@/logic/monster-logic';
 import { MonsterPanel } from '@/components/panels/elements/monster-panel/monster-panel';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { SearchBox } from '@/components/controls/text-input/text-input';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
@@ -21,7 +20,6 @@ interface Props {
 	summons: Summon[];
 	hero: Hero;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	onClose: () => void;
 	onSelect: (summon: Summon) => void;
 }
@@ -52,7 +50,7 @@ export const SummonSelectModal = (props: Props) => {
 									key={s.id}
 									onSelect={() => props.onSelect(s)}
 								>
-									<MonsterPanel monster={SummonLogic.getSummonedMonster(s, props.hero)} summon={s.info} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} />
+									<MonsterPanel monster={SummonLogic.getSummonedMonster(s, props.hero)} summon={s.info} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
 								</SelectablePanel>
 							))
 						}

--- a/src/components/modals/select/title-select/title-select-modal.tsx
+++ b/src/components/modals/select/title-select/title-select-modal.tsx
@@ -9,7 +9,6 @@ import { Hero } from '@/models/hero';
 import { HeroLogic } from '@/logic/hero-logic';
 import { Modal } from '@/components/modals/modal/modal';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { SearchBox } from '@/components/controls/text-input/text-input';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
@@ -25,7 +24,6 @@ import './title-select-modal.scss';
 interface Props {
 	hero: Hero;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	onClose: () => void;
 	onSelect: (title: Title) => void;
 	onCustomize?: () => void;
@@ -88,7 +86,7 @@ export const TitleSelectModal = (props: Props) => {
 											key={t.id}
 											onSelect={() => selectTitle(t)}
 										>
-											<TitlePanel title={t} hero={props.hero} sourcebooks={props.sourcebooks} mode={PanelMode.Full} options={props.options} />
+											<TitlePanel title={t} hero={props.hero} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
 										</SelectablePanel>
 									))
 								}
@@ -100,7 +98,7 @@ export const TitleSelectModal = (props: Props) => {
 										<Button onClick={e => { e.stopPropagation(); setSelectedTitle(null); }}>Unselect</Button>
 									}
 								>
-									<TitlePanel title={selectedTitle} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />
+									<TitlePanel title={selectedTitle} hero={props.hero} sourcebooks={props.sourcebooks} />
 								</SelectablePanel>
 								<Alert
 									type='info'
@@ -113,7 +111,7 @@ export const TitleSelectModal = (props: Props) => {
 											key={f.id}
 											onSelect={() => selectFeature(f)}
 										>
-											<FeaturePanel feature={f} hero={props.hero} mode={PanelMode.Full} options={props.options} />
+											<FeaturePanel feature={f} hero={props.hero} mode={PanelMode.Full} />
 										</SelectablePanel>
 									))
 								}

--- a/src/components/modals/settings/settings-modal.tsx
+++ b/src/components/modals/settings/settings-modal.tsx
@@ -1,5 +1,6 @@
 import { Alert, Button, Drawer, Flex, Segmented, Select, Space } from 'antd';
 import { FlagFilled, FlagOutlined, MoonOutlined, SettingOutlined, SunOutlined } from '@ant-design/icons';
+import { useDataManager, useOptions } from '@/contexts/data-context';
 import { AbilityData } from '@/data/ability-data';
 import { Collections } from '@/utils/collections';
 import { ConnectionSettings } from '@/models/connection-settings';
@@ -24,7 +25,6 @@ import { TextInput } from '@/components/controls/text-input/text-input';
 import { Toggle } from '@/components/controls/toggle/toggle';
 import { Utils } from '@/utils/utils';
 import { WarehouseActionsPanel } from '@/components/panels/connection-settings/warehouse-actions-panel';
-import { useOptions } from '@/contexts/data-context';
 import { useState } from 'react';
 import { useTheme } from '@/hooks/use-theme';
 
@@ -32,7 +32,6 @@ import './settings-modal.scss';
 
 interface Props {
 	heroes: Hero[];
-	setOptions: (options: Options) => void;
 	connectionSettings: ConnectionSettings;
 	dataService: DataService;
 	setConnectionSettings: (settings: ConnectionSettings) => void
@@ -41,7 +40,6 @@ interface Props {
 
 export const SettingsModal = (props: Props) => {
 	const { themeMode, setTheme } = useTheme();
-	// const options = useOptions();
 	const [ options, setOptions ] = useState<Options>(Utils.copy(useOptions()));
 	const [ page, setPage ] = useState<string>('Settings');
 	const [ standardAbilitiesMode, setStandardAbilitiesMode ] = useState<string>(() => {
@@ -65,6 +63,11 @@ export const SettingsModal = (props: Props) => {
 		setConnectionSettings(copy);
 		props.setConnectionSettings(copy);
 		setReloadNeeded(true);
+	};
+
+	const dataManager = useDataManager();
+	const saveOptions = (options: Options) => {
+		dataManager.saveOptions(options);
 	};
 
 	const getAppearance = () => {
@@ -91,14 +94,14 @@ export const SettingsModal = (props: Props) => {
 			const copy = Utils.copy(options);
 			copy.xpPerLevel = value;
 			setOptions(copy);
-			props.setOptions(copy);
+			saveOptions(copy);
 		};
 
 		const setShownStandardAbilities = (value: string | string[]) => {
 			const copy = Utils.copy(options);
 			copy.shownStandardAbilities = [ value ].flat(1);
 			setOptions(copy);
-			props.setOptions(copy);
+			saveOptions(copy);
 		};
 
 		const setShownStandardAbilitiesValue = (value: string) => {
@@ -172,35 +175,35 @@ export const SettingsModal = (props: Props) => {
 			const copy = Utils.copy(options);
 			copy.showSkillsInGroups = value;
 			setOptions(copy);
-			props.setOptions(copy);
+			saveOptions(copy);
 		};
 
 		const setShowSources = (value: boolean) => {
 			const copy = Utils.copy(options);
 			copy.showSources = value;
 			setOptions(copy);
-			props.setOptions(copy);
+			saveOptions(copy);
 		};
 
 		const setSinglePage = (value: boolean) => {
 			const copy = Utils.copy(options);
 			copy.singlePage = value;
 			setOptions(copy);
-			props.setOptions(copy);
+			saveOptions(copy);
 		};
 
 		const setCompactView = (value: boolean) => {
 			const copy = Utils.copy(options);
 			copy.compactView = value;
 			setOptions(copy);
-			props.setOptions(copy);
+			saveOptions(copy);
 		};
 
 		const setAbilityWidth = (value: PanelWidth) => {
 			const copy = Utils.copy(options);
 			copy.abilityWidth = value;
 			setOptions(copy);
-			props.setOptions(copy);
+			saveOptions(copy);
 		};
 
 		return (
@@ -241,21 +244,21 @@ export const SettingsModal = (props: Props) => {
 			const copy = Utils.copy(options);
 			copy.includePlayState = value;
 			setOptions(copy);
-			props.setOptions(copy);
+			saveOptions(copy);
 		};
 
 		const setShowPowerRollCalculation = (value: boolean) => {
 			const copy = Utils.copy(options);
 			copy.showPowerRollCalculation = value;
 			setOptions(copy);
-			props.setOptions(copy);
+			saveOptions(copy);
 		};
 
 		const setFeaturesInclude = (value: 'minimal' | 'no-basic' | 'all') => {
 			const copy = Utils.copy(options);
 			copy.featuresInclude = value;
 			setOptions(copy);
-			props.setOptions(copy);
+			saveOptions(copy);
 		};
 
 		return (
@@ -301,28 +304,28 @@ export const SettingsModal = (props: Props) => {
 			const copy = Utils.copy(options);
 			copy.classicSheetPageSize = value;
 			setOptions(copy);
-			props.setOptions(copy);
+			saveOptions(copy);
 		};
 
 		const setPageOrientation = (value: 'portrait' | 'landscape') => {
 			const copy = Utils.copy(options);
 			copy.pageOrientation = value;
 			setOptions(copy);
-			props.setOptions(copy);
+			saveOptions(copy);
 		};
 
 		const setColorSheet = (value: boolean) => {
 			const copy = Utils.copy(options);
 			copy.colorSheet = value;
 			setOptions(copy);
-			props.setOptions(copy);
+			saveOptions(copy);
 		};
 
 		const setColorScheme = (value: 'community' | 'classic') => {
 			const copy = Utils.copy(options);
 			copy.colorScheme = value;
 			setOptions(copy);
-			props.setOptions(copy);
+			saveOptions(copy);
 		};
 
 		const changeTextColor = (newColor: 'light' | 'default' | 'dark') => {
@@ -353,14 +356,14 @@ export const SettingsModal = (props: Props) => {
 			const copy = Utils.copy(options);
 			copy.sheetTextColor = value;
 			setOptions(copy);
-			props.setOptions(copy);
+			saveOptions(copy);
 		};
 
 		const setDebugClassicSheet = (value: boolean) => {
 			const copy = Utils.copy(options);
 			copy.debugClassicSheet = value;
 			setOptions(copy);
-			props.setOptions(copy);
+			saveOptions(copy);
 		};
 
 		return (
@@ -439,28 +442,28 @@ export const SettingsModal = (props: Props) => {
 			const copy = Utils.copy(options);
 			copy.similarLevel = value;
 			setOptions(copy);
-			props.setOptions(copy);
+			saveOptions(copy);
 		};
 
 		const setSimilarRole = (value: boolean) => {
 			const copy = Utils.copy(options);
 			copy.similarRole = value;
 			setOptions(copy);
-			props.setOptions(copy);
+			saveOptions(copy);
 		};
 
 		const setSimilarOrganization = (value: boolean) => {
 			const copy = Utils.copy(options);
 			copy.similarOrganization = value;
 			setOptions(copy);
-			props.setOptions(copy);
+			saveOptions(copy);
 		};
 
 		const setSimilarSize = (value: boolean) => {
 			const copy = Utils.copy(options);
 			copy.similarSize = value;
 			setOptions(copy);
-			props.setOptions(copy);
+			saveOptions(copy);
 		};
 
 		return (
@@ -481,14 +484,14 @@ export const SettingsModal = (props: Props) => {
 			const copy = Utils.copy(options);
 			copy.party = value;
 			setOptions(copy);
-			props.setOptions(copy);
+			saveOptions(copy);
 		};
 
 		const setShowDefeatedCombatants = (value: boolean) => {
 			const copy = Utils.copy(options);
 			copy.showDefeatedCombatants = value;
 			setOptions(copy);
-			props.setOptions(copy);
+			saveOptions(copy);
 		};
 
 		const parties = Collections
@@ -527,28 +530,28 @@ export const SettingsModal = (props: Props) => {
 			const copy = Utils.copy(options);
 			copy.heroParty = value;
 			setOptions(copy);
-			props.setOptions(copy);
+			saveOptions(copy);
 		};
 
 		const setHeroCount = (value: number) => {
 			const copy = Utils.copy(options);
 			copy.heroCount = value;
 			setOptions(copy);
-			props.setOptions(copy);
+			saveOptions(copy);
 		};
 
 		const setHeroLevel = (value: number) => {
 			const copy = Utils.copy(options);
 			copy.heroLevel = value;
 			setOptions(copy);
-			props.setOptions(copy);
+			saveOptions(copy);
 		};
 
 		const setHeroVictories = (value: number) => {
 			const copy = Utils.copy(options);
 			copy.heroVictories = value;
 			setOptions(copy);
-			props.setOptions(copy);
+			saveOptions(copy);
 		};
 
 		const parties = Collections
@@ -591,14 +594,14 @@ export const SettingsModal = (props: Props) => {
 			const copy = Utils.copy(options);
 			copy.gridSize = value;
 			setOptions(copy);
-			props.setOptions(copy);
+			saveOptions(copy);
 		};
 
 		const setPlayerGridSize = (value: number) => {
 			const copy = Utils.copy(options);
 			copy.playerGridSize = value;
 			setOptions(copy);
-			props.setOptions(copy);
+			saveOptions(copy);
 		};
 
 		return (

--- a/src/components/modals/settings/settings-modal.tsx
+++ b/src/components/modals/settings/settings-modal.tsx
@@ -1,6 +1,6 @@
 import { Alert, Button, Drawer, Flex, Segmented, Select, Space } from 'antd';
 import { FlagFilled, FlagOutlined, MoonOutlined, SettingOutlined, SunOutlined } from '@ant-design/icons';
-import { useDataManager, useOptions } from '@/contexts/data-context';
+import { useDataManager, useHeroes, useOptions } from '@/contexts/data-context';
 import { AbilityData } from '@/data/ability-data';
 import { Collections } from '@/utils/collections';
 import { ConnectionSettings } from '@/models/connection-settings';
@@ -12,7 +12,6 @@ import { Expander } from '@/components/controls/expander/expander';
 import { FeatureFlags } from '@/utils/feature-flags';
 import { Field } from '@/components/controls/field/field';
 import { HeaderText } from '@/components/controls/header-text/header-text';
-import { Hero } from '@/models/hero';
 import { LabelControl } from '@/components/controls/label-control/label-control';
 import { Modal } from '@/components/modals/modal/modal';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
@@ -31,7 +30,6 @@ import { useTheme } from '@/hooks/use-theme';
 import './settings-modal.scss';
 
 interface Props {
-	heroes: Hero[];
 	connectionSettings: ConnectionSettings;
 	dataService: DataService;
 	setConnectionSettings: (settings: ConnectionSettings) => void
@@ -65,6 +63,7 @@ export const SettingsModal = (props: Props) => {
 		setReloadNeeded(true);
 	};
 
+	const heroes = useHeroes();
 	const dataManager = useDataManager();
 	const saveOptions = (options: Options) => {
 		dataManager.saveOptions(options);
@@ -495,7 +494,7 @@ export const SettingsModal = (props: Props) => {
 		};
 
 		const parties = Collections
-			.distinct(props.heroes.map(h => h.folder), f => f)
+			.distinct(heroes.map(h => h.folder), f => f)
 			.sort()
 			.filter(f => !!f);
 
@@ -555,7 +554,7 @@ export const SettingsModal = (props: Props) => {
 		};
 
 		const parties = Collections
-			.distinct(props.heroes.map(h => h.folder), f => f)
+			.distinct(heroes.map(h => h.folder), f => f)
 			.sort()
 			.filter(f => !!f);
 

--- a/src/components/modals/settings/settings-modal.tsx
+++ b/src/components/modals/settings/settings-modal.tsx
@@ -24,13 +24,13 @@ import { TextInput } from '@/components/controls/text-input/text-input';
 import { Toggle } from '@/components/controls/toggle/toggle';
 import { Utils } from '@/utils/utils';
 import { WarehouseActionsPanel } from '@/components/panels/connection-settings/warehouse-actions-panel';
+import { useOptions } from '@/contexts/data-context';
 import { useState } from 'react';
 import { useTheme } from '@/hooks/use-theme';
 
 import './settings-modal.scss';
 
 interface Props {
-	options: Options;
 	heroes: Hero[];
 	setOptions: (options: Options) => void;
 	connectionSettings: ConnectionSettings;
@@ -41,7 +41,8 @@ interface Props {
 
 export const SettingsModal = (props: Props) => {
 	const { themeMode, setTheme } = useTheme();
-	const [ options, setOptions ] = useState<Options>(Utils.copy(props.options));
+	// const options = useOptions();
+	const [ options, setOptions ] = useState<Options>(Utils.copy(useOptions()));
 	const [ page, setPage ] = useState<string>('Settings');
 	const [ standardAbilitiesMode, setStandardAbilitiesMode ] = useState<string>(() => {
 		if (options.shownStandardAbilities.length === 0) {

--- a/src/components/modals/sourcebooks/sourcebooks-modal.tsx
+++ b/src/components/modals/sourcebooks/sourcebooks-modal.tsx
@@ -1,5 +1,6 @@
 import { Button, Drawer, Flex, Segmented, Space, Upload } from 'antd';
 import { DownloadOutlined, PlusOutlined } from '@ant-design/icons';
+import { useDataManager, useHiddenSourcebookIDs } from '@/contexts/data-context';
 import { Collections } from '@/utils/collections';
 import { Empty } from '@/components/controls/empty/empty';
 import { FactoryLogic } from '@/logic/factory-logic';
@@ -22,30 +23,30 @@ import './sourcebooks-modal.scss';
 interface Props {
 	officialSourcebooks: Sourcebook[];
 	homebrewSourcebooks: Sourcebook[];
-	hiddenSourcebookIDs: string[];
 	heroes: Hero[];
 	onClose: () => void;
 	onHomebrewSourcebookChange: (sourcebook: Sourcebook) => void;
 	onHomebrewSourcebookDelete: (sourcebook: Sourcebook) => void;
-	onHiddenSourcebookIDsChange: (ids: string[]) => void;
 }
 
 export const SourcebooksModal = (props: Props) => {
 	const [ page, setPage ] = useState<SourcebookType>(SourcebookType.Official);
 	const [ selectedSourcebook, setSelectedSourcebook ] = useState<Sourcebook | null>(null);
 	const [ homebrewSourcebooks, setHomebrewSourcebooks ] = useState<Sourcebook[]>(Utils.copy(props.homebrewSourcebooks));
-	const [ hiddenSourcebookIDs, setHiddenSourcebookIDs ] = useState<string[]>(Utils.copy(props.hiddenSourcebookIDs));
+	const [ hiddenSourcebookIDs, setHiddenSourcebookIDs ] = useState<string[]>(Utils.copy(useHiddenSourcebookIDs()));
+
+	const dataManager = useDataManager();
 
 	const setVisibility = (sourcebook: Sourcebook, visible: boolean) => {
 		if (visible) {
 			const copy = Utils.copy(hiddenSourcebookIDs.filter(id => id !== sourcebook.id));
 			setHiddenSourcebookIDs(copy);
-			props.onHiddenSourcebookIDsChange(copy);
+			dataManager.saveHiddenSourcebookIDs(copy);
 		} else {
 			const copy = Utils.copy(hiddenSourcebookIDs);
 			copy.push(sourcebook.id);
 			setHiddenSourcebookIDs(copy);
-			props.onHiddenSourcebookIDsChange(copy);
+			dataManager.saveHiddenSourcebookIDs(copy);
 		}
 	};
 

--- a/src/components/modals/sourcebooks/sourcebooks-modal.tsx
+++ b/src/components/modals/sourcebooks/sourcebooks-modal.tsx
@@ -5,7 +5,6 @@ import { Collections } from '@/utils/collections';
 import { Empty } from '@/components/controls/empty/empty';
 import { FactoryLogic } from '@/logic/factory-logic';
 import { HeaderText } from '@/components/controls/header-text/header-text';
-import { Hero } from '@/models/hero';
 import { Info } from '@/components/controls/info/info';
 import { Markdown } from '@/components/controls/markdown/markdown';
 import { Modal } from '@/components/modals/modal/modal';
@@ -23,7 +22,6 @@ import './sourcebooks-modal.scss';
 interface Props {
 	officialSourcebooks: Sourcebook[];
 	homebrewSourcebooks: Sourcebook[];
-	heroes: Hero[];
 	onClose: () => void;
 	onHomebrewSourcebookChange: (sourcebook: Sourcebook) => void;
 	onHomebrewSourcebookDelete: (sourcebook: Sourcebook) => void;
@@ -82,7 +80,6 @@ export const SourcebooksModal = (props: Props) => {
 									<SelectablePanel key={s.id} onSelect={() => setSelectedSourcebook(s)}>
 										<SourcebookPanel
 											sourcebook={s}
-											heroes={props.heroes}
 											sourcebooks={[ ...props.officialSourcebooks, ...homebrewSourcebooks ]}
 											visibility={{
 												visible: !hiddenSourcebookIDs.includes(s.id),
@@ -121,7 +118,6 @@ export const SourcebooksModal = (props: Props) => {
 									<SelectablePanel key={s.id} onSelect={() => setSelectedSourcebook(s)}>
 										<SourcebookPanel
 											sourcebook={s}
-											heroes={props.heroes}
 											sourcebooks={[ ...props.officialSourcebooks, ...homebrewSourcebooks ]}
 											visibility={{
 												visible: !hiddenSourcebookIDs.includes(s.id),
@@ -160,7 +156,6 @@ export const SourcebooksModal = (props: Props) => {
 									<SelectablePanel key={s.id} onSelect={() => setSelectedSourcebook(s)}>
 										<SourcebookPanel
 											sourcebook={s}
-											heroes={props.heroes}
 											sourcebooks={[ ...props.officialSourcebooks, ...homebrewSourcebooks ]}
 											visibility={{
 												visible: !hiddenSourcebookIDs.includes(s.id),
@@ -231,7 +226,6 @@ export const SourcebooksModal = (props: Props) => {
 									<SelectablePanel key={s.id} onSelect={() => setSelectedSourcebook(s)}>
 										<SourcebookPanel
 											sourcebook={s}
-											heroes={props.heroes}
 											sourcebooks={[ ...props.officialSourcebooks, ...props.homebrewSourcebooks ]}
 											visibility={{
 												visible: !hiddenSourcebookIDs.includes(s.id),
@@ -279,7 +273,6 @@ export const SourcebooksModal = (props: Props) => {
 									<div style={{ padding: '0 20px 20px 20px' }}>
 										<SourcebookPanel
 											sourcebook={selectedSourcebook}
-											heroes={props.heroes}
 											sourcebooks={[ ...props.officialSourcebooks, ...props.homebrewSourcebooks ]}
 											mode={PanelMode.Full}
 											onChange={changeSourcebook}

--- a/src/components/pages/auth/auth-page.tsx
+++ b/src/components/pages/auth/auth-page.tsx
@@ -5,7 +5,6 @@ import { AppHeader } from '@/components/panels/app-header/app-header';
 import { CheckIcon } from '@/components/controls/check-icon/check-icon';
 import { ConnectionSettings } from '@/models/connection-settings';
 import { ErrorBoundary } from '@/components/controls/error-boundary/error-boundary';
-import { Options } from '@/models/options';
 import { PatreonLogic } from '@/logic/patreon-logic';
 import { PatreonService } from '@/services/patreon-service';
 import { PatreonSession } from '@/models/patreon-connection';
@@ -19,7 +18,6 @@ import './auth-page.scss';
 
 interface Props {
 	connectionSettings: ConnectionSettings;
-	options: Options;
 	params: FooterParams;
 	setConnectionSettings: (settings: ConnectionSettings) => void
 }
@@ -142,7 +140,6 @@ export const AuthPage = (props: Props) => {
 				</div>
 				<AppFooter
 					page='welcome'
-					options={props.options}
 					params={props.params}
 				/>
 			</div>

--- a/src/components/pages/backup/backup-page.tsx
+++ b/src/components/pages/backup/backup-page.tsx
@@ -3,7 +3,6 @@ import { ErrorBoundary } from '@/components/controls/error-boundary/error-bounda
 import { Hero } from '@/models/hero';
 import { HeroLogic } from '@/logic/hero-logic';
 import { HeroOverviewPanel } from '@/components/panels/hero-overview/hero-overview-panel';
-import { Options } from '@/models/options';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
 import { Sourcebook } from '@/models/sourcebook';
 import { SourcebookPanel } from '@/components/panels/elements/sourcebook-panel/sourcebook-panel';
@@ -14,7 +13,6 @@ import './backup-page.scss';
 interface Props {
 	heroes: Hero[];
 	homebrewSourcebooks: Sourcebook[];
-	options: Options;
 }
 
 export const BackupPage = (props: Props) => {

--- a/src/components/pages/backup/backup-page.tsx
+++ b/src/components/pages/backup/backup-page.tsx
@@ -1,27 +1,27 @@
 import { Empty } from '@/components/controls/empty/empty';
 import { ErrorBoundary } from '@/components/controls/error-boundary/error-boundary';
-import { Hero } from '@/models/hero';
 import { HeroLogic } from '@/logic/hero-logic';
 import { HeroOverviewPanel } from '@/components/panels/hero-overview/hero-overview-panel';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
 import { Sourcebook } from '@/models/sourcebook';
 import { SourcebookPanel } from '@/components/panels/elements/sourcebook-panel/sourcebook-panel';
 import { Utils } from '@/utils/utils';
+import { useHeroes } from '@/contexts/data-context';
 
 import './backup-page.scss';
 
 interface Props {
-	heroes: Hero[];
 	homebrewSourcebooks: Sourcebook[];
 }
 
 export const BackupPage = (props: Props) => {
+	const heroes = useHeroes();
 	return (
 		<ErrorBoundary>
 			<div className='backup-page'>
 				<div className='backup-page-content'>
 					{
-						props.heroes.map(hero => (
+						heroes.map(hero => (
 							<SelectablePanel key={hero.id} onSelect={() => Utils.exportData(hero.name || 'Unnamed Hero', hero, 'hero')}>
 								<HeroOverviewPanel hero={HeroLogic.createOverview(hero)} />
 							</SelectablePanel>
@@ -30,12 +30,12 @@ export const BackupPage = (props: Props) => {
 					{
 						props.homebrewSourcebooks.map(sb => (
 							<SelectablePanel key={sb.id} onSelect={() => Utils.exportData(sb.name || 'Unnamed Sourcebook', sb, 'sourcebook')}>
-								<SourcebookPanel sourcebook={sb} heroes={props.heroes} sourcebooks={[]} />
+								<SourcebookPanel sourcebook={sb} heroes={heroes} sourcebooks={[]} />
 							</SelectablePanel>
 						))
 					}
 					{
-						props.heroes.length + props.homebrewSourcebooks.length === 0 ?
+						heroes.length + props.homebrewSourcebooks.length === 0 ?
 							<Empty text='Nothing to back up' />
 							: null
 					}

--- a/src/components/pages/clocktower/clocktower-page.tsx
+++ b/src/components/pages/clocktower/clocktower-page.tsx
@@ -4,7 +4,6 @@ import { ClocktowerData } from '@/data/clocktower-data';
 import { ClocktowerScriptPanel } from '@/components/pages/clocktower/clocktower-script-panel/clocktower-script-panel';
 import { Divider } from 'antd';
 import { ErrorBoundary } from '@/components/controls/error-boundary/error-boundary';
-import { Options } from '@/models/options';
 
 import './clocktower-page.scss';
 
@@ -15,7 +14,6 @@ import shield4 from '@/assets/clocktower/clocktower-demon.png';
 import shield5 from '@/assets/clocktower/clocktower-traveller.png';
 
 interface Props {
-	options: Options;
 	params: FooterParams;
 }
 
@@ -38,7 +36,6 @@ export const ClocktowerPage = (props: Props) => {
 				<AppFooter
 					page='welcome'
 					params={props.params}
-					options={props.options}
 				/>
 			</div>
 		</ErrorBoundary>

--- a/src/components/pages/heroes/hero-edit/ancestry-section/ancestry-section.tsx
+++ b/src/components/pages/heroes/hero-edit/ancestry-section/ancestry-section.tsx
@@ -7,7 +7,6 @@ import { FeatureData } from '@/models/feature';
 import { FeatureLogic } from '@/logic/feature-logic';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { ReactNode } from 'react';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
@@ -30,7 +29,6 @@ const matchElement = (element: Element, searchTerm: string) => {
 interface Props {
 	hero: Hero;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	searchTerm: string;
 	selectAncestry: (ancestry: Ancestry) => void;
 	setFeatureData: (featureID: string, data: FeatureData) => void;
@@ -42,7 +40,7 @@ export const AncestrySection = (props: Props) => {
 	const ancestries = SourcebookLogic.getAncestries(props.sourcebooks).map(Utils.copy).filter(a => matchElement(a, props.searchTerm));
 	const options = ancestries.map(a => (
 		<SelectablePanel key={a.id} onSelect={() => props.selectAncestry(a)}>
-			<AncestryPanel ancestry={a} sourcebooks={props.sourcebooks} options={props.options} />
+			<AncestryPanel ancestry={a} sourcebooks={props.sourcebooks} />
 		</SelectablePanel>
 	));
 
@@ -53,7 +51,7 @@ export const AncestrySection = (props: Props) => {
 			.filter(f => FeatureLogic.isChoice(f))
 			.map(f => (
 				<SelectablePanel key={f.id}>
-					<FeatureConfigPanel feature={f} options={props.options} hero={props.hero} sourcebooks={props.sourcebooks} setData={props.setFeatureData} />
+					<FeatureConfigPanel feature={f} hero={props.hero} sourcebooks={props.sourcebooks} setData={props.setFeatureData} />
 				</SelectablePanel>
 			));
 	}
@@ -69,7 +67,7 @@ export const AncestrySection = (props: Props) => {
 				props.hero.ancestry && (!isSmall || (choices.length === 0)) ?
 					<div className={columnClassName} id='ancestry-selected'>
 						<SelectablePanel>
-							<AncestryPanel ancestry={props.hero.ancestry} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} />
+							<AncestryPanel ancestry={props.hero.ancestry} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
 						</SelectablePanel>
 					</div>
 					: null

--- a/src/components/pages/heroes/hero-edit/career-section/career-section.tsx
+++ b/src/components/pages/heroes/hero-edit/career-section/career-section.tsx
@@ -14,7 +14,6 @@ import { Field } from '@/components/controls/field/field';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { Markdown } from '@/components/controls/markdown/markdown';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
 import { Sourcebook } from '@/models/sourcebook';
@@ -36,7 +35,6 @@ const matchElement = (element: Element, searchTerm: string) => {
 interface Props {
 	hero: Hero;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	searchTerm: string;
 	selectCareer: (career: Career) => void;
 	selectIncitingIncident: (value: Element | null) => void;
@@ -50,7 +48,7 @@ export const CareerSection = (props: Props) => {
 	const careers = SourcebookLogic.getCareers(props.sourcebooks).map(Utils.copy).filter(c => matchElement(c, props.searchTerm));
 	const options = careers.map(c => (
 		<SelectablePanel key={c.id} onSelect={() => props.selectCareer(c)}>
-			<CareerPanel career={c} sourcebooks={props.sourcebooks} options={props.options} />
+			<CareerPanel career={c} sourcebooks={props.sourcebooks} />
 		</SelectablePanel>
 	));
 
@@ -61,7 +59,7 @@ export const CareerSection = (props: Props) => {
 			.filter(f => FeatureLogic.isChoice(f))
 			.map(f => (
 				<SelectablePanel key={f.id}>
-					<FeatureConfigPanel feature={f} options={props.options} hero={props.hero} sourcebooks={props.sourcebooks} setData={props.setFeatureData} />
+					<FeatureConfigPanel feature={f} hero={props.hero} sourcebooks={props.sourcebooks} setData={props.setFeatureData} />
 				</SelectablePanel>
 			));
 
@@ -107,7 +105,7 @@ export const CareerSection = (props: Props) => {
 					props.hero.career && (!isSmall || (choices.length === 0)) ?
 						<div className={columnClassName} id='career-selected'>
 							<SelectablePanel>
-								<CareerPanel career={props.hero.career} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} />
+								<CareerPanel career={props.hero.career} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
 							</SelectablePanel>
 						</div>
 						: null

--- a/src/components/pages/heroes/hero-edit/class-section/class-section.tsx
+++ b/src/components/pages/heroes/hero-edit/class-section/class-section.tsx
@@ -20,7 +20,6 @@ import { HeroClass } from '@/models/class';
 import { HeroLogic } from '@/logic/hero-logic';
 import { Modal } from '@/components/modals/modal/modal';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
 import { Sourcebook } from '@/models/sourcebook';
@@ -31,6 +30,7 @@ import { SubClassSelectModal } from '@/components/modals/select/subclass-select/
 import { SubclassPanel } from '@/components/panels/elements/subclass-panel/subclass-panel';
 import { Utils } from '@/utils/utils';
 import { useIsSmall } from '@/hooks/use-is-small';
+import { useOptions } from '@/contexts/data-context';
 
 import './class-section.scss';
 
@@ -46,7 +46,6 @@ const matchElement = (element: Element, searchTerm: string) => {
 interface Props {
 	hero: Hero;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	searchTerm: string;
 	selectClass: (heroClass: HeroClass) => void;
 	setLevel: (level: number) => void;
@@ -59,6 +58,7 @@ interface Props {
 
 export const ClassSection = (props: Props) => {
 	const isSmall = useIsSmall();
+	const appOptions = useOptions();
 	const [ selectedSubClass, setSelectedSubClass ] = useState<SubClass | null>(null);
 	const [ subclassSelectorOpen, setSubclassSelectorOpen ] = useState<boolean>(false);
 
@@ -66,7 +66,7 @@ export const ClassSection = (props: Props) => {
 		const options = {
 			level: 0,
 			choices: [] as ReactNode[],
-			completed: !HeroLogic.canLevelUp(props.hero, props.options)
+			completed: !HeroLogic.canLevelUp(props.hero, appOptions)
 				&& (heroClass.primaryCharacteristics.length > 0)
 				&& heroClass.characteristics.some(ch => ch.value !== 0)
 				&& (heroClass.subclasses.filter(sc => sc.selected).length >= heroClass.subclassCount)
@@ -83,7 +83,7 @@ export const ClassSection = (props: Props) => {
 				/>
 				<Field label='XP' value={props.hero.state.xp} />
 				{
-					HeroLogic.canLevelUp(props.hero, props.options) ?
+					HeroLogic.canLevelUp(props.hero, appOptions) ?
 						<Button
 							className='status-warning'
 							onClick={() => props.setLevel(heroClass.level + 1)}
@@ -151,7 +151,6 @@ export const ClassSection = (props: Props) => {
 							subClasses={heroClass.subclasses.filter(sc => !sc.selected)}
 							classID={heroClass.id}
 							sourcebooks={props.sourcebooks}
-							options={props.options}
 							onSelect={sc => {
 								setSubclassSelectorOpen(false);
 								props.addSubclass(sc);
@@ -169,7 +168,7 @@ export const ClassSection = (props: Props) => {
 	const classes = SourcebookLogic.getClasses(props.sourcebooks).map(Utils.copy).filter(c => matchElement(c, props.searchTerm));
 	const options = classes.map(c => (
 		<SelectablePanel key={c.id} onSelect={() => props.selectClass(c)}>
-			<ClassPanel heroClass={c} sourcebooks={props.sourcebooks} options={props.options} />
+			<ClassPanel heroClass={c} sourcebooks={props.sourcebooks} />
 		</SelectablePanel>
 	));
 
@@ -189,7 +188,7 @@ export const ClassSection = (props: Props) => {
 						.filter(f => FeatureLogic.isChoice(f))
 						.map(f => (
 							<SelectablePanel key={f.id}>
-								<FeatureConfigPanel feature={f} options={props.options} hero={props.hero} sourcebooks={props.sourcebooks} setData={props.setFeatureData} />
+								<FeatureConfigPanel feature={f} hero={props.hero} sourcebooks={props.sourcebooks} setData={props.setFeatureData} />
 							</SelectablePanel>
 						)),
 					completed: featuresForLevel.every(f => FeatureLogic.isChosen(f, props.hero, props.sourcebooks))
@@ -209,7 +208,7 @@ export const ClassSection = (props: Props) => {
 				props.hero.class && (!isSmall || (choicesByLevel.length === 0)) ?
 					<div className={columnClassName} id='class-selected'>
 						<SelectablePanel>
-							<ClassPanel heroClass={props.hero.class} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} />
+							<ClassPanel heroClass={props.hero.class} hero={props.hero} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
 						</SelectablePanel>
 					</div>
 					: null
@@ -260,7 +259,7 @@ export const ClassSection = (props: Props) => {
 			}
 			<Drawer open={!!selectedSubClass} onClose={() => setSelectedSubClass(null)} closeIcon={null} size={500}>
 				<Modal
-					content={selectedSubClass ? <SubclassPanel subclass={selectedSubClass} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} /> : null}
+					content={selectedSubClass ? <SubclassPanel subclass={selectedSubClass} sourcebooks={props.sourcebooks} mode={PanelMode.Full} /> : null}
 					onClose={() => setSelectedSubClass(null)}
 				/>
 			</Drawer>

--- a/src/components/pages/heroes/hero-edit/complication-section/complication-section.tsx
+++ b/src/components/pages/heroes/hero-edit/complication-section/complication-section.tsx
@@ -8,7 +8,6 @@ import { FeatureData } from '@/models/feature';
 import { FeatureLogic } from '@/logic/feature-logic';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
 import { Sourcebook } from '@/models/sourcebook';
@@ -30,7 +29,6 @@ const matchElement = (element: Element, searchTerm: string) => {
 interface Props {
 	hero: Hero;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	searchTerm: string;
 	selectComplication: (complication: Complication) => void;
 	setFeatureData: (featureID: string, data: FeatureData) => void;
@@ -59,7 +57,7 @@ export const ComplicationSection = (props: Props) => {
 				props.selectComplication(c);
 			}}
 		>
-			<ComplicationPanel complication={c} sourcebooks={props.sourcebooks} options={props.options} />
+			<ComplicationPanel complication={c} sourcebooks={props.sourcebooks} />
 		</SelectablePanel>
 	));
 
@@ -72,7 +70,6 @@ export const ComplicationSection = (props: Props) => {
 				<SelectablePanel key={f.id}>
 					<FeatureConfigPanel
 						feature={f}
-						options={props.options}
 						hero={props.hero}
 						sourcebooks={props.sourcebooks}
 						setData={props.setFeatureData}
@@ -92,7 +89,7 @@ export const ComplicationSection = (props: Props) => {
 				props.hero.complication && (!isSmall || (choices.length === 0)) ?
 					<div className={columnClassName} id='complication-selected'>
 						<SelectablePanel>
-							<ComplicationPanel complication={props.hero.complication} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} />
+							<ComplicationPanel complication={props.hero.complication} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
 						</SelectablePanel>
 					</div>
 					: null

--- a/src/components/pages/heroes/hero-edit/culture-section/culture-section.tsx
+++ b/src/components/pages/heroes/hero-edit/culture-section/culture-section.tsx
@@ -17,7 +17,6 @@ import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { Markdown } from '@/components/controls/markdown/markdown';
 import { NameSuggestions } from '@/components/panels/name-suggestions/name-suggestions';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
 import { Sourcebook } from '@/models/sourcebook';
@@ -40,7 +39,6 @@ const matchElement = (element: Element, searchTerm: string) => {
 interface CultureSectionProps {
 	hero: Hero;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	searchTerm: string;
 	selectCulture: (culture: Culture) => void;
 	selectEnvironment: (id: string | null) => void;
@@ -68,22 +66,22 @@ export const CultureSection = (props: CultureSectionProps) => {
 		.filter(c => matchElement(c, props.searchTerm));
 	const optionsYourAncestry = cultures.filter(c => c.id === (props.hero.ancestry?.culture?.id || '')).map(c => (
 		<SelectablePanel key={c.id} onSelect={() => props.selectCulture(c)}>
-			<CulturePanel culture={c} sourcebooks={props.sourcebooks} options={props.options} />
+			<CulturePanel culture={c} sourcebooks={props.sourcebooks} />
 		</SelectablePanel>
 	));
 	const optionsAncestral = cultures.filter(c => c.type === CultureType.Ancestral).map(c => (
 		<SelectablePanel key={c.id} onSelect={() => props.selectCulture(c)}>
-			<CulturePanel culture={c} sourcebooks={props.sourcebooks} options={props.options} />
+			<CulturePanel culture={c} sourcebooks={props.sourcebooks} />
 		</SelectablePanel>
 	));
 	const optionsProfessional = cultures.filter(c => c.type === CultureType.Professional).map(c => (
 		<SelectablePanel key={c.id} onSelect={() => props.selectCulture(c)}>
-			<CulturePanel culture={c} sourcebooks={props.sourcebooks} options={props.options} />
+			<CulturePanel culture={c} sourcebooks={props.sourcebooks} />
 		</SelectablePanel>
 	));
 	const optionsBespoke = cultures.filter(c => c.type === CultureType.Bespoke).map(c => (
 		<SelectablePanel key={c.id} onSelect={() => props.selectCulture(c)}>
-			<CulturePanel culture={c} sourcebooks={props.sourcebooks} options={props.options} />
+			<CulturePanel culture={c} sourcebooks={props.sourcebooks} />
 		</SelectablePanel>
 	));
 
@@ -94,7 +92,7 @@ export const CultureSection = (props: CultureSectionProps) => {
 			.filter(f => FeatureLogic.isChoice(f))
 			.map(f => (
 				<SelectablePanel key={f.id}>
-					<FeatureConfigPanel feature={f} options={props.options} hero={props.hero} sourcebooks={props.sourcebooks} setData={props.setFeatureData} />
+					<FeatureConfigPanel feature={f} hero={props.hero} sourcebooks={props.sourcebooks} setData={props.setFeatureData} />
 				</SelectablePanel>
 			));
 
@@ -203,7 +201,7 @@ export const CultureSection = (props: CultureSectionProps) => {
 					props.hero.culture && (!isSmall || (choices.length === 0)) ?
 						<div className={columnClassName} id='culture-selected'>
 							<SelectablePanel>
-								<CulturePanel culture={props.hero.culture} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} />
+								<CulturePanel culture={props.hero.culture} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
 							</SelectablePanel>
 						</div>
 						: null
@@ -268,7 +266,6 @@ export const CultureSection = (props: CultureSectionProps) => {
 				<FeatureSelectModal
 					features={EnvironmentData.getEnvironments().map(f => ({ feature: f, value: 1 }))}
 					sourcebooks={props.sourcebooks}
-					options={props.options}
 					onSelect={f => {
 						setShowEnvironment(false);
 						props.selectEnvironment(f.id);
@@ -280,7 +277,6 @@ export const CultureSection = (props: CultureSectionProps) => {
 				<FeatureSelectModal
 					features={OrganizationData.getOrganizations().map(f => ({ feature: f, value: 1 }))}
 					sourcebooks={props.sourcebooks}
-					options={props.options}
 					onSelect={f => {
 						setShowOrganization(false);
 						props.selectOrganization(f.id);
@@ -292,7 +288,6 @@ export const CultureSection = (props: CultureSectionProps) => {
 				<FeatureSelectModal
 					features={UpbringingData.getUpbringings().map(f => ({ feature: f, value: 1 }))}
 					sourcebooks={props.sourcebooks}
-					options={props.options}
 					onSelect={f => {
 						setShowUpbringing(false);
 						props.selectUpbringing(f.id);

--- a/src/components/pages/heroes/hero-edit/details-section/details-section.tsx
+++ b/src/components/pages/heroes/hero-edit/details-section/details-section.tsx
@@ -11,7 +11,6 @@ import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { HeroLogic } from '@/logic/hero-logic';
 import { NameSuggestions } from '@/components/panels/name-suggestions/name-suggestions';
-import { Options } from '@/models/options';
 import { Sourcebook } from '@/models/sourcebook';
 import { TextInput } from '@/components/controls/text-input/text-input';
 import { Utils } from '@/utils/utils';
@@ -22,7 +21,6 @@ interface DetailsSectionProps {
 	hero: Hero;
 	allHeroes: Hero[];
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setName: (value: string) => void;
 	setPicture: (value: string | null) => void;
 	setFolder: (value: string) => void;
@@ -116,7 +114,6 @@ export const DetailsSection = (props: DetailsSectionProps) => {
 								<FeatureConfigPanel
 									key={f.id}
 									feature={f}
-									options={props.options}
 									hero={props.hero}
 									sourcebooks={props.sourcebooks}
 									setData={props.setFeatureData}
@@ -146,7 +143,6 @@ ${f.data.listOptions.length > 0 ? `**Lists**: ${f.data.listOptions.map(s => `${s
 								<FeatureConfigPanel
 									key={f.id}
 									feature={f}
-									options={props.options}
 									hero={props.hero}
 									sourcebooks={props.sourcebooks}
 									setData={props.setFeatureData}

--- a/src/components/pages/heroes/hero-edit/details-section/details-section.tsx
+++ b/src/components/pages/heroes/hero-edit/details-section/details-section.tsx
@@ -14,12 +14,12 @@ import { NameSuggestions } from '@/components/panels/name-suggestions/name-sugge
 import { Sourcebook } from '@/models/sourcebook';
 import { TextInput } from '@/components/controls/text-input/text-input';
 import { Utils } from '@/utils/utils';
+import { useHeroes } from '@/contexts/data-context';
 
 import './details-section.scss';
 
 interface DetailsSectionProps {
 	hero: Hero;
-	allHeroes: Hero[];
 	sourcebooks: Sourcebook[];
 	setName: (value: string) => void;
 	setPicture: (value: string | null) => void;
@@ -28,7 +28,8 @@ interface DetailsSectionProps {
 }
 
 export const DetailsSection = (props: DetailsSectionProps) => {
-	const folders = props.allHeroes
+	const allHeroes = useHeroes();
+	const folders = allHeroes
 		.map(h => h.folder)
 		.filter(f => !!f)
 		.sort();

--- a/src/components/pages/heroes/hero-edit/hero-edit-page.tsx
+++ b/src/components/pages/heroes/hero-edit/hero-edit-page.tsx
@@ -4,6 +4,7 @@ import { CloseOutlined, SaveOutlined, ThunderboltOutlined } from '@ant-design/ic
 import { CultureData, EnvironmentData, OrganizationData, UpbringingData } from '@/data/culture-data';
 import { Feature, FeatureClassAbilityData, FeatureData } from '@/models/feature';
 import { Hero, HeroEditTab } from '@/models/hero';
+import { useHeroes, useOptions } from '@/contexts/data-context';
 import { useMemo, useState } from 'react';
 import { Ancestry } from '@/models/ancestry';
 import { AncestrySection } from '@/components/pages/heroes/hero-edit/ancestry-section/ancestry-section';
@@ -34,7 +35,6 @@ import { SubClass } from '@/models/subclass';
 import { Utils } from '@/utils/utils';
 import { useIsSmall } from '@/hooks/use-is-small';
 import { useNavigation } from '@/hooks/use-navigation';
-import { useOptions } from '@/contexts/data-context';
 import { useParams } from 'react-router';
 import { useTitle } from '@/hooks/use-title';
 
@@ -49,7 +49,6 @@ enum PageState {
 }
 
 interface Props {
-	heroes: Hero[];
 	sourcebooks: Sourcebook[];
 	params: FooterParams;
 	saveChanges: (hero: Hero) => void;
@@ -59,9 +58,10 @@ interface Props {
 export const HeroEditPage = (props: Props) => {
 	const isSmall = useIsSmall();
 	const options = useOptions();
+	const heroes = useHeroes();
 	const navigation = useNavigation();
 	const { heroID, page } = useParams<{ heroID: string; page: HeroEditTab }>();
-	const originalHero = useMemo(() => props.heroes.find(h => h.id === heroID)!, [ heroID, props.heroes ]);
+	const originalHero = useMemo(() => heroes.find(h => h.id === heroID)!, [ heroID, heroes ]);
 	const [ hero, setHero ] = useState<Hero>(Utils.copy(originalHero));
 	const [ dirty, setDirty ] = useState<boolean>(false);
 	const [ searchTerm, setSearchTerm ] = useState<string>('');
@@ -581,7 +581,6 @@ export const HeroEditPage = (props: Props) => {
 				return (
 					<DetailsSection
 						hero={hero}
-						allHeroes={props.heroes}
 						sourcebooks={props.sourcebooks.filter(sb => hero.sourcebookIDs.includes(sb.id))}
 						setName={setName}
 						setPicture={setPicture}

--- a/src/components/pages/heroes/hero-edit/hero-edit-page.tsx
+++ b/src/components/pages/heroes/hero-edit/hero-edit-page.tsx
@@ -26,7 +26,6 @@ import { FeatureType } from '@/enums/feature-type';
 import { Format } from '@/utils/format';
 import { HeroClass } from '@/models/class';
 import { HeroLogic } from '@/logic/hero-logic';
-import { Options } from '@/models/options';
 import { SearchBox } from '@/components/controls/text-input/text-input';
 import { Sourcebook } from '@/models/sourcebook';
 import { SourcebookLogic } from '@/logic/sourcebook-logic';
@@ -35,6 +34,7 @@ import { SubClass } from '@/models/subclass';
 import { Utils } from '@/utils/utils';
 import { useIsSmall } from '@/hooks/use-is-small';
 import { useNavigation } from '@/hooks/use-navigation';
+import { useOptions } from '@/contexts/data-context';
 import { useParams } from 'react-router';
 import { useTitle } from '@/hooks/use-title';
 
@@ -51,7 +51,6 @@ enum PageState {
 interface Props {
 	heroes: Hero[];
 	sourcebooks: Sourcebook[];
-	options: Options;
 	params: FooterParams;
 	saveChanges: (hero: Hero) => void;
 	importSourcebook: (sourcebook: Sourcebook) => void;
@@ -59,6 +58,7 @@ interface Props {
 
 export const HeroEditPage = (props: Props) => {
 	const isSmall = useIsSmall();
+	const options = useOptions();
 	const navigation = useNavigation();
 	const { heroID, page } = useParams<{ heroID: string; page: HeroEditTab }>();
 	const originalHero = useMemo(() => props.heroes.find(h => h.id === heroID)!, [ heroID, props.heroes ]);
@@ -272,7 +272,7 @@ export const HeroEditPage = (props: Props) => {
 
 	const setLevel = (level: number) => {
 		const heroCopy = Utils.copy(hero);
-		HeroLogic.setLevel(heroCopy, props.options, level);
+		HeroLogic.setLevel(heroCopy, options, level);
 		setHero(heroCopy);
 		setDirty(true);
 	};
@@ -523,7 +523,6 @@ export const HeroEditPage = (props: Props) => {
 					<AncestrySection
 						hero={hero}
 						sourcebooks={props.sourcebooks.filter(sb => hero.sourcebookIDs.includes(sb.id))}
-						options={props.options}
 						searchTerm={searchTerm}
 						selectAncestry={setAncestry}
 						setFeatureData={setFeatureData}
@@ -534,7 +533,6 @@ export const HeroEditPage = (props: Props) => {
 					<CultureSection
 						hero={hero}
 						sourcebooks={props.sourcebooks.filter(sb => hero.sourcebookIDs.includes(sb.id))}
-						options={props.options}
 						searchTerm={searchTerm}
 						selectCulture={setCulture}
 						selectEnvironment={setEnvironment}
@@ -548,7 +546,6 @@ export const HeroEditPage = (props: Props) => {
 					<CareerSection
 						hero={hero}
 						sourcebooks={props.sourcebooks.filter(sb => hero.sourcebookIDs.includes(sb.id))}
-						options={props.options}
 						searchTerm={searchTerm}
 						selectCareer={setCareer}
 						selectIncitingIncident={setIncitingIncident}
@@ -560,7 +557,6 @@ export const HeroEditPage = (props: Props) => {
 					<ClassSection
 						hero={hero}
 						sourcebooks={props.sourcebooks.filter(sb => hero.sourcebookIDs.includes(sb.id))}
-						options={props.options}
 						searchTerm={searchTerm}
 						selectClass={setClass}
 						setLevel={setLevel}
@@ -576,7 +572,6 @@ export const HeroEditPage = (props: Props) => {
 					<ComplicationSection
 						hero={hero}
 						sourcebooks={props.sourcebooks.filter(sb => hero.sourcebookIDs.includes(sb.id))}
-						options={props.options}
 						searchTerm={searchTerm}
 						selectComplication={setComplication}
 						setFeatureData={setFeatureData}
@@ -588,7 +583,6 @@ export const HeroEditPage = (props: Props) => {
 						hero={hero}
 						allHeroes={props.heroes}
 						sourcebooks={props.sourcebooks.filter(sb => hero.sourcebookIDs.includes(sb.id))}
-						options={props.options}
 						setName={setName}
 						setPicture={setPicture}
 						setFolder={setFolder}
@@ -618,7 +612,6 @@ export const HeroEditPage = (props: Props) => {
 				</ErrorBoundary>
 				<AppFooter
 					page='heroes'
-					options={props.options}
 					params={props.params}
 				/>
 			</div>

--- a/src/components/pages/heroes/hero-list/hero-list-page.tsx
+++ b/src/components/pages/heroes/hero-list/hero-list-page.tsx
@@ -10,7 +10,6 @@ import { ErrorBoundary } from '@/components/controls/error-boundary/error-bounda
 import { Expander } from '@/components/controls/expander/expander';
 import { HeroLogic } from '@/logic/hero-logic';
 import { HeroOverviewPanel } from '@/components/panels/hero-overview/hero-overview-panel';
-import { Options } from '@/models/options';
 import { PregenData } from '@/data/pregen-data';
 import { PregenInfo } from '@/components/panels/token/token';
 import { PregenLogic } from '@/logic/pregen-logic';
@@ -20,6 +19,7 @@ import { Sourcebook } from '@/models/sourcebook';
 import { Utils } from '@/utils/utils';
 import { useIsSmall } from '@/hooks/use-is-small';
 import { useNavigation } from '@/hooks/use-navigation';
+import { useOptions } from '@/contexts/data-context';
 import { useParams } from 'react-router';
 import { useState } from 'react';
 import { useTitle } from '@/hooks/use-title';
@@ -29,7 +29,6 @@ import './hero-list-page.scss';
 interface Props {
 	heroes: HeroOverview[];
 	sourcebooks: Sourcebook[];
-	options: Options;
 	params: FooterParams;
 	addHero: (folder: string) => void;
 	importHero: (hero: Hero, folder: string) => void;
@@ -44,6 +43,7 @@ export const HeroListPage = (props: Props) => {
 	const [ currentTab, setCurrentTab ] = useState<string>(folder ?? '');
 	const [ searchTerm, setSearchTerm ] = useState<string>('');
 	useTitle('Heroes');
+	const options = useOptions();
 
 	if (folder !== previousTab) {
 		setCurrentTab(folder ?? '');
@@ -135,7 +135,7 @@ export const HeroListPage = (props: Props) => {
 															className='container-button'
 															block={true}
 															onClick={() => {
-																const hero = PregenLogic.pregenToHero(p, props.sourcebooks, props.options);
+																const hero = PregenLogic.pregenToHero(p, props.sourcebooks, options);
 																props.importHero(hero, currentTab);
 															}}
 														>
@@ -173,7 +173,6 @@ export const HeroListPage = (props: Props) => {
 				<AppFooter
 					page='heroes'
 					params={props.params}
-					options={props.options}
 				/>
 			</div>
 		</ErrorBoundary>

--- a/src/components/pages/heroes/hero-list/hero-list-page.tsx
+++ b/src/components/pages/heroes/hero-list/hero-list-page.tsx
@@ -2,6 +2,8 @@ import { AppFooter, FooterParams } from '@/components/panels/app-footer/app-foot
 import { Button, Divider, Space, Tabs, Upload } from 'antd';
 import { DownloadOutlined, PlusOutlined, TeamOutlined, ThunderboltOutlined } from '@ant-design/icons';
 import { Hero, HeroOverview } from '@/models/hero';
+import { useHeroes, useOptions } from '@/contexts/data-context';
+import { useMemo, useState } from 'react';
 import { AppHeader } from '@/components/panels/app-header/app-header';
 import { ButtonGroup } from '@/components/controls/button-group/button-group';
 import { Collections } from '@/utils/collections';
@@ -19,15 +21,12 @@ import { Sourcebook } from '@/models/sourcebook';
 import { Utils } from '@/utils/utils';
 import { useIsSmall } from '@/hooks/use-is-small';
 import { useNavigation } from '@/hooks/use-navigation';
-import { useOptions } from '@/contexts/data-context';
 import { useParams } from 'react-router';
-import { useState } from 'react';
 import { useTitle } from '@/hooks/use-title';
 
 import './hero-list-page.scss';
 
 interface Props {
-	heroes: HeroOverview[];
 	sourcebooks: Sourcebook[];
 	params: FooterParams;
 	addHero: (folder: string) => void;
@@ -44,19 +43,23 @@ export const HeroListPage = (props: Props) => {
 	const [ searchTerm, setSearchTerm ] = useState<string>('');
 	useTitle('Heroes');
 	const options = useOptions();
+	const fullHeroes = useHeroes();
+	const heroes = useMemo(() => {
+		return fullHeroes.map(HeroLogic.createOverview);
+	}, [ fullHeroes ]);
 
 	if (folder !== previousTab) {
 		setCurrentTab(folder ?? '');
 		setPreviousTab(folder);
 	}
 
-	const folders = Collections.distinct(props.heroes.map(h => h.folder).sort(), f => f);
+	const folders = Collections.distinct(heroes.map(h => h.folder).sort(), f => f);
 	if (folders.length === 0) {
 		folders.push('');
 	}
 
 	const getHeroes = (folder: string) => {
-		return props.heroes
+		return heroes
 			.filter(h => h.folder === folder)
 			.filter(h => Utils.textMatches([
 				h.name,

--- a/src/components/pages/heroes/hero-sheet/hero-sheet-page.tsx
+++ b/src/components/pages/heroes/hero-sheet/hero-sheet-page.tsx
@@ -21,7 +21,6 @@ import { ItemType } from '@/enums/item-type';
 import { ModifiersCard } from '@/components/panels/classic-sheet/modifiers-card/modifiers-card';
 import { MonsterCard } from '@/components/panels/classic-sheet/monster-card/monster-card';
 import { NotesCard } from '@/components/panels/classic-sheet/notes-card/notes-card';
-import { Options } from '@/models/options';
 import { PerksCard } from '@/components/panels/classic-sheet/perks-card/perks-card';
 import { PotenciesCard } from '@/components/panels/classic-sheet/potencies-card/potencies-card';
 import { PrimaryReferenceCard } from '@/components/panels/classic-sheet/reference/primary-reference-card';
@@ -34,41 +33,42 @@ import { Sourcebook } from '@/models/sourcebook';
 import { StatsResourcesCard } from '@/components/panels/classic-sheet/stats-resources-card/stats-resources-card';
 import { TitlesCard } from '@/components/panels/classic-sheet/titles-card/titles-card';
 import { useMemo } from 'react';
+import { useOptions } from '@/contexts/data-context';
 
 import './hero-sheet-page.scss';
 
 interface Props {
 	hero: Hero;
 	sourcebooks: Sourcebook[];
-	options: Options;
 };
 
 export const HeroSheetPage = (props: Props) => {
 	const hero = useMemo(() => props.hero, [ props.hero ]);
+	const options = useOptions();
 
 	const character = useMemo(
-		() => HeroSheetBuilder.buildHeroSheet(hero, props.sourcebooks, props.options),
-		[ hero, props.sourcebooks, props.options ]
+		() => HeroSheetBuilder.buildHeroSheet(hero, props.sourcebooks, options),
+		[ hero, props.sourcebooks, options ]
 	);
 
 	const sheetClasses = useMemo(
 		() => {
 			const classes = [
 				'hero-sheet',
-				props.options.classicSheetPageSize.toLowerCase()
+				options.classicSheetPageSize.toLowerCase()
 			];
-			if (props.options.colorSheet) {
+			if (options.colorSheet) {
 				classes.push('color');
-				classes.push(`colors-${props.options.colorScheme}`);
+				classes.push(`colors-${options.colorScheme}`);
 			}
 			return classes;
 		},
-		[ props.options.classicSheetPageSize, props.options.colorSheet, props.options.colorScheme ]
+		[ options.classicSheetPageSize, options.colorSheet, options.colorScheme ]
 	);
 
 	const layout = useMemo(
-		() => SheetLayout.getAbilityLayout(props.options),
-		[ props.options ]
+		() => SheetLayout.getAbilityLayout(options),
+		[ options ]
 	);
 
 	const populateExtraCards = (character: HeroSheet): ExtraCards => {
@@ -81,9 +81,9 @@ export const HeroSheetPage = (props: Props) => {
 			}
 		];
 
-		if (props.options.debugClassicSheet) {
+		if (options.debugClassicSheet) {
 			required.push({
-				element: <DebugCard options={props.options} key='debug' />,
+				element: <DebugCard key='debug' />,
 				width: 1,
 				height: 15,
 				shown: false
@@ -230,12 +230,12 @@ export const HeroSheetPage = (props: Props) => {
 	};
 
 	const addAbilityPages = (character: HeroSheet, extraCards: ExtraCards) => {
-		return SheetLayout.getAbilityPagesForCharacter(character, extraCards, layout, props.options);
+		return SheetLayout.getAbilityPagesForCharacter(character, extraCards, layout, options);
 	};
 
 	const getRemainingCards = (extraCards: ExtraCards) => {
 		const hasRetainers = character.followers.some(f => [ 'Retainer', 'Companion' ].includes(f.classification));
-		const layoutEnd = SheetLayout.getFollowerCardsLayout(props.options, hasRetainers);
+		const layoutEnd = SheetLayout.getFollowerCardsLayout(options, hasRetainers);
 		const heightRatio = 0.83;
 
 		// Recalculate card heights
@@ -283,7 +283,7 @@ export const HeroSheetPage = (props: Props) => {
 		if (character.followers.length) {
 			character.followers.filter(f => f.classification !== 'Follower').forEach(fs => {
 				extraCards.required.unshift({
-					element: <CompanionCard companion={fs} options={props.options} key={fs.id} />,
+					element: <CompanionCard companion={fs} key={fs.id} />,
 					width: 1,
 					height: Math.min(layoutEnd.linesY, SheetFormatter.calculateFollowerSize(fs, layoutEnd.cardLineLen)),
 					shown: false
@@ -292,7 +292,7 @@ export const HeroSheetPage = (props: Props) => {
 			const followers = character.followers.filter(f => f.classification === 'Follower');
 			if (followers.length) {
 				extraCards.required.unshift({
-					element: <FollowersCard followers={followers} options={props.options} key='followers' />,
+					element: <FollowersCard followers={followers} key='followers' />,
 					width: 1,
 					height: Math.min(layoutEnd.linesY, SheetFormatter.calculateFollowersSize(followers, layoutEnd.cardLineLen)),
 					shown: false
@@ -301,7 +301,7 @@ export const HeroSheetPage = (props: Props) => {
 		}
 		character.summons.forEach(fs => {
 			extraCards.required.unshift({
-				element: <MonsterCard monster={fs} options={props.options} key={fs.id} />,
+				element: <MonsterCard monster={fs} key={fs.id} />,
 				width: 1,
 				height: Math.min(layoutEnd.linesY, SheetFormatter.calculateMonsterSize(fs, layoutEnd.cardLineLen)),
 				shown: false
@@ -326,7 +326,7 @@ export const HeroSheetPage = (props: Props) => {
 		// Artifacts, and maybe consumables on 'overflow' inventory card
 		const artifacts = character.inventory?.filter(i => i.item.type === ItemType.Artifact) ?? [];
 		const consumables = character.inventory?.filter(i => [ ItemType.Consumable1st, ItemType.Consumable2nd, ItemType.Consumable3rd, ItemType.Consumable4th ].includes(i.item.type)) ?? [];
-		const maxConsumables = props.options.pageOrientation === 'portrait' ? 2 : 4; // approximation
+		const maxConsumables = options.pageOrientation === 'portrait' ? 2 : 4; // approximation
 		if (artifacts.length || consumables.length > maxConsumables) {
 			const inv = artifacts.concat(consumables);
 			const invH = SheetFormatter.calculateInventorySize(inv, layoutEnd.cardLineLen);
@@ -346,14 +346,12 @@ export const HeroSheetPage = (props: Props) => {
 		<ErrorBoundary>
 			<main id='classic-sheet'>
 				<div className={sheetClasses.join(' ')} id={SheetFormatter.getPageId('hero', hero.id)}>
-					<div className={`page page-1 ${props.options.pageOrientation}`} id={SheetFormatter.getPageId('hero-sheet', hero.id)}>
+					<div className={`page page-1 ${options.pageOrientation}`} id={SheetFormatter.getPageId('hero-sheet', hero.id)}>
 						<HeroHeaderCard
 							character={character}
-							options={props.options}
 						/>
 						<StatsResourcesCard
 							character={character}
-							options={props.options}
 						/>
 						<ModifiersCard
 							character={character}
@@ -363,22 +361,19 @@ export const HeroSheetPage = (props: Props) => {
 						/>
 						<ConditionsCard
 							character={character}
-							options={props.options}
 						/>
 						<PrimaryReferenceCard
 							character={character}
-							options={props.options}
 						/>
 						<ImmunitiesWeaknessesCard
 							character={character}
 						/>
 						<ClassFeaturesCard
 							character={character}
-							options={props.options}
 						/>
 					</div>
 					<hr className='dashed' />
-					<div className={`page page-2 ${props.options.pageOrientation}`} id={SheetFormatter.getPageId('hero-sheet', hero.id, '2')}>
+					<div className={`page page-2 ${options.pageOrientation}`} id={SheetFormatter.getPageId('hero-sheet', hero.id, '2')}>
 						<CultureCard
 							character={character}
 						/>
@@ -402,15 +397,15 @@ export const HeroSheetPage = (props: Props) => {
 					</div>
 					{addAbilityPages(character, extraCards)}
 					<hr className='dashed' />
-					<div className={`page page-titles-inventory-projects ${props.options.pageOrientation}`} id={SheetFormatter.getPageId('hero-sheet', hero.id, 'titles-inv-proj')}>
+					<div className={`page page-titles-inventory-projects ${options.pageOrientation}`} id={SheetFormatter.getPageId('hero-sheet', hero.id, 'titles-inv-proj')}>
 						<TitlesCard
 							character={character}
 							showLong='all'
-							wide={props.options.pageOrientation === 'portrait'}
+							wide={options.pageOrientation === 'portrait'}
 						/>
 						<TrinketsCard
 							character={character}
-							wide={props.options.pageOrientation === 'portrait'}
+							wide={options.pageOrientation === 'portrait'}
 						/>
 						<LeveledTreasureCard
 							character={character}
@@ -418,7 +413,7 @@ export const HeroSheetPage = (props: Props) => {
 						/>
 						<ConsumablesCard
 							character={character}
-							wide={props.options.pageOrientation !== 'portrait'}
+							wide={options.pageOrientation !== 'portrait'}
 						/>
 						<ProjectsCard
 							projects={character.projects}

--- a/src/components/pages/heroes/hero-sheet/hero-sheet-preview-page.tsx
+++ b/src/components/pages/heroes/hero-sheet/hero-sheet-preview-page.tsx
@@ -20,6 +20,7 @@ import { Sourcebook } from '@/models/sourcebook';
 import { SourcebookLogic } from '@/logic/sourcebook-logic';
 import { Toggle } from '@/components/controls/toggle/toggle';
 import { Utils } from '@/utils/utils';
+import { useOptions } from '@/contexts/data-context';
 import { useParams } from 'react-router';
 
 import './hero-sheet-page.scss';
@@ -27,11 +28,11 @@ import './hero-sheet-page.scss';
 interface Props {
 	heroes: Hero[];
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setOptions: (options: Options) => void;
 }
 
 export const HeroSheetPreviewPage = (props: Props) => {
+	const options = useOptions();
 	const { heroID } = useParams<{ heroID: string }>();
 	const hero = useMemo(
 		() => props.heroes.find(h => h.id === heroID)!,
@@ -64,10 +65,10 @@ export const HeroSheetPreviewPage = (props: Props) => {
 		const lightest = `rgb(${value + 68}, ${value + 68}, ${value + 68})`;
 		document.documentElement.style.setProperty('--color-text-lightest', lightest);
 	};
-	setDrawColor(props.options.sheetTextColor);
+	setDrawColor(options.sheetTextColor);
 
 	const setSheetTextColor = (value: 'light' | 'default' | 'dark') => {
-		const copy = Utils.copy(props.options);
+		const copy = Utils.copy(options);
 		copy.sheetTextColor = value;
 		props.setOptions(copy);
 	};
@@ -81,37 +82,37 @@ export const HeroSheetPreviewPage = (props: Props) => {
 	};
 
 	const setIncludePlayState = (value: boolean) => {
-		const copy = Utils.copy(props.options);
+		const copy = Utils.copy(options);
 		copy.includePlayState = value;
 		props.setOptions(copy);
 	};
 
 	const setColorSheet = (value: boolean) => {
-		const copy = Utils.copy(props.options);
+		const copy = Utils.copy(options);
 		copy.colorSheet = value;
 		props.setOptions(copy);
 	};
 
 	const setFeaturesInclude = (value: 'minimal' | 'no-basic' | 'all') => {
-		const copy = Utils.copy(props.options);
+		const copy = Utils.copy(options);
 		copy.featuresInclude = value;
 		props.setOptions(copy);
 	};
 
 	const setClassicSheetPageSize = (value: SheetPageSize) => {
-		const copy = Utils.copy(props.options);
+		const copy = Utils.copy(options);
 		copy.classicSheetPageSize = value;
 		props.setOptions(copy);
 	};
 
 	const setPageOrientation = (value: 'portrait' | 'landscape') => {
-		const copy = Utils.copy(props.options);
+		const copy = Utils.copy(options);
 		copy.pageOrientation = value;
 		props.setOptions(copy);
 	};
 
 	const includedStandardAbilitiesChanged = (value: string | string[]) => {
-		const copy = Utils.copy(props.options);
+		const copy = Utils.copy(options);
 		copy.shownStandardAbilities = [ value ].flat(1);
 		props.setOptions(copy);
 	};
@@ -156,8 +157,8 @@ export const HeroSheetPreviewPage = (props: Props) => {
 	const getPageClasses = () => {
 		return [
 			'hero-sheet',
-			props.options.classicSheetPageSize.toLowerCase(),
-			props.options.pageOrientation
+			options.classicSheetPageSize.toLowerCase(),
+			options.pageOrientation
 		].join(' ');
 	};
 
@@ -235,7 +236,6 @@ export const HeroSheetPreviewPage = (props: Props) => {
 				<HeroSheetPage
 					hero={hero}
 					sourcebooks={props.sourcebooks}
-					options={props.options}
 				/>
 			);
 		}
@@ -319,8 +319,8 @@ export const HeroSheetPreviewPage = (props: Props) => {
 					open={drawerOpen}
 					style={{ padding: '10px' }}
 				>
-					<Toggle label='Show play state' value={props.options.includePlayState} onChange={setIncludePlayState} />
-					<Toggle label='Use color' value={props.options.colorSheet} onChange={setColorSheet} />
+					<Toggle label='Show play state' value={options.includePlayState} onChange={setIncludePlayState} />
+					<Toggle label='Use color' value={options.colorSheet} onChange={setColorSheet} />
 					<Divider size='small'>Text Color</Divider>
 					<Segmented
 						name='textColor'
@@ -330,7 +330,7 @@ export const HeroSheetPreviewPage = (props: Props) => {
 							{ value: 'default', label: 'Default' },
 							{ value: 'light', label: 'Lighter' }
 						]}
-						value={props.options.sheetTextColor}
+						value={options.sheetTextColor}
 						onChange={changeTextColor}
 					/>
 					<Divider size='small'>Include Class Features</Divider>
@@ -343,7 +343,7 @@ export const HeroSheetPreviewPage = (props: Props) => {
 							{ value: 'no-basic', label: 'No Simple' },
 							{ value: 'all', label: 'All' }
 						]}
-						value={props.options.featuresInclude}
+						value={options.featuresInclude}
 						onChange={setFeaturesInclude}
 					/>
 					<Divider size='small'>Included Standard Abilities</Divider>
@@ -359,7 +359,7 @@ export const HeroSheetPreviewPage = (props: Props) => {
 							name='pagesize'
 							block={true}
 							options={[ SheetPageSize.Letter, SheetPageSize.A4 ]}
-							value={props.options.classicSheetPageSize}
+							value={options.classicSheetPageSize}
 							onChange={setClassicSheetPageSize}
 						/>
 						<Segmented
@@ -369,7 +369,7 @@ export const HeroSheetPreviewPage = (props: Props) => {
 								{ value: 'portrait', label: 'Portrait' },
 								{ value: 'landscape', label: 'Landscape' }
 							]}
-							value={props.options.pageOrientation}
+							value={options.pageOrientation}
 							onChange={setPageOrientation}
 						/>
 					</Space>

--- a/src/components/pages/heroes/hero-sheet/hero-sheet-preview-page.tsx
+++ b/src/components/pages/heroes/hero-sheet/hero-sheet-preview-page.tsx
@@ -1,4 +1,5 @@
 import { Divider, Drawer, FloatButton, Segmented, Select, SelectProps, Space, Spin, Tag } from 'antd';
+import { useDataManager, useOptions } from '@/contexts/data-context';
 import { useEffect, useMemo, useState } from 'react';
 import { AbilityData } from '@/data/ability-data';
 import { Career } from '@/models/career';
@@ -20,7 +21,6 @@ import { Sourcebook } from '@/models/sourcebook';
 import { SourcebookLogic } from '@/logic/sourcebook-logic';
 import { Toggle } from '@/components/controls/toggle/toggle';
 import { Utils } from '@/utils/utils';
-import { useOptions } from '@/contexts/data-context';
 import { useParams } from 'react-router';
 
 import './hero-sheet-page.scss';
@@ -28,7 +28,6 @@ import './hero-sheet-page.scss';
 interface Props {
 	heroes: Hero[];
 	sourcebooks: Sourcebook[];
-	setOptions: (options: Options) => void;
 }
 
 export const HeroSheetPreviewPage = (props: Props) => {
@@ -42,6 +41,11 @@ export const HeroSheetPreviewPage = (props: Props) => {
 	const [ drawerOpen, setDrawerOpen ] = useState(false);
 	const [ spinning, setSpinning ] = useState(false);
 	const [ previewOptions, setPreviewOptions ] = useState<'html' | 'canvas'>('html');
+
+	const dataManager = useDataManager();
+	const saveOptions = (options: Options) => {
+		dataManager.saveOptions(options);
+	};
 
 	const changeTextColor = (newColor: 'light' | 'default' | 'dark') => {
 		setDrawColor(newColor);
@@ -70,7 +74,7 @@ export const HeroSheetPreviewPage = (props: Props) => {
 	const setSheetTextColor = (value: 'light' | 'default' | 'dark') => {
 		const copy = Utils.copy(options);
 		copy.sheetTextColor = value;
-		props.setOptions(copy);
+		saveOptions(copy);
 	};
 
 	const showDrawer = () => {
@@ -84,37 +88,37 @@ export const HeroSheetPreviewPage = (props: Props) => {
 	const setIncludePlayState = (value: boolean) => {
 		const copy = Utils.copy(options);
 		copy.includePlayState = value;
-		props.setOptions(copy);
+		saveOptions(copy);
 	};
 
 	const setColorSheet = (value: boolean) => {
 		const copy = Utils.copy(options);
 		copy.colorSheet = value;
-		props.setOptions(copy);
+		saveOptions(copy);
 	};
 
 	const setFeaturesInclude = (value: 'minimal' | 'no-basic' | 'all') => {
 		const copy = Utils.copy(options);
 		copy.featuresInclude = value;
-		props.setOptions(copy);
+		saveOptions(copy);
 	};
 
 	const setClassicSheetPageSize = (value: SheetPageSize) => {
 		const copy = Utils.copy(options);
 		copy.classicSheetPageSize = value;
-		props.setOptions(copy);
+		saveOptions(copy);
 	};
 
 	const setPageOrientation = (value: 'portrait' | 'landscape') => {
 		const copy = Utils.copy(options);
 		copy.pageOrientation = value;
-		props.setOptions(copy);
+		saveOptions(copy);
 	};
 
 	const includedStandardAbilitiesChanged = (value: string | string[]) => {
 		const copy = Utils.copy(options);
 		copy.shownStandardAbilities = [ value ].flat(1);
-		props.setOptions(copy);
+		saveOptions(copy);
 	};
 
 	const standardAbilityOptions: SelectProps['options'] = [];

--- a/src/components/pages/heroes/hero-sheet/hero-sheet-preview-page.tsx
+++ b/src/components/pages/heroes/hero-sheet/hero-sheet-preview-page.tsx
@@ -1,5 +1,5 @@
 import { Divider, Drawer, FloatButton, Segmented, Select, SelectProps, Space, Spin, Tag } from 'antd';
-import { useDataManager, useOptions } from '@/contexts/data-context';
+import { useDataManager, useHeroes, useOptions } from '@/contexts/data-context';
 import { useEffect, useMemo, useState } from 'react';
 import { AbilityData } from '@/data/ability-data';
 import { Career } from '@/models/career';
@@ -9,7 +9,6 @@ import { ComplicationCard } from '@/components/panels/classic-sheet/complication
 import { ErrorBoundary } from '@/components/controls/error-boundary/error-boundary';
 import { FactoryLogic } from '@/logic/factory-logic';
 import { HeaderText } from '@/components/controls/header-text/header-text';
-import { Hero } from '@/models/hero';
 import { HeroLogic } from '@/logic/hero-logic';
 import { HeroSheetBuilder } from '@/logic/hero-sheet/hero-sheet-builder';
 import { HeroSheetPage } from '@/components/pages/heroes/hero-sheet/hero-sheet-page';
@@ -26,16 +25,16 @@ import { useParams } from 'react-router';
 import './hero-sheet-page.scss';
 
 interface Props {
-	heroes: Hero[];
 	sourcebooks: Sourcebook[];
 }
 
 export const HeroSheetPreviewPage = (props: Props) => {
 	const options = useOptions();
+	const heroes = useHeroes();
 	const { heroID } = useParams<{ heroID: string }>();
 	const hero = useMemo(
-		() => props.heroes.find(h => h.id === heroID)!,
-		[ heroID, props.heroes ]
+		() => heroes.find(h => h.id === heroID)!,
+		[ heroID, heroes ]
 	);
 
 	const [ drawerOpen, setDrawerOpen ] = useState(false);

--- a/src/components/pages/heroes/hero-sheet/standard-abilities-page.tsx
+++ b/src/components/pages/heroes/hero-sheet/standard-abilities-page.tsx
@@ -3,40 +3,40 @@ import { AbilityData } from '@/data/ability-data';
 import { ClassicSheetBuilder } from '@/logic/classic-sheet/classic-sheet-builder';
 import { ErrorBoundary } from '@/components/controls/error-boundary/error-boundary';
 import { Hero } from '@/models/hero';
-import { Options } from '@/models/options';
 import { SheetFormatter } from '@/logic/classic-sheet/sheet-formatter';
 import { useMemo } from 'react';
+import { useOptions } from '@/contexts/data-context';
 
 interface Props {
 	hero: Hero;
-	options: Options;
 };
 
 export const StandardAbilitiesPage = (props: Props) => {
+	const options = useOptions();
 	const abilities = useMemo(
-		() => AbilityData.standardAbilities.map(a => ClassicSheetBuilder.buildAbilitySheet(a, props.hero, undefined, props.options)),
-		[ props.hero, props.options ]
+		() => AbilityData.standardAbilities.map(a => ClassicSheetBuilder.buildAbilitySheet(a, props.hero, undefined, options)),
+		[ props.hero, options ]
 	);
 	abilities.sort((a, b) => SheetFormatter.sortAbilitiesByType(a, b, 'asc'));
 
 	const layout = useMemo(
-		() => SheetLayout.getAbilityLayout(props.options),
-		[ props.options ]
+		() => SheetLayout.getAbilityLayout(options),
+		[ options ]
 	);
 
 	const sheetClasses = useMemo(
 		() => {
 			const classes = [
 				'hero-sheet',
-				props.options.classicSheetPageSize.toLowerCase()
+				options.classicSheetPageSize.toLowerCase()
 			];
-			if (props.options.colorSheet) {
+			if (options.colorSheet) {
 				classes.push('color');
-				classes.push(`colors-${props.options.colorScheme}`);
+				classes.push(`colors-${options.colorScheme}`);
 			}
 			return classes;
 		},
-		[ props.options.classicSheetPageSize, props.options.colorSheet, props.options.colorScheme ]
+		[ options.classicSheetPageSize, options.colorSheet, options.colorScheme ]
 	);
 
 	const extraCards = {

--- a/src/components/pages/heroes/hero-view/hero-view-page.tsx
+++ b/src/components/pages/heroes/hero-view/hero-view-page.tsx
@@ -30,6 +30,7 @@ import { StandardAbilitiesPage } from '@/components/pages/heroes/hero-sheet/stan
 import { SummoningInfo } from '@/models/summon';
 import { Title } from '@/models/title';
 import { ViewSelector } from '@/components/panels/view-selector/view-selector';
+import { useHeroes } from '@/contexts/data-context';
 import { useIsSmall } from '@/hooks/use-is-small';
 import { useNavigation } from '@/hooks/use-navigation';
 import { useParams } from 'react-router';
@@ -38,7 +39,6 @@ import { useTitle } from '@/hooks/use-title';
 import './hero-view-page.scss';
 
 interface Props {
-	heroes: Hero[];
 	sourcebooks: Sourcebook[];
 	params: FooterParams;
 	exportHeroData: (hero: Hero) => void;
@@ -76,9 +76,10 @@ export const HeroViewPage = (props: Props) => {
 	const navigation = useNavigation();
 	const { heroID } = useParams<{ heroID: string }>();
 	const [ view, setView ] = useState<string>('modern');
+	const heroes = useHeroes();
 	const hero = useMemo(
-		() => props.heroes.find(h => h.id === heroID)!,
-		[ heroID, props.heroes ]
+		() => heroes.find(h => h.id === heroID)!,
+		[ heroID, heroes ]
 	);
 	useTitle(hero.name || 'Unnamed Hero');
 

--- a/src/components/pages/heroes/hero-view/hero-view-page.tsx
+++ b/src/components/pages/heroes/hero-view/hero-view-page.tsx
@@ -24,7 +24,6 @@ import { HeroSheetPage } from '@/components/pages/heroes/hero-sheet/hero-sheet-p
 import { Kit } from '@/models/kit';
 import { Monster } from '@/models/monster';
 import { MultiLine } from '@/components/controls/multi-line/multi-line';
-import { Options } from '@/models/options';
 import { RulesPage } from '@/enums/rules-page';
 import { Sourcebook } from '@/models/sourcebook';
 import { StandardAbilitiesPage } from '@/components/pages/heroes/hero-sheet/standard-abilities-page';
@@ -41,7 +40,6 @@ import './hero-view-page.scss';
 interface Props {
 	heroes: Hero[];
 	sourcebooks: Sourcebook[];
-	options: Options;
 	params: FooterParams;
 	exportHeroData: (hero: Hero) => void;
 	exportHeroImage: (hero: Hero) => void;
@@ -91,7 +89,6 @@ export const HeroViewPage = (props: Props) => {
 					<HeroPanel
 						hero={hero}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 						onSelectAncestry={props.showAncestry}
 						onSelectCulture={props.showCulture}
 						onSelectCareer={props.showCareer}
@@ -120,12 +117,11 @@ export const HeroViewPage = (props: Props) => {
 					<HeroSheetPage
 						hero={hero}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 					/>
 				);
 			case 'abilities':
 				return (
-					<StandardAbilitiesPage options={props.options} hero={hero} />
+					<StandardAbilitiesPage hero={hero} />
 				);
 			case 'notes':
 				return (
@@ -194,7 +190,6 @@ export const HeroViewPage = (props: Props) => {
 				</ErrorBoundary>
 				<AppFooter
 					page='heroes'
-					options={props.options}
 					params={props.params}
 				/>
 			</div>

--- a/src/components/pages/library/library-edit/library-edit-page.tsx
+++ b/src/components/pages/library/library-edit/library-edit-page.tsx
@@ -37,7 +37,6 @@ import { Montage } from '@/models/montage';
 import { MontageEditPanel } from '@/components/panels/edit/montage-edit/montage-edit-panel';
 import { Negotiation } from '@/models/negotiation';
 import { NegotiationEditPanel } from '@/components/panels/edit/negotiation-edit/negotiation-edit-panel';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Perk } from '@/models/perk';
 import { Project } from '@/models/project';
@@ -63,7 +62,6 @@ import './library-edit-page.scss';
 interface Props {
 	heroes: Hero[];
 	sourcebooks: Sourcebook[];
-	options: Options;
 	params: FooterParams;
 	showMonster: (monster: Monster, monsterGroup: MonsterGroup) => void;
 	showTerrain: (terrain: Terrain, upgradeIDs: string[]) => void;
@@ -165,7 +163,6 @@ export const LibraryEditPage = (props: Props) => {
 							adventure={element as Adventure}
 							sourcebooks={props.sourcebooks}
 							heroes={props.heroes}
-							options={props.options}
 							onChange={applyChanges}
 						/>
 					</div>
@@ -176,7 +173,6 @@ export const LibraryEditPage = (props: Props) => {
 						key={element.id}
 						ancestry={element as Ancestry}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 						mode={PanelMode.Full}
 						onChange={applyChanges}
 					/>
@@ -187,7 +183,6 @@ export const LibraryEditPage = (props: Props) => {
 						key={element.id}
 						career={element as Career}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 						mode={PanelMode.Full}
 						onChange={applyChanges}
 					/>
@@ -198,7 +193,6 @@ export const LibraryEditPage = (props: Props) => {
 						key={element.id}
 						heroClass={element as HeroClass}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 						mode={PanelMode.Full}
 						onChange={applyChanges}
 					/>
@@ -209,7 +203,6 @@ export const LibraryEditPage = (props: Props) => {
 						key={element.id}
 						complication={element as Complication}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 						mode={PanelMode.Full}
 						onChange={applyChanges}
 					/>
@@ -220,7 +213,6 @@ export const LibraryEditPage = (props: Props) => {
 						key={element.id}
 						culture={element as Culture}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 						mode={PanelMode.Full}
 						onChange={applyChanges}
 					/>
@@ -231,7 +223,6 @@ export const LibraryEditPage = (props: Props) => {
 						key={element.id}
 						domain={element as Domain}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 						mode={PanelMode.Full}
 						onChange={applyChanges}
 					/>
@@ -243,7 +234,6 @@ export const LibraryEditPage = (props: Props) => {
 						encounter={element as Encounter}
 						heroes={props.heroes}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 						onChange={applyChanges}
 						showMonster={props.showMonster}
 						showTerrain={props.showTerrain}
@@ -255,7 +245,6 @@ export const LibraryEditPage = (props: Props) => {
 						key={element.id}
 						imbuement={element as Imbuement}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 						mode={PanelMode.Full}
 						onChange={applyChanges}
 					/>
@@ -266,7 +255,6 @@ export const LibraryEditPage = (props: Props) => {
 						key={element.id}
 						item={element as Item}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 						mode={PanelMode.Full}
 						onChange={applyChanges}
 					/>
@@ -277,7 +265,6 @@ export const LibraryEditPage = (props: Props) => {
 						key={element.id}
 						kit={element as Kit}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 						mode={PanelMode.Full}
 						onChange={applyChanges}
 					/>
@@ -288,7 +275,6 @@ export const LibraryEditPage = (props: Props) => {
 						key={element.id}
 						monsterGroup={element as MonsterGroup}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 						mode={PanelMode.Full}
 						onChange={applyChanges}
 						onSelectMonster={props.showMonster}
@@ -301,7 +287,6 @@ export const LibraryEditPage = (props: Props) => {
 						montage={element as Montage}
 						heroes={props.heroes}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 						mode={PanelMode.Full}
 						onChange={applyChanges}
 					/>
@@ -312,7 +297,6 @@ export const LibraryEditPage = (props: Props) => {
 						key={element.id}
 						negotiation={element as Negotiation}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 						mode={PanelMode.Full}
 						onChange={applyChanges}
 					/>
@@ -323,7 +307,6 @@ export const LibraryEditPage = (props: Props) => {
 						key={element.id}
 						feature={element as Perk}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 						mode={PanelMode.Full}
 						onChange={applyChanges}
 					/>
@@ -345,7 +328,6 @@ export const LibraryEditPage = (props: Props) => {
 						key={element.id}
 						subClass={element as SubClass}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 						mode={PanelMode.Full}
 						onChange={applyChanges}
 					/>
@@ -358,7 +340,6 @@ export const LibraryEditPage = (props: Props) => {
 							map={element as TacticalMap}
 							display={TacticalMapDisplayType.DirectorEdit}
 							sourcebooks={props.sourcebooks}
-							options={props.options}
 							mode={PanelMode.Full}
 							updateMap={applyChanges}
 						/>
@@ -370,7 +351,6 @@ export const LibraryEditPage = (props: Props) => {
 						key={element.id}
 						terrain={element as Terrain}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 						mode={PanelMode.Full}
 						onChange={applyChanges}
 					/>
@@ -381,7 +361,6 @@ export const LibraryEditPage = (props: Props) => {
 						key={element.id}
 						title={element as Title}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 						mode={PanelMode.Full}
 						onChange={applyChanges}
 					/>
@@ -407,7 +386,6 @@ export const LibraryEditPage = (props: Props) => {
 				</div>
 				<AppFooter
 					page='library'
-					options={props.options}
 					params={props.params}
 				/>
 			</div>

--- a/src/components/pages/library/library-edit/library-edit-page.tsx
+++ b/src/components/pages/library/library-edit/library-edit-page.tsx
@@ -22,7 +22,6 @@ import { EncounterEditPanel } from '@/components/panels/edit/encounter-edit/enco
 import { ErrorBoundary } from '@/components/controls/error-boundary/error-boundary';
 import { FeatureEditPanel } from '@/components/panels/edit/feature-edit/feature-edit-panel';
 import { Format } from '@/utils/format';
-import { Hero } from '@/models/hero';
 import { HeroClass } from '@/models/class';
 import { Imbuement } from '@/models/imbuement';
 import { ImbuementEditPanel } from '@/components/panels/edit/imbuement-edit/imbuement-edit-panel';
@@ -60,7 +59,6 @@ import { useTitle } from '@/hooks/use-title';
 import './library-edit-page.scss';
 
 interface Props {
-	heroes: Hero[];
 	sourcebooks: Sourcebook[];
 	params: FooterParams;
 	showMonster: (monster: Monster, monsterGroup: MonsterGroup) => void;
@@ -162,7 +160,6 @@ export const LibraryEditPage = (props: Props) => {
 							key={element.id}
 							adventure={element as Adventure}
 							sourcebooks={props.sourcebooks}
-							heroes={props.heroes}
 							onChange={applyChanges}
 						/>
 					</div>
@@ -232,7 +229,6 @@ export const LibraryEditPage = (props: Props) => {
 					<EncounterEditPanel
 						key={element.id}
 						encounter={element as Encounter}
-						heroes={props.heroes}
 						sourcebooks={props.sourcebooks}
 						onChange={applyChanges}
 						showMonster={props.showMonster}
@@ -285,7 +281,6 @@ export const LibraryEditPage = (props: Props) => {
 					<MontageEditPanel
 						key={element.id}
 						montage={element as Montage}
-						heroes={props.heroes}
 						sourcebooks={props.sourcebooks}
 						mode={PanelMode.Full}
 						onChange={applyChanges}

--- a/src/components/pages/library/library-list/controls/add-btn.tsx
+++ b/src/components/pages/library/library-list/controls/add-btn.tsx
@@ -13,17 +13,16 @@ import { FactoryLogic } from '@/logic/factory-logic';
 import { Field } from '@/components/controls/field/field';
 import { Hero } from '@/models/hero';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { SourcebookLogic } from '@/logic/sourcebook-logic';
 import { TacticalMapLogic } from '@/logic/tactical-map-logic';
 import { Utils } from '@/utils/utils';
+import { useOptions } from '@/contexts/data-context';
 import { useState } from 'react';
 
 interface Props {
 	category: SourcebookElementKind;
 	heroes: Hero[];
 	sourcebooks: Sourcebook[];
-	options: Options;
 	showMonsters: boolean;
 	sourcebookID: string;
 	setShowMonsters: (value: boolean) => void;
@@ -41,6 +40,7 @@ export const AddBtn = (props: Props) => {
 	const [ mapImportHeight, setMapImportHeight ] = useState<number>(5);
 	const [ mapGenerateType, setMapGenerateType ] = useState<'dungeon' | 'cavern'>('dungeon');
 	const [ mapGenerateSize, setMapGenerateSize ] = useState<number>(5);
+	const options = useOptions();
 
 	if ((props.category === 'monster-group') && props.showMonsters) {
 		return (
@@ -71,13 +71,13 @@ export const AddBtn = (props: Props) => {
 	const generateEncounter = () => {
 		const enc = FactoryLogic.createEncounter();
 
-		let heroLevel = props.options.heroLevel;
-		if (props.options.heroParty) {
-			const party = props.heroes.filter(h => h.folder === props.options.heroParty);
+		let heroLevel = options.heroLevel;
+		if (options.heroParty) {
+			const party = props.heroes.filter(h => h.folder === options.heroParty);
 			heroLevel = Math.round(Collections.mean(party, h => h.class ? h.class.level : 1));
 		}
 
-		const budgets = EncounterDifficultyLogic.getBudgets(props.options, props.heroes);
+		const budgets = EncounterDifficultyLogic.getBudgets(options, props.heroes);
 		switch (difficulty) {
 			case EncounterDifficulty.Easy:
 				EncounterLogic.generateEncounter(enc, props.sourcebooks, keywords, budgets.maxTrivial, heroLevel, heroLevel + 1);

--- a/src/components/pages/library/library-list/controls/add-btn.tsx
+++ b/src/components/pages/library/library-list/controls/add-btn.tsx
@@ -1,6 +1,7 @@
 import { Alert, Button, Flex, Popover, Segmented, Select, Space, Upload } from 'antd';
 import { DownOutlined, DownloadOutlined, PlusOutlined, ThunderboltOutlined } from '@ant-design/icons';
 import { Sourcebook, SourcebookElementKind } from '@/models/sourcebook';
+import { useHeroes, useOptions } from '@/contexts/data-context';
 import { Collections } from '@/utils/collections';
 import { DestinationSelector } from '@/components/pages/library/library-list/controls/destination-selector';
 import { Element } from '@/models/element';
@@ -11,17 +12,14 @@ import { EncounterLogic } from '@/logic/encounter-logic';
 import { Expander } from '@/components/controls/expander/expander';
 import { FactoryLogic } from '@/logic/factory-logic';
 import { Field } from '@/components/controls/field/field';
-import { Hero } from '@/models/hero';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
 import { SourcebookLogic } from '@/logic/sourcebook-logic';
 import { TacticalMapLogic } from '@/logic/tactical-map-logic';
 import { Utils } from '@/utils/utils';
-import { useOptions } from '@/contexts/data-context';
 import { useState } from 'react';
 
 interface Props {
 	category: SourcebookElementKind;
-	heroes: Hero[];
 	sourcebooks: Sourcebook[];
 	showMonsters: boolean;
 	sourcebookID: string;
@@ -41,6 +39,7 @@ export const AddBtn = (props: Props) => {
 	const [ mapGenerateType, setMapGenerateType ] = useState<'dungeon' | 'cavern'>('dungeon');
 	const [ mapGenerateSize, setMapGenerateSize ] = useState<number>(5);
 	const options = useOptions();
+	const heroes = useHeroes();
 
 	if ((props.category === 'monster-group') && props.showMonsters) {
 		return (
@@ -73,11 +72,11 @@ export const AddBtn = (props: Props) => {
 
 		let heroLevel = options.heroLevel;
 		if (options.heroParty) {
-			const party = props.heroes.filter(h => h.folder === options.heroParty);
+			const party = heroes.filter(h => h.folder === options.heroParty);
 			heroLevel = Math.round(Collections.mean(party, h => h.class ? h.class.level : 1));
 		}
 
-		const budgets = EncounterDifficultyLogic.getBudgets(options, props.heroes);
+		const budgets = EncounterDifficultyLogic.getBudgets(options, heroes);
 		switch (difficulty) {
 			case EncounterDifficulty.Easy:
 				EncounterLogic.generateEncounter(enc, props.sourcebooks, keywords, budgets.maxTrivial, heroLevel, heroLevel + 1);

--- a/src/components/pages/library/library-list/library-list-page.tsx
+++ b/src/components/pages/library/library-list/library-list-page.tsx
@@ -72,6 +72,7 @@ import { Title } from '@/models/title';
 import { TitlePanel } from '@/components/panels/elements/title-panel/title-panel';
 import { Toggle } from '@/components/controls/toggle/toggle';
 import { ViewSelector } from '@/components/panels/view-selector/view-selector';
+import { useHiddenSourcebookIDs } from '@/contexts/data-context';
 import { useIsSmall } from '@/hooks/use-is-small';
 import { useNavigation } from '@/hooks/use-navigation';
 import { useParams } from 'react-router';
@@ -82,7 +83,6 @@ import './library-list-page.scss';
 interface Props {
 	heroes: Hero[];
 	sourcebooks: Sourcebook[];
-	hiddenSourcebookIDs: string[];
 	params: FooterParams;
 	showSourcebooks: () => void;
 	showMonster: (monster: Monster) => void;
@@ -119,6 +119,7 @@ export const LibraryListPage = (props: Props) => {
 	const [ showMonsterFilter, setShowMonsterFilter ] = useState<boolean>(false);
 	const [ monsterFilter, setMonsterFilter ] = useState<MonsterFilter>(FactoryLogic.createMonsterFilter());
 	const [ sourcebookID, setSourcebookID ] = useState<string>(props.sourcebooks.filter(sb => sb.type === SourcebookType.Homebrew).length > 0 ? Collections.sort(props.sourcebooks, sb => sb.name).filter(sb => sb.type === SourcebookType.Homebrew)[0].id : '');
+	const hiddenSourcebookIDs = useHiddenSourcebookIDs();
 	useTitle('Library');
 
 	if (kind !== previousCategory) {
@@ -136,7 +137,7 @@ export const LibraryListPage = (props: Props) => {
 		let list: Element[] = [];
 
 		const getSourcebooks = () => {
-			return props.sourcebooks.filter(sb => !props.hiddenSourcebookIDs.includes(sb.id));
+			return props.sourcebooks.filter(sb => !hiddenSourcebookIDs.includes(sb.id));
 		};
 
 		switch (type) {

--- a/src/components/pages/library/library-list/library-list-page.tsx
+++ b/src/components/pages/library/library-list/library-list-page.tsx
@@ -52,7 +52,6 @@ import { MontageSheetPage } from '@/components/panels/classic-sheet/montage-shee
 import { Negotiation } from '@/models/negotiation';
 import { NegotiationPanel } from '@/components/panels/elements/negotiation-panel/negotiation-panel';
 import { NegotiationSheetPage } from '@/components/panels/classic-sheet/negotiation-sheet/negotiation-sheet-page';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Perk } from '@/models/perk';
 import { PerkPanel } from '@/components/panels/elements/perk-panel/perk-panel';
@@ -83,7 +82,6 @@ import './library-list-page.scss';
 interface Props {
 	heroes: Hero[];
 	sourcebooks: Sourcebook[];
-	options: Options;
 	hiddenSourcebookIDs: string[];
 	params: FooterParams;
 	showSourcebooks: () => void;
@@ -223,7 +221,6 @@ export const LibraryListPage = (props: Props) => {
 									encounter={element as Encounter}
 									sourcebooks={props.sourcebooks}
 									heroes={props.heroes}
-									options={props.options}
 								/>
 							</div>
 						);
@@ -233,7 +230,6 @@ export const LibraryListPage = (props: Props) => {
 								<MontageSheetPage
 									montage={element as Montage}
 									heroes={props.heroes}
-									options={props.options}
 								/>
 							</div>
 						);
@@ -242,7 +238,6 @@ export const LibraryListPage = (props: Props) => {
 							<div style={{ padding: '20px', overflow: 'auto' }}>
 								<NegotiationSheetPage
 									negotiation={element as Negotiation}
-									options={props.options}
 								/>
 							</div>
 						);
@@ -253,69 +248,69 @@ export const LibraryListPage = (props: Props) => {
 		} else {
 			switch (category) {
 				case 'adventure':
-					getPanel = (element: Element) => <AdventurePanel key={element.id} adventure={element as Adventure} heroes={props.heroes} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} />;
+					getPanel = (element: Element) => <AdventurePanel key={element.id} adventure={element as Adventure} heroes={props.heroes} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />;
 					break;
 				case 'ancestry':
-					getPanel = (element: Element) => <AncestryPanel key={element.id} ancestry={element as Ancestry} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} />;
+					getPanel = (element: Element) => <AncestryPanel key={element.id} ancestry={element as Ancestry} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />;
 					break;
 				case 'career':
-					getPanel = (element: Element) => <CareerPanel key={element.id} career={element as Career} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} />;
+					getPanel = (element: Element) => <CareerPanel key={element.id} career={element as Career} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />;
 					break;
 				case 'class':
-					getPanel = (element: Element) => <ClassPanel key={element.id} heroClass={element as HeroClass} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} />;
+					getPanel = (element: Element) => <ClassPanel key={element.id} heroClass={element as HeroClass} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />;
 					break;
 				case 'complication':
-					getPanel = (element: Element) => <ComplicationPanel key={element.id} complication={element as Complication} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} />;
+					getPanel = (element: Element) => <ComplicationPanel key={element.id} complication={element as Complication} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />;
 					break;
 				case 'culture':
-					getPanel = (element: Element) => <CulturePanel key={element.id} culture={element as Culture} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} />;
+					getPanel = (element: Element) => <CulturePanel key={element.id} culture={element as Culture} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />;
 					break;
 				case 'domain':
-					getPanel = (element: Element) => <DomainPanel key={element.id} domain={element as Domain} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} />;
+					getPanel = (element: Element) => <DomainPanel key={element.id} domain={element as Domain} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />;
 					break;
 				case 'encounter':
-					getPanel = (element: Element) => <EncounterPanel key={element.id} encounter={element as Encounter} heroes={props.heroes} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} showTools={tool => props.showEncounterTools(element as Encounter, tool)} />;
+					getPanel = (element: Element) => <EncounterPanel key={element.id} encounter={element as Encounter} heroes={props.heroes} sourcebooks={props.sourcebooks} mode={PanelMode.Full} showTools={tool => props.showEncounterTools(element as Encounter, tool)} />;
 					break;
 				case 'imbuement':
-					getPanel = (element: Element) => <ImbuementPanel key={element.id} imbuement={element as Imbuement} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} />;
+					getPanel = (element: Element) => <ImbuementPanel key={element.id} imbuement={element as Imbuement} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />;
 					break;
 				case 'item':
-					getPanel = (element: Element) => <ItemPanel key={element.id} item={element as Item} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} />;
+					getPanel = (element: Element) => <ItemPanel key={element.id} item={element as Item} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />;
 					break;
 				case 'kit':
-					getPanel = (element: Element) => <KitPanel key={element.id} kit={element as Kit} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} />;
+					getPanel = (element: Element) => <KitPanel key={element.id} kit={element as Kit} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />;
 					break;
 				case 'monster-group':
 					getPanel = (element: Element) => {
 						return showMonsters ?
-							<MonsterPanel key={element.id} monster={element as Monster} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} />
+							<MonsterPanel key={element.id} monster={element as Monster} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
 							:
-							<MonsterGroupPanel key={element.id} monsterGroup={element as MonsterGroup} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} onSelectMonster={props.showMonster} />;
+							<MonsterGroupPanel key={element.id} monsterGroup={element as MonsterGroup} sourcebooks={props.sourcebooks} mode={PanelMode.Full} onSelectMonster={props.showMonster} />;
 					};
 					break;
 				case 'montage':
-					getPanel = (element: Element) => <MontagePanel key={element.id} montage={element as Montage} heroes={props.heroes} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} />;
+					getPanel = (element: Element) => <MontagePanel key={element.id} montage={element as Montage} heroes={props.heroes} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />;
 					break;
 				case 'negotiation':
-					getPanel = (element: Element) => <NegotiationPanel key={element.id} negotiation={element as Negotiation} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} />;
+					getPanel = (element: Element) => <NegotiationPanel key={element.id} negotiation={element as Negotiation} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />;
 					break;
 				case 'perk':
-					getPanel = (element: Element) => <PerkPanel key={element.id} perk={element as Perk} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} />;
+					getPanel = (element: Element) => <PerkPanel key={element.id} perk={element as Perk} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />;
 					break;
 				case 'project':
 					getPanel = (element: Element) => <ProjectPanel key={element.id} project={element as Project} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />;
 					break;
 				case 'subclass':
-					getPanel = (element: Element) => <SubclassPanel key={element.id} subclass={element as SubClass} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} />;
+					getPanel = (element: Element) => <SubclassPanel key={element.id} subclass={element as SubClass} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />;
 					break;
 				case 'tactical-map':
-					getPanel = (element: Element) => <TacticalMapPanel key={element.id} map={element as TacticalMap} sourcebooks={props.sourcebooks} options={props.options} display={TacticalMapDisplayType.DirectorView} mode={PanelMode.Full} />;
+					getPanel = (element: Element) => <TacticalMapPanel key={element.id} map={element as TacticalMap} sourcebooks={props.sourcebooks} display={TacticalMapDisplayType.DirectorView} mode={PanelMode.Full} />;
 					break;
 				case 'terrain':
 					getPanel = (element: Element) => <TerrainPanel key={element.id} terrain={element as Terrain} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />;
 					break;
 				case 'title':
-					getPanel = (element: Element) => <TitlePanel key={element.id} title={element as Title} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} />;
+					getPanel = (element: Element) => <TitlePanel key={element.id} title={element as Title} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />;
 					break;
 			}
 		}
@@ -846,7 +841,6 @@ export const LibraryListPage = (props: Props) => {
 										category={category}
 										heroes={props.heroes}
 										sourcebooks={props.sourcebooks}
-										options={props.options}
 										showMonsters={showMonsters}
 										sourcebookID={sourcebookID}
 										setShowMonsters={setShowMonsters}
@@ -877,7 +871,6 @@ export const LibraryListPage = (props: Props) => {
 				<AppFooter
 					page='library'
 					params={props.params}
-					options={props.options}
 				/>
 			</div>
 		</ErrorBoundary>

--- a/src/components/pages/library/library-list/library-list-page.tsx
+++ b/src/components/pages/library/library-list/library-list-page.tsx
@@ -30,7 +30,6 @@ import { ErrorBoundary } from '@/components/controls/error-boundary/error-bounda
 import { FactoryLogic } from '@/logic/factory-logic';
 import { Format } from '@/utils/format';
 import { HeaderText } from '@/components/controls/header-text/header-text';
-import { Hero } from '@/models/hero';
 import { HeroClass } from '@/models/class';
 import { Imbuement } from '@/models/imbuement';
 import { ImbuementPanel } from '@/components/panels/elements/imbuement-panel/imbuement-panel';
@@ -81,7 +80,6 @@ import { useTitle } from '@/hooks/use-title';
 import './library-list-page.scss';
 
 interface Props {
-	heroes: Hero[];
 	sourcebooks: Sourcebook[];
 	params: FooterParams;
 	showSourcebooks: () => void;
@@ -221,7 +219,6 @@ export const LibraryListPage = (props: Props) => {
 								<EncounterSheetPage
 									encounter={element as Encounter}
 									sourcebooks={props.sourcebooks}
-									heroes={props.heroes}
 								/>
 							</div>
 						);
@@ -230,7 +227,6 @@ export const LibraryListPage = (props: Props) => {
 							<div style={{ padding: '20px', overflow: 'auto' }}>
 								<MontageSheetPage
 									montage={element as Montage}
-									heroes={props.heroes}
 								/>
 							</div>
 						);
@@ -249,7 +245,7 @@ export const LibraryListPage = (props: Props) => {
 		} else {
 			switch (category) {
 				case 'adventure':
-					getPanel = (element: Element) => <AdventurePanel key={element.id} adventure={element as Adventure} heroes={props.heroes} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />;
+					getPanel = (element: Element) => <AdventurePanel key={element.id} adventure={element as Adventure} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />;
 					break;
 				case 'ancestry':
 					getPanel = (element: Element) => <AncestryPanel key={element.id} ancestry={element as Ancestry} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />;
@@ -270,7 +266,7 @@ export const LibraryListPage = (props: Props) => {
 					getPanel = (element: Element) => <DomainPanel key={element.id} domain={element as Domain} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />;
 					break;
 				case 'encounter':
-					getPanel = (element: Element) => <EncounterPanel key={element.id} encounter={element as Encounter} heroes={props.heroes} sourcebooks={props.sourcebooks} mode={PanelMode.Full} showTools={tool => props.showEncounterTools(element as Encounter, tool)} />;
+					getPanel = (element: Element) => <EncounterPanel key={element.id} encounter={element as Encounter} sourcebooks={props.sourcebooks} mode={PanelMode.Full} showTools={tool => props.showEncounterTools(element as Encounter, tool)} />;
 					break;
 				case 'imbuement':
 					getPanel = (element: Element) => <ImbuementPanel key={element.id} imbuement={element as Imbuement} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />;
@@ -290,7 +286,7 @@ export const LibraryListPage = (props: Props) => {
 					};
 					break;
 				case 'montage':
-					getPanel = (element: Element) => <MontagePanel key={element.id} montage={element as Montage} heroes={props.heroes} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />;
+					getPanel = (element: Element) => <MontagePanel key={element.id} montage={element as Montage} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />;
 					break;
 				case 'negotiation':
 					getPanel = (element: Element) => <NegotiationPanel key={element.id} negotiation={element as Negotiation} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />;
@@ -840,7 +836,6 @@ export const LibraryListPage = (props: Props) => {
 								control: (
 									<AddBtn
 										category={category}
-										heroes={props.heroes}
 										sourcebooks={props.sourcebooks}
 										showMonsters={showMonsters}
 										sourcebookID={sourcebookID}

--- a/src/components/pages/library/library-print/library-print-page.tsx
+++ b/src/components/pages/library/library-print/library-print-page.tsx
@@ -2,7 +2,6 @@ import { Sourcebook, SourcebookElementKind } from '@/models/sourcebook';
 import { Element } from '@/models/element';
 import { ErrorBoundary } from '@/components/controls/error-boundary/error-boundary';
 import { Hero } from '@/models/hero';
-import { Options } from '@/models/options';
 import { PrintSheet } from '@/components/panels/print-sheet/print-sheet';
 import { useParams } from 'react-router';
 import { useState } from 'react';
@@ -13,7 +12,6 @@ import './library-print-page.scss';
 interface Props {
 	heroes: Hero[];
 	sourcebooks: Sourcebook[];
-	options: Options;
 }
 
 export const LibraryPrintPage = (props: Props) => {
@@ -74,7 +72,6 @@ export const LibraryPrintPage = (props: Props) => {
 					element={element}
 					sourcebooks={props.sourcebooks}
 					heroes={props.heroes}
-					options={props.options}
 				/>
 			</div>
 		</ErrorBoundary>

--- a/src/components/pages/library/library-print/library-print-page.tsx
+++ b/src/components/pages/library/library-print/library-print-page.tsx
@@ -1,7 +1,6 @@
 import { Sourcebook, SourcebookElementKind } from '@/models/sourcebook';
 import { Element } from '@/models/element';
 import { ErrorBoundary } from '@/components/controls/error-boundary/error-boundary';
-import { Hero } from '@/models/hero';
 import { PrintSheet } from '@/components/panels/print-sheet/print-sheet';
 import { useParams } from 'react-router';
 import { useState } from 'react';
@@ -10,7 +9,6 @@ import { useTitle } from '@/hooks/use-title';
 import './library-print-page.scss';
 
 interface Props {
-	heroes: Hero[];
 	sourcebooks: Sourcebook[];
 }
 
@@ -71,7 +69,6 @@ export const LibraryPrintPage = (props: Props) => {
 					type={kind!}
 					element={element}
 					sourcebooks={props.sourcebooks}
-					heroes={props.heroes}
 				/>
 			</div>
 		</ErrorBoundary>

--- a/src/components/pages/session/director/session-director-page.tsx
+++ b/src/components/pages/session/director/session-director-page.tsx
@@ -20,7 +20,6 @@ import { Negotiation } from '@/models/negotiation';
 import { NegotiationData } from '@/data/negotiation-data';
 import { NegotiationRunPanel } from '@/components/panels/run/negotiation-run/negotiation-run-panel';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Session } from '@/models/session';
 import { Sourcebook } from '@/models/sourcebook';
@@ -41,7 +40,6 @@ interface Props {
 	heroes: Hero[];
 	sourcebooks: Sourcebook[];
 	session: Session;
-	options: Options;
 	params: FooterParams;
 	showPlayerView: () => void;
 	startEncounter: (encounter: Encounter) => Promise<string>;
@@ -105,7 +103,6 @@ export const SessionDirectorPage = (props: Props) => {
 							encounter={encounter}
 							sourcebooks={props.sourcebooks}
 							heroes={props.heroes}
-							options={props.options}
 							onChange={props.updateEncounter}
 							showTools={tool => props.showEncounterTools(encounter, tool)}
 						/>
@@ -121,7 +118,6 @@ export const SessionDirectorPage = (props: Props) => {
 							key={montage.id}
 							montage={montage}
 							heroes={props.heroes}
-							options={props.options}
 							onChange={props.updateMontage}
 						/>
 					</div>
@@ -149,7 +145,6 @@ export const SessionDirectorPage = (props: Props) => {
 							key={map.id}
 							map={map}
 							display={TacticalMapDisplayType.DirectorEdit}
-							options={props.options}
 							heroes={props.heroes}
 							encounters={props.session.encounters}
 							sourcebooks={props.sourcebooks}
@@ -414,7 +409,6 @@ export const SessionDirectorPage = (props: Props) => {
 				</ErrorBoundary>
 				<AppFooter
 					page='session'
-					options={props.options}
 					params={props.params}
 				/>
 			</div>

--- a/src/components/pages/session/director/session-director-page.tsx
+++ b/src/components/pages/session/director/session-director-page.tsx
@@ -21,7 +21,6 @@ import { NegotiationData } from '@/data/negotiation-data';
 import { NegotiationRunPanel } from '@/components/panels/run/negotiation-run/negotiation-run-panel';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
 import { PanelMode } from '@/enums/panel-mode';
-import { Session } from '@/models/session';
 import { Sourcebook } from '@/models/sourcebook';
 import { SourcebookLogic } from '@/logic/sourcebook-logic';
 import { TacticalMap } from '@/models/tactical-map';
@@ -31,6 +30,7 @@ import { TextInput } from '@/components/controls/text-input/text-input';
 import { Utils } from '@/utils/utils';
 import { useIsSmall } from '@/hooks/use-is-small';
 import { useNavigation } from '@/hooks/use-navigation';
+import { useSession } from '@/contexts/data-context';
 import { useState } from 'react';
 import { useTitle } from '@/hooks/use-title';
 
@@ -39,7 +39,6 @@ import './session-director-page.scss';
 interface Props {
 	heroes: Hero[];
 	sourcebooks: Sourcebook[];
-	session: Session;
 	params: FooterParams;
 	showPlayerView: () => void;
 	startEncounter: (encounter: Encounter) => Promise<string>;
@@ -60,8 +59,9 @@ interface Props {
 export const SessionDirectorPage = (props: Props) => {
 	const isSmall = useIsSmall();
 	const navigation = useNavigation();
+	const session = useSession();
 	const [ selectedElementID, setSelectedElementID ] = useState<string | null>(() => {
-		const options = AdventureLogic.getContentOptions(props.session);
+		const options = AdventureLogic.getContentOptions(session);
 		return options.length > 0 ? options[0].id : null;
 	});
 	const [ startElement, setStartElement ] = useState<string>('encounter');
@@ -70,7 +70,7 @@ export const SessionDirectorPage = (props: Props) => {
 	useTitle('Session');
 
 	const getSelector = () => {
-		const options = AdventureLogic.getContentOptions(props.session).map(o => {
+		const options = AdventureLogic.getContentOptions(session).map(o => {
 			return {
 				value: o.id,
 				label: o.name
@@ -94,7 +94,7 @@ export const SessionDirectorPage = (props: Props) => {
 
 	const getSelectedContent = () => {
 		if (selectedElementID) {
-			const encounter = props.session.encounters.find(e => e.id === selectedElementID);
+			const encounter = session.encounters.find(e => e.id === selectedElementID);
 			if (encounter) {
 				return (
 					<div className='session-page-content-container'>
@@ -110,7 +110,7 @@ export const SessionDirectorPage = (props: Props) => {
 				);
 			}
 
-			const montage = props.session.montages.find(m => m.id === selectedElementID);
+			const montage = session.montages.find(m => m.id === selectedElementID);
 			if (montage) {
 				return (
 					<div className='session-page-content-container'>
@@ -124,7 +124,7 @@ export const SessionDirectorPage = (props: Props) => {
 				);
 			}
 
-			const negotiation = props.session.negotiations.find(n => n.id === selectedElementID);
+			const negotiation = session.negotiations.find(n => n.id === selectedElementID);
 			if (negotiation) {
 				return (
 					<div className='session-page-content-container'>
@@ -137,7 +137,7 @@ export const SessionDirectorPage = (props: Props) => {
 				);
 			}
 
-			const map = props.session.tacticalMaps.find(tm => tm.id === selectedElementID);
+			const map = session.tacticalMaps.find(tm => tm.id === selectedElementID);
 			if (map) {
 				return (
 					<div className='session-page-content-container'>
@@ -146,7 +146,7 @@ export const SessionDirectorPage = (props: Props) => {
 							map={map}
 							display={TacticalMapDisplayType.DirectorEdit}
 							heroes={props.heroes}
-							encounters={props.session.encounters}
+							encounters={session.encounters}
 							sourcebooks={props.sourcebooks}
 							mode={PanelMode.Full}
 							updateMap={props.updateMap}
@@ -157,7 +157,7 @@ export const SessionDirectorPage = (props: Props) => {
 				);
 			}
 
-			const counter = props.session.counters.find(c => c.id === selectedElementID);
+			const counter = session.counters.find(c => c.id === selectedElementID);
 			if (counter) {
 				return (
 					<div className='session-page-content-container'>
@@ -171,7 +171,7 @@ export const SessionDirectorPage = (props: Props) => {
 			}
 		}
 
-		const options = AdventureLogic.getContentOptions(props.session);
+		const options = AdventureLogic.getContentOptions(session);
 		if (options.length === 0) {
 			return (
 				<Empty text='Nothing is currently in progress.' />

--- a/src/components/pages/session/director/session-director-page.tsx
+++ b/src/components/pages/session/director/session-director-page.tsx
@@ -37,7 +37,6 @@ import { useTitle } from '@/hooks/use-title';
 import './session-director-page.scss';
 
 interface Props {
-	heroes: Hero[];
 	sourcebooks: Sourcebook[];
 	params: FooterParams;
 	showPlayerView: () => void;
@@ -102,7 +101,6 @@ export const SessionDirectorPage = (props: Props) => {
 							key={encounter.id}
 							encounter={encounter}
 							sourcebooks={props.sourcebooks}
-							heroes={props.heroes}
 							onChange={props.updateEncounter}
 							showTools={tool => props.showEncounterTools(encounter, tool)}
 						/>
@@ -117,7 +115,6 @@ export const SessionDirectorPage = (props: Props) => {
 						<MontageRunPanel
 							key={montage.id}
 							montage={montage}
-							heroes={props.heroes}
 							onChange={props.updateMontage}
 						/>
 					</div>
@@ -145,7 +142,6 @@ export const SessionDirectorPage = (props: Props) => {
 							key={map.id}
 							map={map}
 							display={TacticalMapDisplayType.DirectorEdit}
-							heroes={props.heroes}
 							encounters={session.encounters}
 							sourcebooks={props.sourcebooks}
 							mode={PanelMode.Full}

--- a/src/components/pages/session/player/session-player-page.tsx
+++ b/src/components/pages/session/player/session-player-page.tsx
@@ -7,7 +7,6 @@ import { ErrorBoundary } from '@/components/controls/error-boundary/error-bounda
 import { Hero } from '@/models/hero';
 import { MontageRunPanel } from '@/components/panels/run/montage-run/montage-run-panel';
 import { NegotiationRunPanel } from '@/components/panels/run/negotiation-run/negotiation-run-panel';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Session } from '@/models/session';
 import { Sourcebook } from '@/models/sourcebook';
@@ -20,7 +19,6 @@ interface Props {
 	heroes: Hero[];
 	sourcebooks: Sourcebook[];
 	session: Session;
-	options: Options;
 	params: FooterParams;
 }
 
@@ -33,7 +31,6 @@ export const SessionPlayerPage = (props: Props) => {
 					encounter={encounter}
 					sourcebooks={props.sourcebooks}
 					heroes={props.heroes}
-					options={props.options}
 					onChange={() => null}
 				/>
 			);
@@ -45,7 +42,6 @@ export const SessionPlayerPage = (props: Props) => {
 				<MontageRunPanel
 					montage={montage}
 					heroes={props.heroes}
-					options={props.options}
 					onChange={() => null}
 				/>
 			);
@@ -68,7 +64,6 @@ export const SessionPlayerPage = (props: Props) => {
 					key={JSON.stringify(map)}
 					map={map}
 					display={TacticalMapDisplayType.Player}
-					options={props.options}
 					heroes={props.heroes}
 					encounters={props.session.encounters}
 					sourcebooks={props.sourcebooks}
@@ -101,7 +96,6 @@ export const SessionPlayerPage = (props: Props) => {
 				</ErrorBoundary>
 				<AppFooter
 					page='player-view'
-					options={props.options}
 					params={props.params}
 				/>
 			</div>

--- a/src/components/pages/session/player/session-player-page.tsx
+++ b/src/components/pages/session/player/session-player-page.tsx
@@ -8,23 +8,23 @@ import { Hero } from '@/models/hero';
 import { MontageRunPanel } from '@/components/panels/run/montage-run/montage-run-panel';
 import { NegotiationRunPanel } from '@/components/panels/run/negotiation-run/negotiation-run-panel';
 import { PanelMode } from '@/enums/panel-mode';
-import { Session } from '@/models/session';
 import { Sourcebook } from '@/models/sourcebook';
 import { TacticalMapDisplayType } from '@/enums/tactical-map-display-type';
 import { TacticalMapPanel } from '@/components/panels/elements/tactical-map-panel/tactical-map-panel';
+import { useSession } from '@/contexts/data-context';
 
 import './session-player-page.scss';
 
 interface Props {
 	heroes: Hero[];
 	sourcebooks: Sourcebook[];
-	session: Session;
 	params: FooterParams;
 }
 
 export const SessionPlayerPage = (props: Props) => {
+	const session = useSession();
 	const getContent = () => {
-		const encounter = props.session.encounters.find(e => e.id === props.session.playerViewID);
+		const encounter = session.encounters.find(e => e.id === session.playerViewID);
 		if (encounter) {
 			return (
 				<EncounterRunPanel
@@ -36,7 +36,7 @@ export const SessionPlayerPage = (props: Props) => {
 			);
 		}
 
-		const montage = props.session.montages.find(m => m.id === props.session.playerViewID);
+		const montage = session.montages.find(m => m.id === session.playerViewID);
 		if (montage) {
 			return (
 				<MontageRunPanel
@@ -47,7 +47,7 @@ export const SessionPlayerPage = (props: Props) => {
 			);
 		}
 
-		const negotiation = props.session.negotiations.find(n => n.id === props.session.playerViewID);
+		const negotiation = session.negotiations.find(n => n.id === session.playerViewID);
 		if (negotiation) {
 			return (
 				<NegotiationRunPanel
@@ -57,7 +57,7 @@ export const SessionPlayerPage = (props: Props) => {
 			);
 		}
 
-		const map = props.session.tacticalMaps.find(tm => tm.id === props.session.playerViewID);
+		const map = session.tacticalMaps.find(tm => tm.id === session.playerViewID);
 		if (map) {
 			return (
 				<TacticalMapPanel
@@ -65,14 +65,14 @@ export const SessionPlayerPage = (props: Props) => {
 					map={map}
 					display={TacticalMapDisplayType.Player}
 					heroes={props.heroes}
-					encounters={props.session.encounters}
+					encounters={session.encounters}
 					sourcebooks={props.sourcebooks}
 					mode={PanelMode.Full}
 				/>
 			);
 		}
 
-		const counter = props.session.counters.find(c => c.id === props.session.playerViewID);
+		const counter = session.counters.find(c => c.id === session.playerViewID);
 		if (counter) {
 			return (
 				<CounterRunPanel

--- a/src/components/pages/session/player/session-player-page.tsx
+++ b/src/components/pages/session/player/session-player-page.tsx
@@ -4,7 +4,6 @@ import { CounterRunPanel } from '@/components/panels/run/counter-run/counter-run
 import { Empty } from '@/components/controls/empty/empty';
 import { EncounterRunPanel } from '@/components/panels/run/encounter-run/encounter-run-panel';
 import { ErrorBoundary } from '@/components/controls/error-boundary/error-boundary';
-import { Hero } from '@/models/hero';
 import { MontageRunPanel } from '@/components/panels/run/montage-run/montage-run-panel';
 import { NegotiationRunPanel } from '@/components/panels/run/negotiation-run/negotiation-run-panel';
 import { PanelMode } from '@/enums/panel-mode';
@@ -16,7 +15,6 @@ import { useSession } from '@/contexts/data-context';
 import './session-player-page.scss';
 
 interface Props {
-	heroes: Hero[];
 	sourcebooks: Sourcebook[];
 	params: FooterParams;
 }
@@ -30,7 +28,6 @@ export const SessionPlayerPage = (props: Props) => {
 				<EncounterRunPanel
 					encounter={encounter}
 					sourcebooks={props.sourcebooks}
-					heroes={props.heroes}
 					onChange={() => null}
 				/>
 			);
@@ -41,7 +38,6 @@ export const SessionPlayerPage = (props: Props) => {
 			return (
 				<MontageRunPanel
 					montage={montage}
-					heroes={props.heroes}
 					onChange={() => null}
 				/>
 			);
@@ -64,7 +60,6 @@ export const SessionPlayerPage = (props: Props) => {
 					key={JSON.stringify(map)}
 					map={map}
 					display={TacticalMapDisplayType.Player}
-					heroes={props.heroes}
 					encounters={session.encounters}
 					sourcebooks={props.sourcebooks}
 					mode={PanelMode.Full}

--- a/src/components/pages/transfer/transfer-page.tsx
+++ b/src/components/pages/transfer/transfer-page.tsx
@@ -14,7 +14,6 @@ import { HeroOverviewPanel } from '@/components/panels/hero-overview/hero-overvi
 import { LabelControl } from '@/components/controls/label-control/label-control';
 import { LocalService } from '@/services/storage/local-service';
 import { MergeDuplicateBehavior } from '@/enums/merge-duplicate-behavior';
-import { Options } from '@/models/options';
 import { Sourcebook } from '@/models/sourcebook';
 import { SourcebookMergeLogic } from '@/logic/merge/sourcebook-merge-logic';
 import { SourcebookPanel } from '@/components/panels/elements/sourcebook-panel/sourcebook-panel';
@@ -26,7 +25,6 @@ import './transfer-page.scss';
 
 interface Props {
 	connectionSettings: ConnectionSettings;
-	options: Options;
 };
 
 export const TransferPage = (props: Props) => {

--- a/src/components/pages/welcome/welcome-page.tsx
+++ b/src/components/pages/welcome/welcome-page.tsx
@@ -7,7 +7,6 @@ import { Collections } from '@/utils/collections';
 import { ErrorBoundary } from '@/components/controls/error-boundary/error-boundary';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
-import { Options } from '@/models/options';
 import { PregenData } from '@/data/pregen-data';
 import { PregenInfo } from '@/components/panels/token/token';
 import { PregenLogic } from '@/logic/pregen-logic';
@@ -18,6 +17,7 @@ import { TipData } from '@/data/tip-data';
 import { TipPanel } from '@/components/panels/tip/tip-panel';
 import { useMediaQuery } from '@/hooks/use-media-query';
 import { useNavigation } from '@/hooks/use-navigation';
+import { useOptions } from '@/contexts/data-context';
 import { useState } from 'react';
 
 import './welcome-page.scss';
@@ -26,7 +26,6 @@ type WelcomeType = 'player' | 'director-prep' | 'director-run' | 'creator';
 
 interface Props {
 	sourcebooks: Sourcebook[];
-	options: Options;
 	params: FooterParams;
 	onNewHero: () => void;
 	onPregen: (hero: Hero) => void;
@@ -76,7 +75,6 @@ export const WelcomePage = (props: Props) => {
 							<div className='welcome-column'>
 								<Welcome
 									sourcebooks={props.sourcebooks}
-									options={props.options}
 									onNewHero={props.onNewHero}
 									onPregen={props.onPregen}
 									onNewEncounter={props.onNewEncounter}
@@ -86,7 +84,6 @@ export const WelcomePage = (props: Props) => {
 					</ErrorBoundary>
 					<AppFooter
 						page='welcome'
-						options={props.options}
 						params={props.params}
 					/>
 				</div>
@@ -104,7 +101,6 @@ export const WelcomePage = (props: Props) => {
 					<div className='welcome-column'>
 						<Welcome
 							sourcebooks={props.sourcebooks}
-							options={props.options}
 							onNewHero={props.onNewHero}
 							onPregen={props.onPregen}
 							onNewEncounter={props.onNewEncounter}
@@ -151,7 +147,6 @@ export const WelcomePage = (props: Props) => {
 				</div>
 				<AppFooter
 					page='welcome'
-					options={props.options}
 					params={props.params}
 				/>
 			</div>
@@ -161,7 +156,6 @@ export const WelcomePage = (props: Props) => {
 
 interface WelcomeProps {
 	sourcebooks: Sourcebook[];
-	options: Options;
 	onNewHero: () => void;
 	onPregen: (hero: Hero) => void;
 	onNewEncounter: () => void;
@@ -170,6 +164,7 @@ interface WelcomeProps {
 const Welcome = (props: WelcomeProps) => {
 	const navigation = useNavigation();
 	const [ page, setPage ] = useState<WelcomeType>('player');
+	const options = useOptions();
 
 	const getContent = () => {
 		switch (page) {
@@ -225,7 +220,7 @@ const Welcome = (props: WelcomeProps) => {
 														className='container-button'
 														block={true}
 														onClick={() => {
-															const hero = PregenLogic.pregenToHero(p, props.sourcebooks, props.options);
+															const hero = PregenLogic.pregenToHero(p, props.sourcebooks, options);
 															props.onPregen(hero);
 														}}
 													>

--- a/src/components/panels/app-footer/app-footer.tsx
+++ b/src/components/panels/app-footer/app-footer.tsx
@@ -9,6 +9,7 @@ import { SyncStatus } from '@/components/panels/sync-status/sync-status';
 import shield from '@/assets/shield.png';
 import { useIsSmall } from '@/hooks/use-is-small';
 import { useNavigation } from '@/hooks/use-navigation';
+import { useOptions } from '@/contexts/data-context';
 import { useState } from 'react';
 
 import './app-footer.scss';
@@ -25,7 +26,6 @@ export interface FooterParams {
 
 interface Props {
 	page: 'welcome' | 'heroes' | 'library' | 'session' | 'player-view';
-	options: Options;
 	params: FooterParams;
 }
 
@@ -33,9 +33,10 @@ export const AppFooter = (props: Props) => {
 	const isSmall = useIsSmall();
 	const navigation = useNavigation();
 	const [ showSidebar, setShowSidebar ] = useState<boolean>(false);
+	const options = useOptions();
 
 	const onOK = () => {
-		props.params.setOptions({ ...props.options, cookieConsent: true });
+		props.params.setOptions({ ...options, cookieConsent: true });
 		setShowSidebar(false);
 	};
 
@@ -78,7 +79,7 @@ export const AppFooter = (props: Props) => {
 						</Flex>
 				}
 				{
-					!props.options.cookieConsent ?
+					!options.cookieConsent ?
 						<ButtonGroup
 							buttons={[
 								{ type: 'button', label: 'Cookies', onClick: () => setShowSidebar(true) }

--- a/src/components/panels/app-footer/app-footer.tsx
+++ b/src/components/panels/app-footer/app-footer.tsx
@@ -1,6 +1,7 @@
 import { BookOutlined, DatabaseFilled, InfoCircleOutlined, PlayCircleOutlined, ReadOutlined, SettingOutlined, TeamOutlined, WarningFilled } from '@ant-design/icons';
 import { Button, Divider, Drawer, Flex, Space, Tag } from 'antd';
 import { ButtonConfig, ButtonGroup } from '@/components/controls/button-group/button-group';
+import { useDataManager, useOptions } from '@/contexts/data-context';
 import { ConnectionSettings } from '@/models/connection-settings';
 import { ErrorBoundary } from '@/components/controls/error-boundary/error-boundary';
 import { Modal } from '@/components/modals/modal/modal';
@@ -9,7 +10,6 @@ import { SyncStatus } from '@/components/panels/sync-status/sync-status';
 import shield from '@/assets/shield.png';
 import { useIsSmall } from '@/hooks/use-is-small';
 import { useNavigation } from '@/hooks/use-navigation';
-import { useOptions } from '@/contexts/data-context';
 import { useState } from 'react';
 
 import './app-footer.scss';
@@ -20,7 +20,6 @@ export interface FooterParams {
 	showAbout: () => void;
 	showSettings: () => void;
 	showErrors: () => void;
-	setOptions: (options: Options) => void;
 	connectionSettings: ConnectionSettings;
 }
 
@@ -34,9 +33,13 @@ export const AppFooter = (props: Props) => {
 	const navigation = useNavigation();
 	const [ showSidebar, setShowSidebar ] = useState<boolean>(false);
 	const options = useOptions();
+	const dataManager = useDataManager();
+	const saveOptions = (options: Options) => {
+		dataManager.saveOptions(options);
+	};
 
 	const onOK = () => {
-		props.params.setOptions({ ...options, cookieConsent: true });
+		saveOptions({ ...options, cookieConsent: true });
 		setShowSidebar(false);
 	};
 

--- a/src/components/panels/classic-sheet/class-features-card/class-features-card.tsx
+++ b/src/components/panels/classic-sheet/class-features-card/class-features-card.tsx
@@ -1,16 +1,16 @@
 import { FeatureComponent } from '@/components/panels/classic-sheet/components/feature-component';
 import { HeroSheet } from '@/models/classic-sheets/hero-sheet';
-import { Options } from '@/models/options';
+import { useOptions } from '@/contexts/data-context';
 
 import './class-features-card.scss';
 
 interface Props {
 	character: HeroSheet;
-	options: Options;
 }
 
 export const ClassFeaturesCard = (props: Props) => {
 	const character = props.character;
+	const options = useOptions();
 
 	let moreInRef;
 	if (character.featuresReferenceOther?.find(r => [ character.className, character.subclassName ].includes(r.source))) {
@@ -20,7 +20,7 @@ export const ClassFeaturesCard = (props: Props) => {
 	return (
 		<div className='class-features card'>
 			<h2>Class Features</h2>
-			<div className={`features-container ${props.options.pageOrientation === 'portrait' ? 'two-column' : null}`}>
+			<div className={`features-container ${options.pageOrientation === 'portrait' ? 'two-column' : null}`}>
 				{character.classFeatures?.map(f =>
 					<FeatureComponent
 						key={f.id}

--- a/src/components/panels/classic-sheet/components/recoveries-component.tsx
+++ b/src/components/panels/classic-sheet/components/recoveries-component.tsx
@@ -1,17 +1,17 @@
 import { LabeledTextField } from '@/components/panels/classic-sheet/components/labeled-field';
-import { Options } from '@/models/options';
 import { RecoveriesSheet } from '@/models/classic-sheets/hero-sheet';
+import { useOptions } from '@/contexts/data-context';
 
 import './recoveries-component.scss';
 
 interface Props {
 	recoveries: RecoveriesSheet;
-	options: Options;
 }
 
 export const RecoveriesComponent = (props: Props) => {
 	const recoveries = props.recoveries;
-	const showState = props.options.includePlayState;
+	const options = useOptions();
+	const showState = options.includePlayState;
 
 	return (
 

--- a/src/components/panels/classic-sheet/components/stamina-component.tsx
+++ b/src/components/panels/classic-sheet/components/stamina-component.tsx
@@ -1,17 +1,17 @@
 import { LabeledBooleanField, LabeledTextField } from '@/components/panels/classic-sheet/components/labeled-field';
-import { Options } from '@/models/options';
 import { StaminaSheet } from '@/models/classic-sheets/hero-sheet';
+import { useOptions } from '@/contexts/data-context';
 
 import './stamina-component.scss';
 
 interface Props {
 	stamina: StaminaSheet;
-	options: Options;
 }
 
 export const StaminaComponent = (props: Props) => {
 	const stamina = props.stamina;
-	const showState = props.options.includePlayState;
+	const options = useOptions();
+	const showState = options.includePlayState;
 
 	return (
 		<div className='stamina'>

--- a/src/components/panels/classic-sheet/conditions-card/conditions-card.tsx
+++ b/src/components/panels/classic-sheet/conditions-card/conditions-card.tsx
@@ -2,14 +2,13 @@ import { ConditionEndType, ConditionType } from '@/enums/condition-type';
 import { Condition } from '@/models/condition';
 import { HeroSheet } from '@/models/classic-sheets/hero-sheet';
 import { LabeledBooleanField } from '@/components/panels/classic-sheet/components/labeled-field';
-import { Options } from '@/models/options';
 import { SheetFormatter } from '@/logic/classic-sheet/sheet-formatter';
+import { useOptions } from '@/contexts/data-context';
 
 import './conditions-card.scss';
 
 interface Props {
 	character: HeroSheet;
-	options: Options;
 }
 
 export const ConditionsCard = (props: Props) => {
@@ -26,7 +25,8 @@ export const ConditionsCard = (props: Props) => {
 	];
 
 	const character = props.character;
-	const showState = props.options.includePlayState;
+	const options = useOptions();
+	const showState = options.includePlayState;
 
 	const otherConditions: Condition[] = character.conditions?.filter(c => !conditionTypes.includes(c.type)) || [];
 	if (!otherConditions.length) {

--- a/src/components/panels/classic-sheet/encounter-header/encounter-header.tsx
+++ b/src/components/panels/classic-sheet/encounter-header/encounter-header.tsx
@@ -2,14 +2,12 @@ import { EncounterSheet } from '@/models/classic-sheets/encounter-sheet';
 import { HeaderImage } from '@/components/panels/classic-sheet/header-image/header-image';
 import { LabeledTextField } from '@/components/panels/classic-sheet/components/labeled-field';
 import { Markdown } from '@/components/controls/markdown/markdown';
-import { Options } from '@/models/options';
 import { useMemo } from 'react';
 
 import './encounter-header.scss';
 
 interface Props {
 	encounter: EncounterSheet;
-	options: Options;
 }
 
 export const EncounterHeaderCard = (props: Props) => {

--- a/src/components/panels/classic-sheet/encounter-roster/encounter-roster.tsx
+++ b/src/components/panels/classic-sheet/encounter-roster/encounter-roster.tsx
@@ -2,7 +2,6 @@ import { EncounterSheet } from '@/models/classic-sheets/encounter-sheet';
 import { FormatLogic } from '@/logic/format-logic';
 import { MonsterLogic } from '@/logic/monster-logic';
 import { MonsterOrganizationType } from '@/enums/monster-organization-type';
-import { Options } from '@/models/options';
 import { Sourcebook } from '@/models/sourcebook';
 import { TerrainLogic } from '@/logic/terrain-logic';
 import { useMemo } from 'react';
@@ -12,7 +11,6 @@ import './encounter-roster.scss';
 interface Props {
 	encounter: EncounterSheet;
 	sourcebooks: Sourcebook[];
-	options: Options;
 }
 
 export const EncounterRosterCard = (props: Props) => {

--- a/src/components/panels/classic-sheet/encounter-sheet/encounter-sheet-page.tsx
+++ b/src/components/panels/classic-sheet/encounter-sheet/encounter-sheet-page.tsx
@@ -1,31 +1,30 @@
 import { FillerCard, SheetLayout } from '@/logic/classic-sheet/sheet-layout';
+import { useHeroes, useOptions } from '@/contexts/data-context';
 import { DebugCard } from '@/components/panels/classic-sheet/reference/debug-card';
 import { Encounter } from '@/models/encounter';
 import { EncounterHeaderCard } from '@/components/panels/classic-sheet/encounter-header/encounter-header';
 import { EncounterRosterCard } from '@/components/panels/classic-sheet/encounter-roster/encounter-roster';
 import { EncounterSheetBuilder } from '@/logic/playbook-sheets/encounter-sheet-builder';
-import { Hero } from '@/models/hero';
 import { MaliceCard } from '@/components/panels/classic-sheet/malice-card/malice-card';
 import { MonsterCard } from '@/components/panels/classic-sheet/monster-card/monster-card';
 import { NotesCard } from '@/components/panels/classic-sheet/notes-card/notes-card';
 import { SheetFormatter } from '@/logic/classic-sheet/sheet-formatter';
 import { Sourcebook } from '@/models/sourcebook';
 import { useMemo } from 'react';
-import { useOptions } from '@/contexts/data-context';
 
 import './encounter-sheet-page.scss';
 
 interface Props {
 	encounter: Encounter;
 	sourcebooks: Sourcebook[];
-	heroes: Hero[];
 }
 
 export const EncounterSheetPage = (props: Props) => {
 	const options = useOptions();
+	const heroes = useHeroes();
 	const encounter = useMemo(
-		() => EncounterSheetBuilder.buildEncounterSheet(props.encounter, props.sourcebooks, props.heroes, options),
-		[ props.encounter, props.sourcebooks, props.heroes, options ]
+		() => EncounterSheetBuilder.buildEncounterSheet(props.encounter, props.sourcebooks, heroes, options),
+		[ props.encounter, props.sourcebooks, heroes, options ]
 	);
 
 	const getMonsterCards = () => {

--- a/src/components/panels/classic-sheet/encounter-sheet/encounter-sheet-page.tsx
+++ b/src/components/panels/classic-sheet/encounter-sheet/encounter-sheet-page.tsx
@@ -8,10 +8,10 @@ import { Hero } from '@/models/hero';
 import { MaliceCard } from '@/components/panels/classic-sheet/malice-card/malice-card';
 import { MonsterCard } from '@/components/panels/classic-sheet/monster-card/monster-card';
 import { NotesCard } from '@/components/panels/classic-sheet/notes-card/notes-card';
-import { Options } from '@/models/options';
 import { SheetFormatter } from '@/logic/classic-sheet/sheet-formatter';
 import { Sourcebook } from '@/models/sourcebook';
 import { useMemo } from 'react';
+import { useOptions } from '@/contexts/data-context';
 
 import './encounter-sheet-page.scss';
 
@@ -19,17 +19,17 @@ interface Props {
 	encounter: Encounter;
 	sourcebooks: Sourcebook[];
 	heroes: Hero[];
-	options: Options;
 }
 
 export const EncounterSheetPage = (props: Props) => {
+	const options = useOptions();
 	const encounter = useMemo(
-		() => EncounterSheetBuilder.buildEncounterSheet(props.encounter, props.sourcebooks, props.heroes, props.options),
-		[ props.encounter, props.sourcebooks, props.heroes, props.options ]
+		() => EncounterSheetBuilder.buildEncounterSheet(props.encounter, props.sourcebooks, props.heroes, options),
+		[ props.encounter, props.sourcebooks, props.heroes, options ]
 	);
 
 	const getMonsterCards = () => {
-		const layout = SheetLayout.getFollowerCardsLayout(props.options, true);
+		const layout = SheetLayout.getFollowerCardsLayout(options, true);
 
 		const requiredCards: FillerCard[] = [];
 
@@ -44,9 +44,9 @@ export const EncounterSheetPage = (props: Props) => {
 			});
 		}
 
-		if (props.options.debugClassicSheet) {
+		if (options.debugClassicSheet) {
 			requiredCards.push({
-				element: <DebugCard options={props.options} key='debug' />,
+				element: <DebugCard key='debug' />,
 				width: 1,
 				height: 15,
 				shown: false
@@ -66,7 +66,7 @@ export const EncounterSheetPage = (props: Props) => {
 					}
 				}
 				requiredCards.push({
-					element: <MonsterCard monster={ms} columns={mW} options={props.options} key={ms.id} />,
+					element: <MonsterCard monster={ms} columns={mW} key={ms.id} />,
 					width: mW,
 					height: mH,
 					shown: false
@@ -83,24 +83,24 @@ export const EncounterSheetPage = (props: Props) => {
 		() => {
 			const classes = [
 				'encounter-sheet',
-				props.options.classicSheetPageSize.toLowerCase()
+				options.classicSheetPageSize.toLowerCase()
 			];
-			if (props.options.colorSheet) {
+			if (options.colorSheet) {
 				classes.push('color');
-				classes.push(`colors-${props.options.colorScheme}`);
+				classes.push(`colors-${options.colorScheme}`);
 			}
 			return classes;
 		},
-		[ props.options.classicSheetPageSize, props.options.colorSheet, props.options.colorScheme ]
+		[ options.classicSheetPageSize, options.colorSheet, options.colorScheme ]
 	);
 
 	return (
 		<main id='classic-sheet'>
 			<div className={sheetClasses.join(' ')}>
-				<div className={`page page-1 ${props.options.pageOrientation}`} id={SheetFormatter.getPageId('encounter', encounter.id)}>
-					<EncounterHeaderCard encounter={encounter} options={props.options} />
-					<MaliceCard encounter={encounter} options={props.options} />
-					<EncounterRosterCard encounter={encounter} sourcebooks={props.sourcebooks} options={props.options} />
+				<div className={`page page-1 ${options.pageOrientation}`} id={SheetFormatter.getPageId('encounter', encounter.id)}>
+					<EncounterHeaderCard encounter={encounter} />
+					<MaliceCard encounter={encounter} />
+					<EncounterRosterCard encounter={encounter} sourcebooks={props.sourcebooks} />
 				</div>
 				{getMonsterCards()}
 			</div>

--- a/src/components/panels/classic-sheet/follower-card/companion-card.tsx
+++ b/src/components/panels/classic-sheet/follower-card/companion-card.tsx
@@ -3,7 +3,6 @@ import { AbilitySheet } from '@/models/classic-sheets/ability-sheet';
 import { CharacteristicsComponent } from '@/components/panels/classic-sheet/components/characteristics-component';
 import { FeatureComponent } from '@/components/panels/classic-sheet/components/feature-component';
 import { FollowerSheet } from '@/models/classic-sheets/hero-sheet';
-import { Options } from '@/models/options';
 import { RecoveriesComponent } from '@/components/panels/classic-sheet/components/recoveries-component';
 import { SheetFormatter } from '@/logic/classic-sheet/sheet-formatter';
 import { StaminaComponent } from '@/components/panels/classic-sheet/components/stamina-component';
@@ -16,7 +15,6 @@ import starIcon from '@/assets/icons/star.svg';
 
 interface Props {
 	companion: FollowerSheet;
-	options: Options;
 }
 
 export const CompanionCard = (props: Props) => {
@@ -75,7 +73,6 @@ export const CompanionCard = (props: Props) => {
 						companion.stamina ?
 							<StaminaComponent
 								stamina={companion.stamina}
-								options={props.options}
 							/>
 							: null
 					}
@@ -83,7 +80,6 @@ export const CompanionCard = (props: Props) => {
 						companion.recoveries ?
 							<RecoveriesComponent
 								recoveries={companion.recoveries}
-								options={props.options}
 							/>
 							: null
 					}

--- a/src/components/panels/classic-sheet/follower-card/followers-card.tsx
+++ b/src/components/panels/classic-sheet/follower-card/followers-card.tsx
@@ -1,13 +1,11 @@
 import { CharacteristicsComponent } from '@/components/panels/classic-sheet/components/characteristics-component';
 import { FollowerSheet } from '@/models/classic-sheets/hero-sheet';
-import { Options } from '@/models/options';
 import { useMemo } from 'react';
 
 import './follower-card.scss';
 
 interface Props {
 	followers: FollowerSheet[];
-	options: Options;
 }
 
 export const FollowersCard = (props: Props) => {

--- a/src/components/panels/classic-sheet/hero-header-card/hero-header-card.tsx
+++ b/src/components/panels/classic-sheet/hero-header-card/hero-header-card.tsx
@@ -1,18 +1,18 @@
 import { HeaderImage } from '@/components/panels/classic-sheet/header-image/header-image';
 import { HeroSheet } from '@/models/classic-sheets/hero-sheet';
 import { LabeledTextField } from '@/components/panels/classic-sheet/components/labeled-field';
-import { Options } from '@/models/options';
+import { useOptions } from '@/contexts/data-context';
 
 import './hero-header-card.scss';
 
 interface Props {
 	character: HeroSheet;
-	options: Options;
 }
 
 export const HeroHeaderCard = (props: Props) => {
 	const character = props.character;
-	const showState = props.options.includePlayState;
+	const options = useOptions();
+	const showState = options.includePlayState;
 
 	const currentVictories = (showState && character.currentVictories) || 0;
 	return (

--- a/src/components/panels/classic-sheet/malice-card/malice-card.tsx
+++ b/src/components/panels/classic-sheet/malice-card/malice-card.tsx
@@ -1,13 +1,11 @@
 import { Fragment, useMemo } from 'react';
 import { EncounterSheet } from '@/models/classic-sheets/encounter-sheet';
 import { FeatureComponent } from '@/components/panels/classic-sheet/components/feature-component';
-import { Options } from '@/models/options';
 
 import './malice-card.scss';
 
 interface Props {
 	encounter: EncounterSheet;
-	options: Options;
 }
 
 export const MaliceCard = (props: Props) => {

--- a/src/components/panels/classic-sheet/monster-card/monster-card.tsx
+++ b/src/components/panels/classic-sheet/monster-card/monster-card.tsx
@@ -3,7 +3,6 @@ import { AbilitySheet } from '@/models/classic-sheets/ability-sheet';
 import { CharacteristicsComponent } from '@/components/panels/classic-sheet/components/characteristics-component';
 import { FeatureComponent } from '@/components/panels/classic-sheet/components/feature-component';
 import { MonsterSheet } from '@/models/classic-sheets/monster-sheet';
-import { Options } from '@/models/options';
 import { SheetFormatter } from '@/logic/classic-sheet/sheet-formatter';
 import { Utils } from '@/utils/utils';
 import { useMemo } from 'react';
@@ -14,7 +13,6 @@ import starIcon from '@/assets/icons/star.svg';
 
 interface Props {
 	monster: MonsterSheet;
-	options: Options;
 	columns?: number;
 }
 

--- a/src/components/panels/classic-sheet/montage-sheet/montage-challenges.tsx
+++ b/src/components/panels/classic-sheet/montage-sheet/montage-challenges.tsx
@@ -1,14 +1,12 @@
 import { LabeledBooleanField } from '@/components/panels/classic-sheet/components/labeled-field';
 import { Markdown } from '@/components/controls/markdown/markdown';
 import { MontageSheet } from '@/models/classic-sheets/montage-sheet';
-import { Options } from '@/models/options';
 import { useMemo } from 'react';
 
 import './montage-challenges.scss';
 
 interface Props {
 	montage: MontageSheet;
-	options: Options;
 }
 
 export const MontageChallengesCard = (props: Props) => {

--- a/src/components/panels/classic-sheet/montage-sheet/montage-header.tsx
+++ b/src/components/panels/classic-sheet/montage-sheet/montage-header.tsx
@@ -1,14 +1,12 @@
 import { HeaderImage } from '@/components/panels/classic-sheet/header-image/header-image';
 import { LabeledTextField } from '@/components/panels/classic-sheet/components/labeled-field';
 import { MontageSheet } from '@/models/classic-sheets/montage-sheet';
-import { Options } from '@/models/options';
 import { useMemo } from 'react';
 
 import './montage-header.scss';
 
 interface Props {
 	montage: MontageSheet;
-	options: Options;
 }
 
 export const MontageHeaderCard = (props: Props) => {

--- a/src/components/panels/classic-sheet/montage-sheet/montage-sheet-page.tsx
+++ b/src/components/panels/classic-sheet/montage-sheet/montage-sheet-page.tsx
@@ -1,4 +1,4 @@
-import { Hero } from '@/models/hero';
+import { useHeroes, useOptions } from '@/contexts/data-context';
 import { Montage } from '@/models/montage';
 import { MontageChallengesCard } from '@/components/panels/classic-sheet/montage-sheet/montage-challenges';
 import { MontageHeaderCard } from '@/components/panels/classic-sheet/montage-sheet/montage-header';
@@ -6,7 +6,6 @@ import { MontageSheetBuilder } from '@/logic/playbook-sheets/montage-sheet-build
 import { SheetFormatter } from '@/logic/classic-sheet/sheet-formatter';
 import { SuccessFailureTrackerCard } from '@/components/panels/classic-sheet/montage-sheet/success-failure-tracker';
 import { useMemo } from 'react';
-import { useOptions } from '@/contexts/data-context';
 
 import rollT1Icon from '@/assets/icons/power-roll-t1.svg';
 import rollT2Icon from '@/assets/icons/power-roll-t2.svg';
@@ -16,14 +15,14 @@ import './montage-sheet-page.scss';
 
 interface Props {
 	montage: Montage;
-	heroes: Hero[];
 }
 
 export const MontageSheetPage = (props: Props) => {
 	const options = useOptions();
+	const heroes = useHeroes();
 	const montage = useMemo(
-		() => MontageSheetBuilder.buildMontageSheet(props.montage, props.heroes, options),
-		[ props.montage, props.heroes, options ]
+		() => MontageSheetBuilder.buildMontageSheet(props.montage, heroes, options),
+		[ props.montage, heroes, options ]
 	);
 
 	const sheetClasses = useMemo(

--- a/src/components/panels/classic-sheet/montage-sheet/montage-sheet-page.tsx
+++ b/src/components/panels/classic-sheet/montage-sheet/montage-sheet-page.tsx
@@ -3,10 +3,10 @@ import { Montage } from '@/models/montage';
 import { MontageChallengesCard } from '@/components/panels/classic-sheet/montage-sheet/montage-challenges';
 import { MontageHeaderCard } from '@/components/panels/classic-sheet/montage-sheet/montage-header';
 import { MontageSheetBuilder } from '@/logic/playbook-sheets/montage-sheet-builder';
-import { Options } from '@/models/options';
 import { SheetFormatter } from '@/logic/classic-sheet/sheet-formatter';
 import { SuccessFailureTrackerCard } from '@/components/panels/classic-sheet/montage-sheet/success-failure-tracker';
 import { useMemo } from 'react';
+import { useOptions } from '@/contexts/data-context';
 
 import rollT1Icon from '@/assets/icons/power-roll-t1.svg';
 import rollT2Icon from '@/assets/icons/power-roll-t2.svg';
@@ -17,35 +17,35 @@ import './montage-sheet-page.scss';
 interface Props {
 	montage: Montage;
 	heroes: Hero[];
-	options: Options;
 }
 
 export const MontageSheetPage = (props: Props) => {
+	const options = useOptions();
 	const montage = useMemo(
-		() => MontageSheetBuilder.buildMontageSheet(props.montage, props.heroes, props.options),
-		[ props.montage, props.heroes, props.options ]
+		() => MontageSheetBuilder.buildMontageSheet(props.montage, props.heroes, options),
+		[ props.montage, props.heroes, options ]
 	);
 
 	const sheetClasses = useMemo(
 		() => {
 			const classes = [
 				'montage-sheet',
-				props.options.classicSheetPageSize.toLowerCase()
+				options.classicSheetPageSize.toLowerCase()
 			];
-			if (props.options.colorSheet) {
+			if (options.colorSheet) {
 				classes.push('color');
-				classes.push(`colors-${props.options.colorScheme}`);
+				classes.push(`colors-${options.colorScheme}`);
 			}
 			return classes;
 		},
-		[ props.options.classicSheetPageSize, props.options.colorSheet, props.options.colorScheme ]
+		[ options.classicSheetPageSize, options.colorSheet, options.colorScheme ]
 	);
 
 	return (
 		<main id='classic-sheet'>
 			<div className={sheetClasses.join(' ')}>
-				<div className={`page page-1 ${props.options.pageOrientation}`} id={SheetFormatter.getPageId('montage', montage.id)}>
-					<MontageHeaderCard montage={montage} options={props.options} />
+				<div className={`page page-1 ${options.pageOrientation}`} id={SheetFormatter.getPageId('montage', montage.id)}>
+					<MontageHeaderCard montage={montage} />
 
 					<div className='tests-difficulty card'>
 						<h2>Test Difficulty</h2>
@@ -109,9 +109,9 @@ export const MontageSheetPage = (props: Props) => {
 						</div>
 					</div>
 
-					<SuccessFailureTrackerCard montage={montage} options={props.options} />
+					<SuccessFailureTrackerCard montage={montage} />
 
-					<MontageChallengesCard montage={montage} options={props.options} />
+					<MontageChallengesCard montage={montage} />
 				</div>
 			</div>
 		</main>

--- a/src/components/panels/classic-sheet/montage-sheet/success-failure-tracker.tsx
+++ b/src/components/panels/classic-sheet/montage-sheet/success-failure-tracker.tsx
@@ -1,13 +1,11 @@
 import { LabeledTextField } from '@/components/panels/classic-sheet/components/labeled-field';
 import { MontageSheet } from '@/models/classic-sheets/montage-sheet';
-import { Options } from '@/models/options';
 import { useMemo } from 'react';
 
 import './success-failure-tracker.scss';
 
 interface Props {
 	montage: MontageSheet;
-	options: Options;
 }
 
 export const SuccessFailureTrackerCard = (props: Props) => {

--- a/src/components/panels/classic-sheet/negotiation-sheet/negotiation-sheet-page.tsx
+++ b/src/components/panels/classic-sheet/negotiation-sheet/negotiation-sheet-page.tsx
@@ -4,16 +4,15 @@ import { NegotiationHeaderCard } from '@/components/panels/classic-sheet/negotia
 import { NegotiationNpcCard } from '@/components/panels/classic-sheet/negotiation-sheet/negotiation-npc-card';
 import { NegotiationResponsesCard } from '@/components/panels/classic-sheet/negotiation-sheet/negotiation-responses-card';
 import { NegotiationSheetBuilder } from '@/logic/playbook-sheets/negotiation-sheet-builder';
-import { Options } from '@/models/options';
 import { PatienceInterestCard } from '@/components/panels/classic-sheet/negotiation-sheet/patience-interest-card';
 import { SheetFormatter } from '@/logic/classic-sheet/sheet-formatter';
 import { useMemo } from 'react';
+import { useOptions } from '@/contexts/data-context';
 
 import './negotiation-sheet-page.scss';
 
 interface Props {
 	negotiation: Negotiation;
-	options: Options;
 }
 
 export const NegotiationSheetPage = (props: Props) => {
@@ -22,25 +21,27 @@ export const NegotiationSheetPage = (props: Props) => {
 		[ props.negotiation ]
 	);
 
+	const options = useOptions();
+
 	const sheetClasses = useMemo(
 		() => {
 			const classes = [
 				'negotiation-sheet',
-				props.options.classicSheetPageSize.toLowerCase()
+				options.classicSheetPageSize.toLowerCase()
 			];
-			if (props.options.colorSheet) {
+			if (options.colorSheet) {
 				classes.push('color');
-				classes.push(`colors-${props.options.colorScheme}`);
+				classes.push(`colors-${options.colorScheme}`);
 			}
 			return classes;
 		},
-		[ props.options.classicSheetPageSize, props.options.colorSheet, props.options.colorScheme ]
+		[ options.classicSheetPageSize, options.colorSheet, options.colorScheme ]
 	);
 
 	return (
 		<main id='classic-sheet'>
 			<div className={sheetClasses.join(' ')}>
-				<div className={`page page-1 ${props.options.pageOrientation}`} id={SheetFormatter.getPageId('negotiation', negotiation.id)}>
+				<div className={`page page-1 ${options.pageOrientation}`} id={SheetFormatter.getPageId('negotiation', negotiation.id)}>
 					<NegotiationHeaderCard negotiation={negotiation} />
 					<PatienceInterestCard negotiation={negotiation} />
 					<NegotiationNpcCard negotiation={negotiation} />

--- a/src/components/panels/classic-sheet/reference/debug-card.tsx
+++ b/src/components/panels/classic-sheet/reference/debug-card.tsx
@@ -1,15 +1,13 @@
-import { Options } from '@/models/options';
+import { useOptions } from '@/contexts/data-context';
+
 import './debug-card.scss';
 
-interface Props {
-	options: Options;
-}
-
-export const DebugCard = (props: Props) => {
+export const DebugCard = () => {
 	const userAgent = navigator.userAgent || 'unknown';
 	const dpr = window.devicePixelRatio || 'unknown';
 	const width = window.screen.width || 'unknown';
 	const height = window.screen.height || 'unknown';
+	const options = useOptions();
 
 	return (
 		<div className='debug card'>
@@ -29,7 +27,7 @@ export const DebugCard = (props: Props) => {
 				</div>
 				<div className='data'>
 					<label>Page Options</label>
-					<div>{props.options.classicSheetPageSize} / {props.options.pageOrientation}</div>
+					<div>{options.classicSheetPageSize} / {options.pageOrientation}</div>
 				</div>
 			</div>
 		</div>

--- a/src/components/panels/classic-sheet/reference/primary-reference-card.tsx
+++ b/src/components/panels/classic-sheet/reference/primary-reference-card.tsx
@@ -1,14 +1,12 @@
 import { Fragment, useMemo } from 'react';
-
 import { HeroSheet } from '@/models/classic-sheets/hero-sheet';
-import { Options } from '@/models/options';
 import { SheetPageSize } from '@/enums/sheet-page-size';
+import { useOptions } from '@/contexts/data-context';
 
 import './primary-reference-card.scss';
 
 interface Props {
 	character: HeroSheet;
-	options: Options;
 }
 
 export const PrimaryReferenceCard = (props: Props) => {
@@ -16,9 +14,10 @@ export const PrimaryReferenceCard = (props: Props) => {
 		() => props.character,
 		[ props.character ]
 	);
+	const options = useOptions();
 
-	const showTriggerHelp = props.options.classicSheetPageSize === SheetPageSize.A4 &&
-		props.options.pageOrientation === 'portrait' &&
+	const showTriggerHelp = options.classicSheetPageSize === SheetPageSize.A4 &&
+		options.pageOrientation === 'portrait' &&
 		(props.character.heroicResourceGains || []).length < 3;
 
 	const showActionsManeuversReference = (props.character.heroicResourceGains || []).length <= 3;

--- a/src/components/panels/classic-sheet/stats-resources-card/stats-resources-card.tsx
+++ b/src/components/panels/classic-sheet/stats-resources-card/stats-resources-card.tsx
@@ -1,20 +1,20 @@
 import { HeroSheet } from '@/models/classic-sheets/hero-sheet';
 import { LabeledTextField } from '@/components/panels/classic-sheet/components/labeled-field';
-import { Options } from '@/models/options';
 import { RecoveriesComponent } from '@/components/panels/classic-sheet/components/recoveries-component';
 import { StaminaComponent } from '@/components/panels/classic-sheet/components/stamina-component';
 import { Utils } from '@/utils/utils';
+import { useOptions } from '@/contexts/data-context';
 
 import './stats-resources-card.scss';
 
 interface Props {
 	character: HeroSheet;
-	options: Options;
 }
 
 export const StatsResourcesCard = (props: Props) => {
 	const character = props.character;
-	const showState = props.options.includePlayState;
+	const options = useOptions();
+	const showState = options.includePlayState;
 
 	return (
 		<div className='stats-resources card'>
@@ -62,11 +62,9 @@ export const StatsResourcesCard = (props: Props) => {
 			</div>
 			<StaminaComponent
 				stamina={character.stamina}
-				options={props.options}
 			/>
 			<RecoveriesComponent
 				recoveries={character.recoveries}
-				options={props.options}
 			/>
 			<div className='heroic-resource'>
 				<LabeledTextField

--- a/src/components/panels/data-loader/data-loader.tsx
+++ b/src/components/panels/data-loader/data-loader.tsx
@@ -23,6 +23,7 @@ import { SourcebookLogic } from '@/logic/sourcebook-logic';
 import { SourcebookUpdateLogic } from '@/logic/update/sourcebook-update-logic';
 import { StorageServiceFactory } from '@/services/storage/storage-service-factory';
 import localforage from 'localforage';
+import { useIsSmall } from '@/hooks/use-is-small';
 
 import './data-loader.scss';
 
@@ -214,6 +215,10 @@ export const DataLoader = (props: Props) => {
 
 					const options = results[4] as Options;
 					OptionsUpdateLogic.updateOptions(options);
+					const isSmall = useIsSmall();
+					if (isSmall) {
+						options.compactView = true;
+					}
 
 					setOverallLoadState('success');
 

--- a/src/components/panels/data-loader/data-loader.tsx
+++ b/src/components/panels/data-loader/data-loader.tsx
@@ -55,6 +55,7 @@ export const DataLoader = (props: Props) => {
 	const [ connectionSettings, setConnectionSettings ] = useState<ConnectionSettings | null>(null);
 	const [ dataSource, setDataSource ] = useState<FSDataSource>(undefined);
 	const [ error, setError ] = useState<string | null>(null);
+	const isSmall = useIsSmall();
 
 	async function initializeConnectionSettings() {
 		let settings = await localforage.getItem<ConnectionSettings>('forgesteel-connection-settings');
@@ -215,7 +216,6 @@ export const DataLoader = (props: Props) => {
 
 					const options = results[4] as Options;
 					OptionsUpdateLogic.updateOptions(options);
-					const isSmall = useIsSmall();
 					if (isSmall) {
 						options.compactView = true;
 					}

--- a/src/components/panels/edit/adventure-edit/adventure-edit-panel.tsx
+++ b/src/components/panels/edit/adventure-edit/adventure-edit-panel.tsx
@@ -10,7 +10,6 @@ import { ErrorBoundary } from '@/components/controls/error-boundary/error-bounda
 import { Expander } from '@/components/controls/expander/expander';
 import { FactoryLogic } from '@/logic/factory-logic';
 import { HeaderText } from '@/components/controls/header-text/header-text';
-import { Hero } from '@/models/hero';
 import { NameDescEditPanel } from '@/components/panels/edit/name-desc-edit/name-desc-edit-panel';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
 import { Plot } from '@/models/plot';
@@ -26,7 +25,6 @@ import './adventure-edit-panel.scss';
 interface Props {
 	adventure: Adventure;
 	sourcebooks: Sourcebook[];
-	heroes: Hero[];
 	onChange: (adventure: Adventure) => void;
 }
 
@@ -309,7 +307,6 @@ export const AdventureEditPanel = (props: Props) => {
 				plot={plot}
 				adventure={adventure}
 				sourcebooks={props.sourcebooks}
-				heroes={props.heroes}
 				onChange={changePlotPoint}
 				onAddAfter={addPlotPoint}
 				onDelete={deletePlotPoint}

--- a/src/components/panels/edit/adventure-edit/adventure-edit-panel.tsx
+++ b/src/components/panels/edit/adventure-edit/adventure-edit-panel.tsx
@@ -13,7 +13,6 @@ import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { NameDescEditPanel } from '@/components/panels/edit/name-desc-edit/name-desc-edit-panel';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { Plot } from '@/models/plot';
 import { PlotEditPanel } from '@/components/panels/edit/plot-edit/plot-edit-panel';
 import { PlotGraphPanel } from '@/components/panels/plot-graph/plot-graph-panel';
@@ -28,7 +27,6 @@ interface Props {
 	adventure: Adventure;
 	sourcebooks: Sourcebook[];
 	heroes: Hero[];
-	options: Options;
 	onChange: (adventure: Adventure) => void;
 }
 
@@ -312,7 +310,6 @@ export const AdventureEditPanel = (props: Props) => {
 				adventure={adventure}
 				sourcebooks={props.sourcebooks}
 				heroes={props.heroes}
-				options={props.options}
 				onChange={changePlotPoint}
 				onAddAfter={addPlotPoint}
 				onDelete={deletePlotPoint}

--- a/src/components/panels/edit/ancestry-edit/ancestry-edit-panel.tsx
+++ b/src/components/panels/edit/ancestry-edit/ancestry-edit-panel.tsx
@@ -19,7 +19,6 @@ import { FeaturePanel } from '@/components/panels/elements/feature-panel/feature
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { NameDescEditPanel } from '@/components/panels/edit/name-desc-edit/name-desc-edit-panel';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { SearchBox } from '@/components/controls/text-input/text-input';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
@@ -34,7 +33,6 @@ import './ancestry-edit-panel.scss';
 interface Props {
 	ancestry: Ancestry;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	mode?: PanelMode;
 	onChange: (ancestry: Ancestry) => void;
 }
@@ -125,7 +123,6 @@ export const AncestryEditPanel = (props: Props) => {
 							<FeatureEditPanel
 								feature={f}
 								sourcebooks={props.sourcebooks}
-								options={props.options}
 								onChange={changeFeature}
 							/>
 						</Expander>
@@ -234,7 +231,6 @@ export const AncestryEditPanel = (props: Props) => {
 							<FeatureEditPanel
 								feature={f.feature}
 								sourcebooks={props.sourcebooks}
-								options={props.options}
 								onChange={x => changeFeature({ feature: x, value: f.value })}
 							/>
 						</Expander>
@@ -270,7 +266,7 @@ export const AncestryEditPanel = (props: Props) => {
 				<Toggle label='Include a culture' value={!!ancestry.culture} onChange={setHasCulture} />
 				{
 					ancestry.culture ?
-						<CultureEditPanel culture={ancestry.culture} sourcebooks={props.sourcebooks} options={props.options} onChange={setCulture} />
+						<CultureEditPanel culture={ancestry.culture} sourcebooks={props.sourcebooks} onChange={setCulture} />
 						: null
 				}
 			</Space>
@@ -350,7 +346,6 @@ export const AncestryEditPanel = (props: Props) => {
 									feature={f.feature}
 									cost={f.value || 'signature'}
 									sourcebooks={props.sourcebooks}
-									options={props.options}
 									mode={PanelMode.Full}
 								/>
 							</SelectablePanel>
@@ -402,7 +397,6 @@ export const AncestryEditPanel = (props: Props) => {
 												<AncestryPanel
 													ancestry={ancestry}
 													sourcebooks={props.sourcebooks}
-													options={props.options}
 													mode={PanelMode.Full}
 												/>
 											</SelectablePanel>

--- a/src/components/panels/edit/career-edit/career-edit-panel.tsx
+++ b/src/components/panels/edit/career-edit/career-edit-panel.tsx
@@ -13,7 +13,6 @@ import { Feature } from '@/models/feature';
 import { FeatureListEditPanel } from '@/components/panels/edit/feature-list-edit/feature-list-edit-panel';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { NameDescEditPanel } from '@/components/panels/edit/name-desc-edit/name-desc-edit-panel';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
 import { Sourcebook } from '@/models/sourcebook';
@@ -25,7 +24,6 @@ import './career-edit-panel.scss';
 interface Props {
 	career: Career;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	mode?: PanelMode;
 	onChange: (career: Career) => void;
 }
@@ -63,7 +61,6 @@ export const CareerEditPanel = (props: Props) => {
 				title='Features'
 				features={career.features}
 				sourcebooks={props.sourcebooks}
-				options={props.options}
 				onChange={onChange}
 			/>
 		);
@@ -179,7 +176,6 @@ export const CareerEditPanel = (props: Props) => {
 												<CareerPanel
 													career={career}
 													sourcebooks={props.sourcebooks}
-													options={props.options}
 													mode={PanelMode.Full}
 												/>
 											</SelectablePanel>

--- a/src/components/panels/edit/class-edit/class-edit-panel.tsx
+++ b/src/components/panels/edit/class-edit/class-edit-panel.tsx
@@ -17,7 +17,6 @@ import { HeroClass } from '@/models/class';
 import { Modal } from '@/components/modals/modal/modal';
 import { NameDescEditPanel } from '@/components/panels/edit/name-desc-edit/name-desc-edit-panel';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
 import { Sourcebook } from '@/models/sourcebook';
@@ -34,7 +33,6 @@ import './class-edit-panel.scss';
 interface Props {
 	heroClass: HeroClass;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	mode?: PanelMode;
 	onChange: (heroClass: HeroClass) => void;
 }
@@ -214,7 +212,6 @@ export const ClassEditPanel = (props: Props) => {
 							title={`Level ${lvl.level}`}
 							features={lvl.features}
 							sourcebooks={props.sourcebooks}
-							options={props.options}
 							onChange={features => onChange(lvl.level, features)}
 						/>
 					))
@@ -392,7 +389,7 @@ export const ClassEditPanel = (props: Props) => {
 									<DangerButton key='delete' mode='clear' onConfirm={e => { e.stopPropagation(); deleteSubclass(sc); }} />
 								]}
 							>
-								<SubclassPanel subclass={sc} sourcebooks={props.sourcebooks} options={props.options} />
+								<SubclassPanel subclass={sc} sourcebooks={props.sourcebooks} />
 							</Expander>
 						))
 					}
@@ -417,7 +414,7 @@ export const ClassEditPanel = (props: Props) => {
 													setDrawerOpen(false);
 												}}
 											>
-												<SubclassPanel subclass={sc} sourcebooks={props.sourcebooks} options={props.options} />
+												<SubclassPanel subclass={sc} sourcebooks={props.sourcebooks} />
 											</SelectablePanel>
 										))
 									}
@@ -489,7 +486,6 @@ export const ClassEditPanel = (props: Props) => {
 														<ClassPanel
 															heroClass={heroClass}
 															sourcebooks={props.sourcebooks}
-															options={props.options}
 															mode={PanelMode.Full}
 														/>
 													</SelectablePanel>
@@ -506,7 +502,6 @@ export const ClassEditPanel = (props: Props) => {
 						key={subclassID}
 						subClass={heroClass.subclasses.find(sc => sc.id === subclassID) as SubClass}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 						mode={PanelMode.Full}
 						onChange={sc => {
 							const copy = Utils.copy(heroClass);

--- a/src/components/panels/edit/complication-edit/complication-edit-panel.tsx
+++ b/src/components/panels/edit/complication-edit/complication-edit-panel.tsx
@@ -4,7 +4,6 @@ import { ErrorBoundary } from '@/components/controls/error-boundary/error-bounda
 import { Feature } from '@/models/feature';
 import { FeatureListEditPanel } from '@/components/panels/edit/feature-list-edit/feature-list-edit-panel';
 import { NameDescEditPanel } from '@/components/panels/edit/name-desc-edit/name-desc-edit-panel';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
 import { Sourcebook } from '@/models/sourcebook';
@@ -17,7 +16,6 @@ import './complication-edit-panel.scss';
 interface Props {
 	complication: Complication;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	mode?: PanelMode;
 	onChange: (complication: Complication) => void;
 }
@@ -55,7 +53,6 @@ export const ComplicationEditPanel = (props: Props) => {
 				title='Features'
 				features={complication.features}
 				sourcebooks={props.sourcebooks}
-				options={props.options}
 				onChange={onChange}
 			/>
 		);
@@ -93,7 +90,6 @@ export const ComplicationEditPanel = (props: Props) => {
 												<ComplicationPanel
 													complication={complication}
 													sourcebooks={props.sourcebooks}
-													options={props.options}
 													mode={PanelMode.Full}
 												/>
 											</SelectablePanel>

--- a/src/components/panels/edit/culture-edit/culture-edit-panel.tsx
+++ b/src/components/panels/edit/culture-edit/culture-edit-panel.tsx
@@ -6,7 +6,6 @@ import { CultureType } from '@/enums/culture-type';
 import { ErrorBoundary } from '@/components/controls/error-boundary/error-boundary';
 import { Field } from '@/components/controls/field/field';
 import { NameDescEditPanel } from '@/components/panels/edit/name-desc-edit/name-desc-edit-panel';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
 import { Sourcebook } from '@/models/sourcebook';
@@ -19,7 +18,6 @@ import './culture-edit-panel.scss';
 interface Props {
 	culture: Culture;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	mode?: PanelMode;
 	onChange: (culture: Culture) => void;
 }
@@ -156,7 +154,6 @@ export const CultureEditPanel = (props: Props) => {
 												<CulturePanel
 													culture={culture}
 													sourcebooks={props.sourcebooks}
-													options={props.options}
 													mode={PanelMode.Full}
 												/>
 											</SelectablePanel>

--- a/src/components/panels/edit/domain-edit/domain-edit-panel.tsx
+++ b/src/components/panels/edit/domain-edit/domain-edit-panel.tsx
@@ -9,7 +9,6 @@ import { Feature } from '@/models/feature';
 import { FeatureListEditPanel } from '@/components/panels/edit/feature-list-edit/feature-list-edit-panel';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { NameDescEditPanel } from '@/components/panels/edit/name-desc-edit/name-desc-edit-panel';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { PlusOutlined } from '@ant-design/icons';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
@@ -23,7 +22,6 @@ import './domain-edit-panel.scss';
 interface Props {
 	domain: Domain;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	mode?: PanelMode;
 	onChange: (domain: Domain) => void;
 }
@@ -67,7 +65,6 @@ export const DomainEditPanel = (props: Props) => {
 							title={`Level ${lvl.level}`}
 							features={lvl.features}
 							sourcebooks={props.sourcebooks}
-							options={props.options}
 							onChange={features => onChange(lvl.level, features)}
 						/>
 					))
@@ -198,7 +195,6 @@ export const DomainEditPanel = (props: Props) => {
 				title='Features'
 				features={domain.defaultFeatures}
 				sourcebooks={props.sourcebooks}
-				options={props.options}
 				onChange={onChange}
 			/>
 		);
@@ -246,7 +242,6 @@ export const DomainEditPanel = (props: Props) => {
 												<DomainPanel
 													domain={domain}
 													sourcebooks={props.sourcebooks}
-													options={props.options}
 													mode={PanelMode.Full}
 												/>
 											</SelectablePanel>

--- a/src/components/panels/edit/encounter-edit/encounter-edit-panel.tsx
+++ b/src/components/panels/edit/encounter-edit/encounter-edit-panel.tsx
@@ -30,7 +30,6 @@ import { MonsterLogic } from '@/logic/monster-logic';
 import { MonsterOrganizationType } from '@/enums/monster-organization-type';
 import { NameDescEditPanel } from '@/components/panels/edit/name-desc-edit/name-desc-edit-panel';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Pill } from '@/components/controls/pill/pill';
 import { Sourcebook } from '@/models/sourcebook';
@@ -41,6 +40,7 @@ import { TerrainLogic } from '@/logic/terrain-logic';
 import { TextInput } from '@/components/controls/text-input/text-input';
 import { Toggle } from '@/components/controls/toggle/toggle';
 import { Utils } from '@/utils/utils';
+import { useOptions } from '@/contexts/data-context';
 
 import './encounter-edit-panel.scss';
 
@@ -48,7 +48,6 @@ interface Props {
 	encounter: Encounter;
 	heroes: Hero[];
 	sourcebooks: Sourcebook[];
-	options: Options;
 	onChange: (encounter: Encounter) => void;
 	showMonster: (monster: Monster, monsterGroup: MonsterGroup) => void;
 	showTerrain: (terrain: Terrain, upgradeIDs: string[]) => void;
@@ -63,6 +62,7 @@ export const EncounterEditPanel = (props: Props) => {
 	const [ terrainFilter, setTerrainFilter ] = useState<TerrainFilter>(FactoryLogic.createTerrainFilter());
 	const [ draggedMonster, setDraggedMonster ] = useState<Monster | null>(null);
 	const [ draggedTerrain, setDraggedTerrain ] = useState<Terrain | null>(null);
+	const options = useOptions();
 
 	const switchLeftTab = (key: string) => {
 		setActiveLeftTabKey(key);
@@ -300,7 +300,6 @@ export const EncounterEditPanel = (props: Props) => {
 					group={group}
 					encounter={encounter}
 					sourcebooks={props.sourcebooks}
-					options={props.options}
 					showMonster={props.showMonster}
 					setSlotCount={setSlotCount}
 					moveSlot={moveSlot}
@@ -343,7 +342,6 @@ export const EncounterEditPanel = (props: Props) => {
 							group={group}
 							index={n}
 							sourcebooks={props.sourcebooks}
-							options={props.options}
 							draggedMonster={draggedMonster}
 							setName={setName}
 							copyGroup={copyGroup}
@@ -698,7 +696,7 @@ ${value.victories}`
 
 	const getDifficultySection = () => {
 		const strength = EncounterDifficultyLogic.getStrength(encounter, props.sourcebooks);
-		const difficulty = EncounterDifficultyLogic.getDifficulty(strength, props.options, props.heroes);
+		const difficulty = EncounterDifficultyLogic.getDifficulty(strength, options, props.heroes);
 
 		return (
 			<Expander title='Difficulty' tags={[ difficulty ]} style={{ flex: '0 0 auto' }}>
@@ -706,7 +704,6 @@ ${value.victories}`
 					encounter={encounter}
 					sourcebooks={props.sourcebooks}
 					heroes={props.heroes}
-					options={props.options}
 				/>
 			</Expander>
 		);
@@ -844,7 +841,6 @@ interface GroupPanelProps {
 	group: EncounterGroup;
 	index: number;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	draggedMonster: Monster | null;
 	setName: (group: EncounterGroup, value: string) => void;
 	copyGroup: (group: EncounterGroup) => void;
@@ -854,6 +850,7 @@ interface GroupPanelProps {
 
 const GroupPanel = (props: GroupPanelProps) => {
 	const [ editing, setEditing ] = useState<boolean>(false);
+	const options = useOptions();
 
 	return (
 		<ErrorBoundary>
@@ -886,7 +883,7 @@ const GroupPanel = (props: GroupPanelProps) => {
 					getSlot={props.getSlot}
 				/>
 				{
-					(props.group.slots.length > 0) && (EncounterDifficultyLogic.getGroupStrength(props.group, props.sourcebooks) < EncounterDifficultyLogic.getHeroValue(props.options.heroLevel)) ?
+					(props.group.slots.length > 0) && (EncounterDifficultyLogic.getGroupStrength(props.group, props.sourcebooks) < EncounterDifficultyLogic.getHeroValue(options.heroLevel)) ?
 						<Alert
 							type='warning'
 							showIcon={true}
@@ -895,7 +892,7 @@ const GroupPanel = (props: GroupPanelProps) => {
 						: null
 				}
 				{
-					(props.group.slots.length > 0) && (EncounterDifficultyLogic.getGroupStrength(props.group, props.sourcebooks) > (EncounterDifficultyLogic.getHeroValue(props.options.heroLevel) * 2)) ?
+					(props.group.slots.length > 0) && (EncounterDifficultyLogic.getGroupStrength(props.group, props.sourcebooks) > (EncounterDifficultyLogic.getHeroValue(options.heroLevel) * 2)) ?
 						<Alert
 							type='warning'
 							showIcon={true}
@@ -991,7 +988,6 @@ interface MonsterSlotPanelProps {
 	group: EncounterGroup;
 	encounter: Encounter;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	showMonster: (monster: Monster, group: MonsterGroup) => void;
 	setSlotCount: (groupID: string, slotID: string, value: number) => void;
 	moveSlot: (slotID: string, fromGroupID: string, toGroupID: string, remove: boolean) => void;
@@ -1037,7 +1033,7 @@ const MonsterSlotPanel = (props: MonsterSlotPanelProps) => {
 									placeholder='Select'
 									mode='multiple'
 									options={Collections.sort(monsterGroup.addOns, a => a.name).map(a => ({ value: a.id, label: a.name, feature: a, cost: a.data.cost }))}
-									optionRender={option => <FeaturePanel feature={option.data.feature} options={props.options} cost={option.data.cost} mode={PanelMode.Full} />}
+									optionRender={option => <FeaturePanel feature={option.data.feature} cost={option.data.cost} mode={PanelMode.Full} />}
 									value={props.slot.customization.addOnIDs}
 									onChange={ids => props.setSlotAddOnIDs(props.group.id, props.slot.id, ids)}
 								/>

--- a/src/components/panels/edit/encounter-edit/encounter-edit-panel.tsx
+++ b/src/components/panels/edit/encounter-edit/encounter-edit-panel.tsx
@@ -5,6 +5,7 @@ import { Encounter, EncounterGroup, EncounterObjective, TerrainSlot } from '@/mo
 import { Fragment, ReactNode, useState } from 'react';
 import { MonsterFilter, TerrainFilter } from '@/models/filter';
 import { MonsterInfo, TerrainInfo } from '@/components/panels/token/token';
+import { useHeroes, useOptions } from '@/contexts/data-context';
 import { Collections } from '@/utils/collections';
 import { DangerButton } from '@/components/controls/danger-button/danger-button';
 import { DropdownButton } from '@/components/controls/dropdown-button/dropdown-button';
@@ -22,7 +23,6 @@ import { FactoryLogic } from '@/logic/factory-logic';
 import { FeaturePanel } from '@/components/panels/elements/feature-panel/feature-panel';
 import { Field } from '@/components/controls/field/field';
 import { HeaderText } from '@/components/controls/header-text/header-text';
-import { Hero } from '@/models/hero';
 import { Monster } from '@/models/monster';
 import { MonsterFilterPanel } from '@/components/panels/monster-filter/monster-filter-panel';
 import { MonsterGroup } from '@/models/monster-group';
@@ -40,13 +40,11 @@ import { TerrainLogic } from '@/logic/terrain-logic';
 import { TextInput } from '@/components/controls/text-input/text-input';
 import { Toggle } from '@/components/controls/toggle/toggle';
 import { Utils } from '@/utils/utils';
-import { useOptions } from '@/contexts/data-context';
 
 import './encounter-edit-panel.scss';
 
 interface Props {
 	encounter: Encounter;
-	heroes: Hero[];
 	sourcebooks: Sourcebook[];
 	onChange: (encounter: Encounter) => void;
 	showMonster: (monster: Monster, monsterGroup: MonsterGroup) => void;
@@ -63,6 +61,7 @@ export const EncounterEditPanel = (props: Props) => {
 	const [ draggedMonster, setDraggedMonster ] = useState<Monster | null>(null);
 	const [ draggedTerrain, setDraggedTerrain ] = useState<Terrain | null>(null);
 	const options = useOptions();
+	const heroes = useHeroes();
 
 	const switchLeftTab = (key: string) => {
 		setActiveLeftTabKey(key);
@@ -696,14 +695,13 @@ ${value.victories}`
 
 	const getDifficultySection = () => {
 		const strength = EncounterDifficultyLogic.getStrength(encounter, props.sourcebooks);
-		const difficulty = EncounterDifficultyLogic.getDifficulty(strength, options, props.heroes);
+		const difficulty = EncounterDifficultyLogic.getDifficulty(strength, options, heroes);
 
 		return (
 			<Expander title='Difficulty' tags={[ difficulty ]} style={{ flex: '0 0 auto' }}>
 				<EncounterDifficultyPanel
 					encounter={encounter}
 					sourcebooks={props.sourcebooks}
-					heroes={props.heroes}
 				/>
 			</Expander>
 		);

--- a/src/components/panels/edit/feature-edit/feature-edit-panel.tsx
+++ b/src/components/panels/edit/feature-edit/feature-edit-panel.tsx
@@ -10,7 +10,6 @@ import { FeatureTypeSelectModal } from '@/components/modals/select/feature-type-
 import { Field } from '@/components/controls/field/field';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { NameDescEditPanel } from '@/components/panels/edit/name-desc-edit/name-desc-edit-panel';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Perk } from '@/models/perk';
 import { PerkList } from '@/enums/perk-list';
@@ -26,7 +25,6 @@ interface Props {
 	feature: Feature | Perk;
 	allowedTypes?: FeatureType[];
 	sourcebooks: Sourcebook[];
-	options: Options;
 	mode?: PanelMode;
 	onChange: (feature: Feature) => void;
 }
@@ -128,7 +126,6 @@ export const FeatureEditPanel = (props: Props) => {
 										<EditFeature
 											feature={feature}
 											sourcebooks={props.sourcebooks}
-											options={props.options}
 											setData={setData}
 										/>
 									</div>
@@ -152,14 +149,12 @@ export const FeatureEditPanel = (props: Props) => {
 														<FeaturePanel
 															feature={feature}
 															sourcebooks={props.sourcebooks}
-															options={props.options}
 															mode={PanelMode.Full}
 														/>
 														:
 														<PerkPanel
 															perk={feature as Perk}
 															sourcebooks={props.sourcebooks}
-															options={props.options}
 															mode={PanelMode.Full}
 														/>
 												}

--- a/src/components/panels/edit/feature-list-edit/feature-list-edit-panel.tsx
+++ b/src/components/panels/edit/feature-list-edit/feature-list-edit-panel.tsx
@@ -11,7 +11,6 @@ import { FeatureLogic } from '@/logic/feature-logic';
 import { FeatureType } from '@/enums/feature-type';
 import { FeatureTypeSelectModal } from '@/components/modals/select/feature-type-select/feature-type-select-modal';
 import { HeaderText } from '@/components/controls/header-text/header-text';
-import { Options } from '@/models/options';
 import { Sourcebook } from '@/models/sourcebook';
 import { Utils } from '@/utils/utils';
 import { useState } from 'react';
@@ -23,7 +22,6 @@ interface Props {
 	features: Feature[];
 	allowedTypes?: FeatureType[];
 	sourcebooks: Sourcebook[];
-	options: Options;
 	onChange: (features: Feature[]) => void;
 }
 
@@ -98,7 +96,6 @@ export const FeatureListEditPanel = (props: Props) => {
 									feature={f}
 									allowedTypes={props.allowedTypes}
 									sourcebooks={props.sourcebooks}
-									options={props.options}
 									onChange={feature => changeFeature(feature)}
 								/>
 							</Expander>

--- a/src/components/panels/edit/fixture-edit/fixture-edit-panel.tsx
+++ b/src/components/panels/edit/fixture-edit/fixture-edit-panel.tsx
@@ -9,7 +9,6 @@ import { MonsterLogic } from '@/logic/monster-logic';
 import { MonsterRoleType } from '@/enums/monster-role-type';
 import { NameDescEditPanel } from '@/components/panels/edit/name-desc-edit/name-desc-edit-panel';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { Sourcebook } from '@/models/sourcebook';
 import { TerrainRoleType } from '@/enums/terrain-role-type';
 import { Utils } from '@/utils/utils';
@@ -20,7 +19,6 @@ import './fixture-edit-panel.scss';
 interface Props {
 	fixture: Fixture;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	onChange: (fixture: Fixture) => void;
 }
 
@@ -135,7 +133,6 @@ export const FixtureEditPanel = (props: Props) => {
 							title={`Level ${lvl.level}`}
 							features={lvl.features}
 							sourcebooks={props.sourcebooks}
-							options={props.options}
 							onChange={features => onChange(lvl.level, features)}
 						/>
 					))

--- a/src/components/panels/edit/follower-edit/follower-edit-panel.tsx
+++ b/src/components/panels/edit/follower-edit/follower-edit-panel.tsx
@@ -7,7 +7,6 @@ import { FollowerLogic } from '@/logic/follower-logic';
 import { FollowerType } from '@/enums/follower-type';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { NameDescEditPanel } from '@/components/panels/edit/name-desc-edit/name-desc-edit-panel';
-import { Options } from '@/models/options';
 import { Sourcebook } from '@/models/sourcebook';
 import { Utils } from '@/utils/utils';
 import { useState } from 'react';
@@ -17,7 +16,6 @@ import './follower-edit-panel.scss';
 interface Props {
 	follower: Follower;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	onChange: (follower: Follower) => void;
 }
 

--- a/src/components/panels/edit/imbuement-edit/imbuement-edit-panel.tsx
+++ b/src/components/panels/edit/imbuement-edit/imbuement-edit-panel.tsx
@@ -9,7 +9,6 @@ import { ImbuementPanel } from '@/components/panels/elements/imbuement-panel/imb
 import { ItemType } from '@/enums/item-type';
 import { NameDescEditPanel } from '@/components/panels/edit/name-desc-edit/name-desc-edit-panel';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Project } from '@/models/project';
 import { ProjectEditPanel } from '@/components/panels/edit/project-edit/project-edit';
@@ -24,7 +23,6 @@ import './imbuement-edit-panel.scss';
 interface Props {
 	imbuement: Imbuement;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	mode?: PanelMode;
 	onChange: (imbuemenet: Imbuement) => void;
 }
@@ -135,7 +133,6 @@ export const ImbuementEditPanel = (props: Props) => {
 				<FeatureEditPanel
 					feature={imbuement.feature}
 					sourcebooks={props.sourcebooks}
-					options={props.options}
 					onChange={changeFeature}
 				/>
 			</Space>
@@ -184,7 +181,6 @@ export const ImbuementEditPanel = (props: Props) => {
 												<ImbuementPanel
 													imbuement={imbuement}
 													sourcebooks={props.sourcebooks}
-													options={props.options}
 													mode={PanelMode.Full}
 												/>
 											</SelectablePanel>

--- a/src/components/panels/edit/item-edit/item-edit-panel.tsx
+++ b/src/components/panels/edit/item-edit/item-edit-panel.tsx
@@ -15,7 +15,6 @@ import { KitArmor } from '@/enums/kit-armor';
 import { KitWeapon } from '@/enums/kit-weapon';
 import { MarkdownEditor } from '@/components/controls/markdown/markdown';
 import { NameDescEditPanel } from '@/components/panels/edit/name-desc-edit/name-desc-edit-panel';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Project } from '@/models/project';
 import { ProjectEditPanel } from '@/components/panels/edit/project-edit/project-edit';
@@ -30,7 +29,6 @@ import './item-edit-panel.scss';
 interface Props {
 	item: Item;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	mode?: PanelMode;
 	onChange: (item: Item) => void;
 }
@@ -146,7 +144,6 @@ export const ItemEditPanel = (props: Props) => {
 							title={`Level ${lvl.level}`}
 							features={lvl.features}
 							sourcebooks={props.sourcebooks}
-							options={props.options}
 							onChange={features => onChange(lvl.level, features)}
 						/>
 					))
@@ -242,7 +239,6 @@ export const ItemEditPanel = (props: Props) => {
 													key={revision}
 													item={item}
 													sourcebooks={props.sourcebooks}
-													options={props.options}
 													mode={PanelMode.Full}
 												/>
 											</SelectablePanel>

--- a/src/components/panels/edit/kit-edit/kit-edit-panel.tsx
+++ b/src/components/panels/edit/kit-edit/kit-edit-panel.tsx
@@ -13,7 +13,6 @@ import { KitPanel } from '@/components/panels/elements/kit-panel/kit-panel';
 import { KitWeapon } from '@/enums/kit-weapon';
 import { NameDescEditPanel } from '@/components/panels/edit/name-desc-edit/name-desc-edit-panel';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
 import { Sourcebook } from '@/models/sourcebook';
@@ -27,7 +26,6 @@ import './kit-edit-panel.scss';
 interface Props {
 	kit: Kit;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	mode?: PanelMode;
 	onChange: (kit: Kit) => void;
 }
@@ -302,7 +300,6 @@ export const KitEditPanel = (props: Props) => {
 				title='Features'
 				features={kit.features}
 				sourcebooks={props.sourcebooks}
-				options={props.options}
 				onChange={onChange}
 			/>
 		);
@@ -469,7 +466,6 @@ export const KitEditPanel = (props: Props) => {
 												<KitPanel
 													kit={kit}
 													sourcebooks={props.sourcebooks}
-													options={props.options}
 													mode={PanelMode.Full}
 												/>
 											</SelectablePanel>

--- a/src/components/panels/edit/monster-edit/monster-edit-panel.tsx
+++ b/src/components/panels/edit/monster-edit/monster-edit-panel.tsx
@@ -28,7 +28,6 @@ import { MonsterRoleType } from '@/enums/monster-role-type';
 import { MonsterSelectModal } from '@/components/modals/select/monster-select/monster-select-modal';
 import { NameDescEditPanel } from '@/components/panels/edit/name-desc-edit/name-desc-edit-panel';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Pill } from '@/components/controls/pill/pill';
 import { RadioGroup } from '@/components/controls/radio-group/radio-group';
@@ -38,6 +37,7 @@ import { Sourcebook } from '@/models/sourcebook';
 import { SourcebookLogic } from '@/logic/sourcebook-logic';
 import { TextInput } from '@/components/controls/text-input/text-input';
 import { Utils } from '@/utils/utils';
+import { useOptions } from '@/contexts/data-context';
 import { useState } from 'react';
 
 import './monster-edit-panel.scss';
@@ -46,7 +46,6 @@ interface Props {
 	monster: Monster;
 	monsterGroup?: MonsterGroup;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	mode?: PanelMode;
 	onChange: (monster: Monster) => void;
 	onSelectMonster?: (monster: Monster, group: MonsterGroup) => void;
@@ -58,6 +57,7 @@ export const MonsterEditPanel = (props: Props) => {
 	const [ scratchpadMonsters, setScratchpadMonsters ] = useState<Monster[]>([]);
 	const [ hiddenMonsterIDs, setHiddenMonsterIDs ] = useState<string[]>([]);
 	const [ drawerOpen, setDrawerOpen ] = useState<boolean>(false);
+	const options = useOptions();
 
 	const setEncounterValue = (value: number) => {
 		const copy = Utils.copy(monster);
@@ -394,7 +394,6 @@ export const MonsterEditPanel = (props: Props) => {
 					features={monster.features}
 					allowedTypes={[ FeatureType.Text, FeatureType.Ability, FeatureType.ConditionImmunity, FeatureType.DamageModifier ]}
 					sourcebooks={props.sourcebooks}
-					options={props.options}
 					onChange={onChange}
 				/>
 			</Space>
@@ -470,7 +469,6 @@ export const MonsterEditPanel = (props: Props) => {
 								feature={monster.retainer.level4}
 								sourcebooks={props.sourcebooks}
 								allowedTypes={[ FeatureType.Ability ]}
-								options={props.options}
 								onChange={f => changeRetainerFeature(f, 4)}
 							/>
 						</Expander>
@@ -486,7 +484,6 @@ export const MonsterEditPanel = (props: Props) => {
 								feature={monster.retainer.level7}
 								sourcebooks={props.sourcebooks}
 								allowedTypes={[ FeatureType.Ability ]}
-								options={props.options}
 								onChange={f => changeRetainerFeature(f, 7)}
 							/>
 						</Expander>
@@ -502,7 +499,6 @@ export const MonsterEditPanel = (props: Props) => {
 								feature={monster.retainer.level10}
 								sourcebooks={props.sourcebooks}
 								allowedTypes={[ FeatureType.Ability ]}
-								options={props.options}
 								onChange={f => changeRetainerFeature(f, 10)}
 							/>
 						</Expander>
@@ -514,7 +510,7 @@ export const MonsterEditPanel = (props: Props) => {
 
 	const getSimilarMonsters = () => {
 		const monsters = SourcebookLogic
-			.getSimilarMonsters(props.sourcebooks, monster, props.options)
+			.getSimilarMonsters(props.sourcebooks, monster, options)
 			.filter(m => !hiddenMonsterIDs.includes(m.id));
 
 		scratchpadMonsters
@@ -919,7 +915,7 @@ export const MonsterEditPanel = (props: Props) => {
 								<Button key='up' type='text' title='Import' icon={<ImportOutlined />} onClick={e => { e.stopPropagation(); importFeature(s.feature); }} />
 							]}
 						>
-							<FeaturePanel feature={s.feature} options={props.options} mode={PanelMode.Full} />
+							<FeaturePanel feature={s.feature} mode={PanelMode.Full} />
 						</Expander>
 					))
 				}
@@ -997,7 +993,6 @@ export const MonsterEditPanel = (props: Props) => {
 									monster={m}
 									monsterGroup={monsterGroup}
 									sourcebooks={props.sourcebooks}
-									options={props.options}
 								/>
 							</SelectablePanel>
 						);
@@ -1012,7 +1007,6 @@ export const MonsterEditPanel = (props: Props) => {
 					<MonsterSelectModal
 						monsters={props.sourcebooks.flatMap(sb => sb.monsterGroups).flatMap(g => g.monsters)}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 						onSelect={monster => {
 							const copy = Utils.copy(scratchpadMonsters) as Monster[];
 							copy.push(monster);
@@ -1089,7 +1083,6 @@ export const MonsterEditPanel = (props: Props) => {
 												<MonsterPanel
 													monster={monster}
 													sourcebooks={props.sourcebooks}
-													options={props.options}
 													mode={PanelMode.Full}
 												/>
 											</SelectablePanel>

--- a/src/components/panels/edit/monster-group-edit/monster-group-edit-panel.tsx
+++ b/src/components/panels/edit/monster-group-edit/monster-group-edit-panel.tsx
@@ -24,7 +24,6 @@ import { MonsterPanel } from '@/components/panels/elements/monster-panel/monster
 import { MonsterRoleType } from '@/enums/monster-role-type';
 import { MonsterSelectModal } from '@/components/modals/select/monster-select/monster-select-modal';
 import { NameDescEditPanel } from '@/components/panels/edit/name-desc-edit/name-desc-edit-panel';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
 import { Sourcebook } from '@/models/sourcebook';
@@ -36,7 +35,6 @@ import './monster-group-edit-panel.scss';
 interface Props {
 	monsterGroup: MonsterGroup;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	mode?: PanelMode;
 	onChange: (monsterGroup: MonsterGroup) => void;
 	onSelectMonster: (monster: Monster, group: MonsterGroup) => void;
@@ -192,7 +190,6 @@ export const MonsterGroupEditPanel = (props: Props) => {
 				features={monsterGroup.malice}
 				allowedTypes={[ FeatureType.Malice, FeatureType.MaliceAbility ]}
 				sourcebooks={props.sourcebooks}
-				options={props.options}
 				onChange={onChange}
 			/>
 		);
@@ -303,7 +300,6 @@ export const MonsterGroupEditPanel = (props: Props) => {
 								monster={m}
 								monsterGroup={monsterGroup}
 								sourcebooks={props.sourcebooks}
-								options={props.options}
 							/>
 						</Expander>
 					))
@@ -317,7 +313,6 @@ export const MonsterGroupEditPanel = (props: Props) => {
 					<MonsterSelectModal
 						monsters={props.sourcebooks.flatMap(sb => sb.monsterGroups).flatMap(g => g.monsters)}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 						onSelect={monster => {
 							copyMonster(monster);
 							setDrawerOpen(false);
@@ -392,7 +387,6 @@ export const MonsterGroupEditPanel = (props: Props) => {
 								feature={i}
 								allowedTypes={[ FeatureType.AddOn ]}
 								sourcebooks={props.sourcebooks}
-								options={props.options}
 								onChange={f => changeAddOn(f as FeatureAddOn)}
 							/>
 						</Expander>
@@ -465,7 +459,6 @@ export const MonsterGroupEditPanel = (props: Props) => {
 														<MonsterGroupPanel
 															monsterGroup={monsterGroup}
 															sourcebooks={props.sourcebooks}
-															options={props.options}
 															mode={PanelMode.Full}
 														/>
 													</SelectablePanel>
@@ -482,7 +475,6 @@ export const MonsterGroupEditPanel = (props: Props) => {
 						key={monsterID}
 						monster={monsterGroup.monsters.find(m => m.id === monsterID) as Monster}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 						mode={PanelMode.Full}
 						onChange={monster => {
 							const copy = Utils.copy(monsterGroup);

--- a/src/components/panels/edit/montage-edit/montage-edit-panel.tsx
+++ b/src/components/panels/edit/montage-edit/montage-edit-panel.tsx
@@ -9,7 +9,6 @@ import { ErrorBoundary } from '@/components/controls/error-boundary/error-bounda
 import { Expander } from '@/components/controls/expander/expander';
 import { FactoryLogic } from '@/logic/factory-logic';
 import { HeaderText } from '@/components/controls/header-text/header-text';
-import { Hero } from '@/models/hero';
 import { MarkdownEditor } from '@/components/controls/markdown/markdown';
 import { Montage } from '@/models/montage';
 import { MontagePanel } from '@/components/panels/elements/montage-panel/montage-panel';
@@ -26,7 +25,6 @@ import './montage-edit-panel.scss';
 
 interface Props {
 	montage: Montage;
-	heroes: Hero[];
 	sourcebooks: Sourcebook[];
 	mode?: PanelMode;
 	onChange: (montage: Montage) => void;
@@ -560,7 +558,6 @@ export const MontageEditPanel = (props: Props) => {
 											<SelectablePanel>
 												<MontagePanel
 													montage={montage}
-													heroes={props.heroes}
 													sourcebooks={props.sourcebooks}
 													mode={PanelMode.Full}
 												/>

--- a/src/components/panels/edit/montage-edit/montage-edit-panel.tsx
+++ b/src/components/panels/edit/montage-edit/montage-edit-panel.tsx
@@ -15,7 +15,6 @@ import { Montage } from '@/models/montage';
 import { MontagePanel } from '@/components/panels/elements/montage-panel/montage-panel';
 import { NameDescEditPanel } from '@/components/panels/edit/name-desc-edit/name-desc-edit-panel';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
 import { Sourcebook } from '@/models/sourcebook';
@@ -29,7 +28,6 @@ interface Props {
 	montage: Montage;
 	heroes: Hero[];
 	sourcebooks: Sourcebook[];
-	options: Options;
 	mode?: PanelMode;
 	onChange: (montage: Montage) => void;
 }
@@ -564,7 +562,6 @@ export const MontageEditPanel = (props: Props) => {
 													montage={montage}
 													heroes={props.heroes}
 													sourcebooks={props.sourcebooks}
-													options={props.options}
 													mode={PanelMode.Full}
 												/>
 											</SelectablePanel>

--- a/src/components/panels/edit/negotiation-edit/negotiation-edit-panel.tsx
+++ b/src/components/panels/edit/negotiation-edit/negotiation-edit-panel.tsx
@@ -15,7 +15,6 @@ import { NegotiationLogic } from '@/logic/negotiation-logic';
 import { NegotiationPanel } from '@/components/panels/elements/negotiation-panel/negotiation-panel';
 import { NegotiationTrait } from '@/enums/negotiation-trait';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
 import { Sourcebook } from '@/models/sourcebook';
@@ -28,7 +27,6 @@ import './negotiation-edit-panel.scss';
 interface Props {
 	negotiation: Negotiation;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	mode?: PanelMode;
 	onChange: (negotiation: Negotiation) => void;
 }
@@ -345,7 +343,6 @@ export const NegotiationEditPanel = (props: Props) => {
 												<NegotiationPanel
 													negotiation={negotiation}
 													sourcebooks={props.sourcebooks}
-													options={props.options}
 													mode={PanelMode.Full}
 												/>
 											</SelectablePanel>

--- a/src/components/panels/edit/plot-edit/plot-edit-panel.tsx
+++ b/src/components/panels/edit/plot-edit/plot-edit-panel.tsx
@@ -16,7 +16,6 @@ import { Expander } from '@/components/controls/expander/expander';
 import { FactoryLogic } from '@/logic/factory-logic';
 import { Format } from '@/utils/format';
 import { HeaderText } from '@/components/controls/header-text/header-text';
-import { Hero } from '@/models/hero';
 import { Modal } from '@/components/modals/modal/modal';
 import { MontagePanel } from '@/components/panels/elements/montage-panel/montage-panel';
 import { NameDescEditPanel } from '@/components/panels/edit/name-desc-edit/name-desc-edit-panel';
@@ -36,7 +35,6 @@ interface Props {
 	plot: Plot;
 	adventure: Adventure;
 	sourcebooks: Sourcebook[];
-	heroes: Hero[];
 	onChange: (plot: Plot) => void;
 	onAddAfter: (plotPointID: string) => void;
 	onDelete: (plotPointID: string) => void;
@@ -405,7 +403,7 @@ export const PlotEditPanel = (props: Props) => {
 											name = element.name;
 											tag = 'Encounter';
 											content = (
-												<EncounterPanel encounter={element} sourcebooks={props.sourcebooks} heroes={props.heroes} />
+												<EncounterPanel encounter={element} sourcebooks={props.sourcebooks} />
 											);
 										}
 										break;
@@ -416,7 +414,7 @@ export const PlotEditPanel = (props: Props) => {
 											name = element.name;
 											tag = 'Montage';
 											content = (
-												<MontagePanel montage={element} heroes={props.heroes} sourcebooks={props.sourcebooks} />
+												<MontagePanel montage={element} sourcebooks={props.sourcebooks} />
 											);
 										}
 										break;
@@ -580,7 +578,6 @@ export const PlotEditPanel = (props: Props) => {
 				plot={plot}
 				adventure={props.adventure}
 				sourcebooks={props.sourcebooks}
-				heroes={props.heroes}
 				mode={PanelMode.Full}
 				onSelect={() => null}
 				onStart={() => null}

--- a/src/components/panels/edit/plot-edit/plot-edit-panel.tsx
+++ b/src/components/panels/edit/plot-edit/plot-edit-panel.tsx
@@ -21,7 +21,6 @@ import { Modal } from '@/components/modals/modal/modal';
 import { MontagePanel } from '@/components/panels/elements/montage-panel/montage-panel';
 import { NameDescEditPanel } from '@/components/panels/edit/name-desc-edit/name-desc-edit-panel';
 import { NegotiationPanel } from '@/components/panels/elements/negotiation-panel/negotiation-panel';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { PlotPanel } from '@/components/panels/elements/plot-panel/plot-panel';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
@@ -38,7 +37,6 @@ interface Props {
 	adventure: Adventure;
 	sourcebooks: Sourcebook[];
 	heroes: Hero[];
-	options: Options;
 	onChange: (plot: Plot) => void;
 	onAddAfter: (plotPointID: string) => void;
 	onDelete: (plotPointID: string) => void;
@@ -407,7 +405,7 @@ export const PlotEditPanel = (props: Props) => {
 											name = element.name;
 											tag = 'Encounter';
 											content = (
-												<EncounterPanel encounter={element} sourcebooks={props.sourcebooks} heroes={props.heroes} options={props.options} />
+												<EncounterPanel encounter={element} sourcebooks={props.sourcebooks} heroes={props.heroes} />
 											);
 										}
 										break;
@@ -418,7 +416,7 @@ export const PlotEditPanel = (props: Props) => {
 											name = element.name;
 											tag = 'Montage';
 											content = (
-												<MontagePanel montage={element} heroes={props.heroes} sourcebooks={props.sourcebooks} options={props.options} />
+												<MontagePanel montage={element} heroes={props.heroes} sourcebooks={props.sourcebooks} />
 											);
 										}
 										break;
@@ -429,7 +427,7 @@ export const PlotEditPanel = (props: Props) => {
 											name = element.name;
 											tag = 'Negotiation';
 											content = (
-												<NegotiationPanel negotiation={element} sourcebooks={props.sourcebooks} options={props.options} />
+												<NegotiationPanel negotiation={element} sourcebooks={props.sourcebooks} />
 											);
 										}
 										break;
@@ -440,7 +438,7 @@ export const PlotEditPanel = (props: Props) => {
 											name = element.name;
 											tag = 'Tactical Map';
 											content = (
-												<TacticalMapPanel map={element} display={TacticalMapDisplayType.Thumbnail} sourcebooks={props.sourcebooks} options={props.options} />
+												<TacticalMapPanel map={element} display={TacticalMapDisplayType.Thumbnail} sourcebooks={props.sourcebooks} />
 											);
 										}
 										break;
@@ -583,7 +581,6 @@ export const PlotEditPanel = (props: Props) => {
 				adventure={props.adventure}
 				sourcebooks={props.sourcebooks}
 				heroes={props.heroes}
-				options={props.options}
 				mode={PanelMode.Full}
 				onSelect={() => null}
 				onStart={() => null}

--- a/src/components/panels/edit/subclass-edit/subclass-edit-panel.tsx
+++ b/src/components/panels/edit/subclass-edit/subclass-edit-panel.tsx
@@ -12,7 +12,6 @@ import { Feature } from '@/models/feature';
 import { FeatureListEditPanel } from '@/components/panels/edit/feature-list-edit/feature-list-edit-panel';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { NameDescEditPanel } from '@/components/panels/edit/name-desc-edit/name-desc-edit-panel';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
 import { Sourcebook } from '@/models/sourcebook';
@@ -26,7 +25,6 @@ import './subclass-edit-panel.scss';
 interface Props {
 	subClass: SubClass;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	mode?: PanelMode;
 	onChange: (subClass: SubClass) => void;
 }
@@ -70,7 +68,6 @@ export const SubClassEditPanel = (props: Props) => {
 							title={`Level ${lvl.level}`}
 							features={lvl.features}
 							sourcebooks={props.sourcebooks}
-							options={props.options}
 							onChange={features => onChange(lvl.level, features)}
 						/>
 					))
@@ -197,7 +194,6 @@ export const SubClassEditPanel = (props: Props) => {
 												<SubclassPanel
 													subclass={subClass}
 													sourcebooks={props.sourcebooks}
-													options={props.options}
 													mode={PanelMode.Full}
 												/>
 											</SelectablePanel>

--- a/src/components/panels/edit/terrain-edit/terrain-edit-panel.tsx
+++ b/src/components/panels/edit/terrain-edit/terrain-edit-panel.tsx
@@ -17,7 +17,6 @@ import { MarkdownEditor } from '@/components/controls/markdown/markdown';
 import { MonsterRoleType } from '@/enums/monster-role-type';
 import { NameDescEditPanel } from '@/components/panels/edit/name-desc-edit/name-desc-edit-panel';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { RadioGroup } from '@/components/controls/radio-group/radio-group';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
@@ -36,7 +35,6 @@ import './terrain-edit-panel.scss';
 interface Props {
 	terrain: Terrain;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	mode?: PanelMode;
 	onChange: (terrain: Terrain) => void;
 }
@@ -402,7 +400,6 @@ export const TerrainEditPanel = (props: Props) => {
 												feature={feature}
 												allowedTypes={[ FeatureType.Text, FeatureType.Ability ]}
 												sourcebooks={props.sourcebooks}
-												options={props.options}
 												onChange={f => setSectionContentFeature(sectionIndex, contentIndex, f as FeatureText | FeatureAbility)}
 											/>
 										</Expander>
@@ -601,7 +598,6 @@ export const TerrainEditPanel = (props: Props) => {
 																feature={feature}
 																allowedTypes={[ FeatureType.Text, FeatureType.Ability ]}
 																sourcebooks={props.sourcebooks}
-																options={props.options}
 																onChange={f => setUpgradeSectionContentFeature(upgradeIndex, sectionIndex, contentIndex, f as FeatureText | FeatureAbility)}
 															/>
 														</Expander>

--- a/src/components/panels/edit/title-edit/title-edit-panel.tsx
+++ b/src/components/panels/edit/title-edit/title-edit-panel.tsx
@@ -5,7 +5,6 @@ import { FeatureListEditPanel } from '@/components/panels/edit/feature-list-edit
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { NameDescEditPanel } from '@/components/panels/edit/name-desc-edit/name-desc-edit-panel';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
 import { Sourcebook } from '@/models/sourcebook';
@@ -20,7 +19,6 @@ import './title-edit-panel.scss';
 interface Props {
 	title: Title;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	mode?: PanelMode;
 	onChange: (title: Title) => void;
 }
@@ -91,7 +89,6 @@ export const TitleEditPanel = (props: Props) => {
 				title='Features'
 				features={title.features}
 				sourcebooks={props.sourcebooks}
-				options={props.options}
 				onChange={onChange}
 			/>
 		);
@@ -135,7 +132,6 @@ export const TitleEditPanel = (props: Props) => {
 													key={revision}
 													title={title}
 													sourcebooks={props.sourcebooks}
-													options={props.options}
 													mode={PanelMode.Full}
 												/>
 											</SelectablePanel>

--- a/src/components/panels/elements/adventure-panel/adventure-panel.tsx
+++ b/src/components/panels/elements/adventure-panel/adventure-panel.tsx
@@ -5,7 +5,6 @@ import { Divider } from 'antd';
 import { Element } from '@/models/element';
 import { ErrorBoundary } from '@/components/controls/error-boundary/error-boundary';
 import { HeaderText } from '@/components/controls/header-text/header-text';
-import { Hero } from '@/models/hero';
 import { Markdown } from '@/components/controls/markdown/markdown';
 import { PanelMode } from '@/enums/panel-mode';
 import { Plot } from '@/models/plot';
@@ -21,7 +20,6 @@ import './adventure-panel.scss';
 interface Props {
 	adventure: Adventure;
 	sourcebooks: Sourcebook[];
-	heroes: Hero[];
 	mode?: PanelMode;
 	onStart?: (kind: SourcebookElementKind, element: Element, party: string) => void;
 }
@@ -37,7 +35,6 @@ export const AdventurePanel = (props: Props) => {
 					plot={selectedPlot}
 					adventure={props.adventure}
 					sourcebooks={props.sourcebooks}
-					heroes={props.heroes}
 					mode={PanelMode.Full}
 					onSelect={setSelectedPlot}
 					onStart={props.onStart!}
@@ -51,7 +48,6 @@ export const AdventurePanel = (props: Props) => {
 					plot={currentPlot}
 					adventure={props.adventure}
 					sourcebooks={props.sourcebooks}
-					heroes={props.heroes}
 					mode={PanelMode.Full}
 					onSelect={setSelectedPlot}
 					onStart={props.onStart!}

--- a/src/components/panels/elements/adventure-panel/adventure-panel.tsx
+++ b/src/components/panels/elements/adventure-panel/adventure-panel.tsx
@@ -7,7 +7,6 @@ import { ErrorBoundary } from '@/components/controls/error-boundary/error-bounda
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { Markdown } from '@/components/controls/markdown/markdown';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Plot } from '@/models/plot';
 import { PlotGraphPanel } from '@/components/panels/plot-graph/plot-graph-panel';
@@ -23,7 +22,6 @@ interface Props {
 	adventure: Adventure;
 	sourcebooks: Sourcebook[];
 	heroes: Hero[];
-	options: Options;
 	mode?: PanelMode;
 	onStart?: (kind: SourcebookElementKind, element: Element, party: string) => void;
 }
@@ -40,7 +38,6 @@ export const AdventurePanel = (props: Props) => {
 					adventure={props.adventure}
 					sourcebooks={props.sourcebooks}
 					heroes={props.heroes}
-					options={props.options}
 					mode={PanelMode.Full}
 					onSelect={setSelectedPlot}
 					onStart={props.onStart!}
@@ -55,7 +52,6 @@ export const AdventurePanel = (props: Props) => {
 					adventure={props.adventure}
 					sourcebooks={props.sourcebooks}
 					heroes={props.heroes}
-					options={props.options}
 					mode={PanelMode.Full}
 					onSelect={setSelectedPlot}
 					onStart={props.onStart!}

--- a/src/components/panels/elements/ancestry-panel/ancestry-panel.tsx
+++ b/src/components/panels/elements/ancestry-panel/ancestry-panel.tsx
@@ -10,7 +10,6 @@ import { Field } from '@/components/controls/field/field';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { Markdown } from '@/components/controls/markdown/markdown';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
 import { SheetFormatter } from '@/logic/classic-sheet/sheet-formatter';
@@ -24,7 +23,6 @@ import './ancestry-panel.scss';
 interface Props {
 	ancestry: Ancestry;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	hero?: Hero;
 	mode?: PanelMode;
 }
@@ -46,7 +44,7 @@ export const AncestryPanel = (props: Props) => {
 				{
 					features.map(f => (
 						<SelectablePanel key={f.id}>
-							<FeaturePanel feature={f} options={props.options} hero={props.hero} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
+							<FeaturePanel feature={f} hero={props.hero} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
 						</SelectablePanel>
 					))
 				}
@@ -64,7 +62,7 @@ export const AncestryPanel = (props: Props) => {
 				{
 					features.map(f => (
 						<SelectablePanel key={f.feature.id}>
-							<FeaturePanel feature={f.feature} cost={f.value} options={props.options} hero={props.hero} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
+							<FeaturePanel feature={f.feature} cost={f.value} hero={props.hero} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
 						</SelectablePanel>
 					))
 				}
@@ -75,7 +73,7 @@ export const AncestryPanel = (props: Props) => {
 
 	const getCulture = () => {
 		return props.ancestry.culture ?
-			<CulturePanel culture={props.ancestry.culture} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} />
+			<CulturePanel culture={props.ancestry.culture} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
 			:
 			<Empty />;
 	};

--- a/src/components/panels/elements/career-panel/career-panel.tsx
+++ b/src/components/panels/elements/career-panel/career-panel.tsx
@@ -6,7 +6,6 @@ import { Field } from '@/components/controls/field/field';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { Markdown } from '@/components/controls/markdown/markdown';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
 import { SheetFormatter } from '@/logic/classic-sheet/sheet-formatter';
@@ -20,7 +19,6 @@ import './career-panel.scss';
 interface Props {
 	career: Career;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	hero?: Hero;
 	mode?: PanelMode;
 }
@@ -40,7 +38,7 @@ export const CareerPanel = (props: Props) => {
 				{
 					props.career.features.map(f => (
 						<SelectablePanel key={f.id}>
-							<FeaturePanel feature={f} options={props.options} hero={props.hero} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
+							<FeaturePanel feature={f} hero={props.hero} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
 						</SelectablePanel>
 					))
 				}

--- a/src/components/panels/elements/class-panel/class-panel.tsx
+++ b/src/components/panels/elements/class-panel/class-panel.tsx
@@ -9,7 +9,6 @@ import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { HeroClass } from '@/models/class';
 import { Markdown } from '@/components/controls/markdown/markdown';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Segmented } from 'antd';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
@@ -25,7 +24,6 @@ import './class-panel.scss';
 interface Props {
 	heroClass: HeroClass;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	hero?: Hero;
 	mode?: PanelMode;
 }
@@ -63,7 +61,7 @@ export const ClassPanel = (props: Props) => {
 								}
 							>
 								{
-									lvl.features.map(f => <FeaturePanel key={f.id} feature={f} options={props.options} hero={props.hero} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />)
+									lvl.features.map(f => <FeaturePanel key={f.id} feature={f} hero={props.hero} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />)
 								}
 							</Expander>
 						);
@@ -116,7 +114,7 @@ export const ClassPanel = (props: Props) => {
 				{
 					props.heroClass.subclasses.map(sc => (
 						<Expander key={sc.id} title={sc.name}>
-							<SubclassPanel key={sc.id} subclass={sc} sourcebooks={props.sourcebooks} options={props.options} hero={props.hero} mode={PanelMode.Full} style={{ padding: '5px' }} />
+							<SubclassPanel key={sc.id} subclass={sc} sourcebooks={props.sourcebooks} hero={props.hero} mode={PanelMode.Full} style={{ padding: '5px' }} />
 						</Expander>
 					))
 				}

--- a/src/components/panels/elements/complication-panel/complication-panel.tsx
+++ b/src/components/panels/elements/complication-panel/complication-panel.tsx
@@ -4,7 +4,6 @@ import { FeaturePanel } from '@/components/panels/elements/feature-panel/feature
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { Markdown } from '@/components/controls/markdown/markdown';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { SheetFormatter } from '@/logic/classic-sheet/sheet-formatter';
 import { Sourcebook } from '@/models/sourcebook';
@@ -16,7 +15,6 @@ import './complication-panel.scss';
 interface Props {
 	complication: Complication;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	hero?: Hero;
 	mode?: PanelMode;
 }
@@ -40,7 +38,7 @@ export const ComplicationPanel = (props: Props) => {
 				{
 					props.mode === PanelMode.Full ?
 						props.complication.features.map(f => (
-							<FeaturePanel key={f.id} feature={f} options={props.options} hero={props.hero} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
+							<FeaturePanel key={f.id} feature={f} hero={props.hero} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
 						))
 						: null
 				}

--- a/src/components/panels/elements/culture-panel/culture-panel.tsx
+++ b/src/components/panels/elements/culture-panel/culture-panel.tsx
@@ -4,7 +4,6 @@ import { FeaturePanel } from '@/components/panels/elements/feature-panel/feature
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { Markdown } from '@/components/controls/markdown/markdown';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { SheetFormatter } from '@/logic/classic-sheet/sheet-formatter';
 import { Sourcebook } from '@/models/sourcebook';
@@ -16,7 +15,6 @@ import './culture-panel.scss';
 interface Props {
 	culture: Culture;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	hero?: Hero;
 	mode?: PanelMode;
 }
@@ -43,10 +41,10 @@ export const CulturePanel = (props: Props) => {
 				{
 					props.mode === PanelMode.Full ?
 						<div style={{ paddingTop: '10px' }}>
-							<FeaturePanel feature={props.culture.language} options={props.options} hero={props.hero} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
-							{props.culture.environment ? <FeaturePanel feature={props.culture.environment} options={props.options} hero={props.hero} sourcebooks={props.sourcebooks} mode={PanelMode.Full} /> : null}
-							{props.culture.organization ? <FeaturePanel feature={props.culture.organization} options={props.options} hero={props.hero} sourcebooks={props.sourcebooks} mode={PanelMode.Full} /> : null}
-							{props.culture.upbringing ? <FeaturePanel feature={props.culture.upbringing} options={props.options} hero={props.hero} sourcebooks={props.sourcebooks} mode={PanelMode.Full} /> : null}
+							<FeaturePanel feature={props.culture.language} hero={props.hero} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
+							{props.culture.environment ? <FeaturePanel feature={props.culture.environment} hero={props.hero} sourcebooks={props.sourcebooks} mode={PanelMode.Full} /> : null}
+							{props.culture.organization ? <FeaturePanel feature={props.culture.organization} hero={props.hero} sourcebooks={props.sourcebooks} mode={PanelMode.Full} /> : null}
+							{props.culture.upbringing ? <FeaturePanel feature={props.culture.upbringing} hero={props.hero} sourcebooks={props.sourcebooks} mode={PanelMode.Full} /> : null}
 						</div>
 						: null
 				}

--- a/src/components/panels/elements/domain-panel/domain-panel.tsx
+++ b/src/components/panels/elements/domain-panel/domain-panel.tsx
@@ -8,7 +8,6 @@ import { Field } from '@/components/controls/field/field';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { Markdown } from '@/components/controls/markdown/markdown';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Pill } from '@/components/controls/pill/pill';
 import { SheetFormatter } from '@/logic/classic-sheet/sheet-formatter';
@@ -22,7 +21,6 @@ import './domain-panel.scss';
 interface Props {
 	domain: Domain;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	hero?: Hero;
 	mode?: PanelMode;
 }
@@ -53,7 +51,7 @@ export const DomainPanel = (props: Props) => {
 							>
 								{
 									...lvl.features.map(f =>
-										<FeaturePanel key={f.id} feature={f} options={props.options} hero={props.hero} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
+										<FeaturePanel key={f.id} feature={f} hero={props.hero} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
 									)
 								}
 							</Expander>
@@ -94,7 +92,7 @@ export const DomainPanel = (props: Props) => {
 				{
 					props.domain.defaultFeatures.map(f => {
 						return (
-							<FeaturePanel key={f.id} feature={f} options={props.options} hero={props.hero} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
+							<FeaturePanel key={f.id} feature={f} hero={props.hero} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
 						);
 					})
 				}

--- a/src/components/panels/elements/encounter-panel/encounter-panel.tsx
+++ b/src/components/panels/elements/encounter-panel/encounter-panel.tsx
@@ -16,7 +16,6 @@ import { Hero } from '@/models/hero';
 import { Markdown } from '@/components/controls/markdown/markdown';
 import { MonsterLogic } from '@/logic/monster-logic';
 import { MonsterPanel } from '@/components/panels/elements/monster-panel/monster-panel';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Pill } from '@/components/controls/pill/pill';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
@@ -25,6 +24,7 @@ import { Sourcebook } from '@/models/sourcebook';
 import { SourcebookLogic } from '@/logic/sourcebook-logic';
 import { SourcebookType } from '@/enums/sourcebook-type';
 import { TerrainPanel } from '@/components/panels/elements/terrain-panel/terrain-panel';
+import { useOptions } from '@/contexts/data-context';
 import { useState } from 'react';
 
 import './encounter-panel.scss';
@@ -33,19 +33,19 @@ interface Props {
 	encounter: Encounter;
 	sourcebooks: Sourcebook[];
 	heroes: Hero[];
-	options: Options;
 	mode?: PanelMode;
 	showTools?: (tool: string) => void;
 }
 
 export const EncounterPanel = (props: Props) => {
 	const [ page, setPage ] = useState<string>('overview');
+	const options = useOptions();
 
 	const getOverview = () => {
 		return (
 			<>
 				<Markdown text={props.encounter.description} />
-				<EncounterDifficultyPanel encounter={props.encounter} sourcebooks={props.sourcebooks} heroes={props.heroes} options={props.options} />
+				<EncounterDifficultyPanel encounter={props.encounter} sourcebooks={props.sourcebooks} heroes={props.heroes} />
 				{props.encounter.notes.map(note => <Field key={note.id} label={note.name} value={<Markdown text={note.description} useSpan={true} />} />)}
 			</>
 		);
@@ -144,7 +144,6 @@ export const EncounterPanel = (props: Props) => {
 										monster={monster}
 										monsterGroup={monsterGroup}
 										sourcebooks={props.sourcebooks}
-										options={props.options}
 										mode={PanelMode.Full}
 									/>
 								);
@@ -226,7 +225,6 @@ export const EncounterPanel = (props: Props) => {
 													<SelectablePanel key={m.id}>
 														<FeaturePanel
 															feature={m}
-															options={props.options}
 															mode={PanelMode.Full}
 															cost={cost}
 															repeatable={m.type === FeatureType.Malice ? m.data.repeatable : undefined}
@@ -289,7 +287,7 @@ export const EncounterPanel = (props: Props) => {
 	}
 
 	const strength = EncounterDifficultyLogic.getStrength(props.encounter, props.sourcebooks);
-	const difficulty = EncounterDifficultyLogic.getDifficulty(strength, props.options, props.heroes);
+	const difficulty = EncounterDifficultyLogic.getDifficulty(strength, options, props.heroes);
 	tags.push(difficulty);
 
 	if (props.mode !== PanelMode.Full) {

--- a/src/components/panels/elements/encounter-panel/encounter-panel.tsx
+++ b/src/components/panels/elements/encounter-panel/encounter-panel.tsx
@@ -1,5 +1,6 @@
 import { MonsterInfo, TerrainInfo } from '@/components/panels/token/token';
 import { Segmented, Space } from 'antd';
+import { useHeroes, useOptions } from '@/contexts/data-context';
 import { ButtonGroup } from '@/components/controls/button-group/button-group';
 import { CreatureLogic } from '@/logic/creature-logic';
 import { Empty } from '@/components/controls/empty/empty';
@@ -12,7 +13,6 @@ import { FeaturePanel } from '@/components/panels/elements/feature-panel/feature
 import { FeatureType } from '@/enums/feature-type';
 import { Field } from '@/components/controls/field/field';
 import { HeaderText } from '@/components/controls/header-text/header-text';
-import { Hero } from '@/models/hero';
 import { Markdown } from '@/components/controls/markdown/markdown';
 import { MonsterLogic } from '@/logic/monster-logic';
 import { MonsterPanel } from '@/components/panels/elements/monster-panel/monster-panel';
@@ -24,7 +24,6 @@ import { Sourcebook } from '@/models/sourcebook';
 import { SourcebookLogic } from '@/logic/sourcebook-logic';
 import { SourcebookType } from '@/enums/sourcebook-type';
 import { TerrainPanel } from '@/components/panels/elements/terrain-panel/terrain-panel';
-import { useOptions } from '@/contexts/data-context';
 import { useState } from 'react';
 
 import './encounter-panel.scss';
@@ -32,7 +31,6 @@ import './encounter-panel.scss';
 interface Props {
 	encounter: Encounter;
 	sourcebooks: Sourcebook[];
-	heroes: Hero[];
 	mode?: PanelMode;
 	showTools?: (tool: string) => void;
 }
@@ -40,12 +38,13 @@ interface Props {
 export const EncounterPanel = (props: Props) => {
 	const [ page, setPage ] = useState<string>('overview');
 	const options = useOptions();
+	const heroes = useHeroes();
 
 	const getOverview = () => {
 		return (
 			<>
 				<Markdown text={props.encounter.description} />
-				<EncounterDifficultyPanel encounter={props.encounter} sourcebooks={props.sourcebooks} heroes={props.heroes} />
+				<EncounterDifficultyPanel encounter={props.encounter} sourcebooks={props.sourcebooks} />
 				{props.encounter.notes.map(note => <Field key={note.id} label={note.name} value={<Markdown text={note.description} useSpan={true} />} />)}
 			</>
 		);
@@ -287,7 +286,7 @@ export const EncounterPanel = (props: Props) => {
 	}
 
 	const strength = EncounterDifficultyLogic.getStrength(props.encounter, props.sourcebooks);
-	const difficulty = EncounterDifficultyLogic.getDifficulty(strength, options, props.heroes);
+	const difficulty = EncounterDifficultyLogic.getDifficulty(strength, options, heroes);
 	tags.push(difficulty);
 
 	if (props.mode !== PanelMode.Full) {

--- a/src/components/panels/elements/feature-panel/feature-panel.tsx
+++ b/src/components/panels/elements/feature-panel/feature-panel.tsx
@@ -13,7 +13,6 @@ import { FollowerPanel } from '@/components/panels/elements/follower-panel/follo
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { InfoFeature } from '@/components/features/feature';
 import { Markdown } from '@/components/controls/markdown/markdown';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Perk } from '@/models/perk';
 import { SheetFormatter } from '@/logic/classic-sheet/sheet-formatter';
@@ -26,7 +25,6 @@ import './feature-panel.scss';
 interface Props {
 	feature: Feature | Perk;
 	source?: string;
-	options: Options;
 	cost?: number | 'signature';
 	repeatable?: boolean;
 	hero?: Hero;
@@ -107,7 +105,7 @@ export const FeaturePanel = (props: Props) => {
 	if (props.feature.type === FeatureType.AncestryFeatureChoice) {
 		if (props.feature.data.selected) {
 			return (
-				<FeaturePanel feature={props.feature.data.selected} options={props.options} style={props.style} />
+				<FeaturePanel feature={props.feature.data.selected} style={props.style} />
 			);
 		}
 	}
@@ -163,7 +161,6 @@ export const FeaturePanel = (props: Props) => {
 							feature={props.feature}
 							hero={props.hero}
 							sourcebooks={props.sourcebooks}
-							options={props.options}
 						/>
 						: null
 				}

--- a/src/components/panels/elements/fixture-panel/fixture-panel.tsx
+++ b/src/components/panels/elements/fixture-panel/fixture-panel.tsx
@@ -8,7 +8,6 @@ import { FormatLogic } from '@/logic/format-logic';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { Markdown } from '@/components/controls/markdown/markdown';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { SheetFormatter } from '@/logic/classic-sheet/sheet-formatter';
 import { Sourcebook } from '@/models/sourcebook';
@@ -18,7 +17,6 @@ import './fixture-panel.scss';
 
 interface Props {
 	fixture: Fixture;
-	options: Options;
 	hero?: Hero;
 	sourcebooks?: Sourcebook[];
 	mode?: PanelMode;
@@ -38,7 +36,7 @@ export const FixturePanel = (props: Props) => {
 						props.fixture.featuresByLevel.filter(lvl => lvl.features.length > 0).map(lvl => (
 							<Space key={lvl.level} orientation='vertical'>
 								<HeaderText level={1}>Level {lvl.level.toString()}</HeaderText>
-								{...lvl.features.map(f => <FeaturePanel key={f.id} feature={f} options={props.options} hero={props.hero} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />)}
+								{...lvl.features.map(f => <FeaturePanel key={f.id} feature={f} hero={props.hero} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />)}
 							</Space>
 						))
 						: null

--- a/src/components/panels/elements/imbuement-panel/imbuement-panel.tsx
+++ b/src/components/panels/elements/imbuement-panel/imbuement-panel.tsx
@@ -5,7 +5,6 @@ import { Field } from '@/components/controls/field/field';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { Imbuement } from '@/models/imbuement';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { ProjectPanel } from '@/components/panels/elements/project-panel/project-panel';
 import { SheetFormatter } from '@/logic/classic-sheet/sheet-formatter';
@@ -18,7 +17,6 @@ import './imbuement-panel.scss';
 interface Props {
 	imbuement: Imbuement;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	hero?: Hero;
 	mode?: PanelMode;
 	onChange?: (imbuement: Imbuement) => void;
@@ -47,7 +45,6 @@ export const ImbuementPanel = (props: Props) => {
 					<FeaturePanel
 						key={props.imbuement.feature.id}
 						feature={props.imbuement.feature}
-						options={props.options}
 						hero={props.hero}
 						sourcebooks={props.sourcebooks}
 						mode={PanelMode.Full}

--- a/src/components/panels/elements/item-panel/item-panel.tsx
+++ b/src/components/panels/elements/item-panel/item-panel.tsx
@@ -15,7 +15,6 @@ import { ItemType } from '@/enums/item-type';
 import { Markdown } from '@/components/controls/markdown/markdown';
 import { Modal } from '@/components/modals/modal/modal';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { PlusOutlined } from '@ant-design/icons';
 import { ProjectPanel } from '@/components/panels/elements/project-panel/project-panel';
@@ -31,7 +30,6 @@ import './item-panel.scss';
 interface Props {
 	item: Item;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	wielder?: Hero;
 	mode?: PanelMode;
 	style?: CSSProperties;
@@ -92,7 +90,6 @@ export const ItemPanel = (props: Props) => {
 											<FeaturePanel
 												key={f.id}
 												feature={f}
-												options={props.options}
 												mode={PanelMode.Full}
 											/>
 										))
@@ -185,7 +182,7 @@ export const ItemPanel = (props: Props) => {
 					{
 						options.map(f => (
 							<SelectablePanel key={f.feature.id} onSelect={() => addImbuement(f)}>
-								<FeaturePanel feature={f.feature} options={props.options} hero={props.wielder} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
+								<FeaturePanel feature={f.feature} hero={props.wielder} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
 							</SelectablePanel>
 						))
 					}
@@ -217,7 +214,6 @@ export const ItemPanel = (props: Props) => {
 							<FeatureConfigPanel
 								key={f.id}
 								feature={f}
-								options={props.options}
 								hero={props.wielder!}
 								sourcebooks={props.sourcebooks}
 								setData={setFeatureData}

--- a/src/components/panels/elements/kit-panel/kit-panel.tsx
+++ b/src/components/panels/elements/kit-panel/kit-panel.tsx
@@ -5,7 +5,6 @@ import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { Kit } from '@/models/kit';
 import { Markdown } from '@/components/controls/markdown/markdown';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Segmented } from 'antd';
 import { SheetFormatter } from '@/logic/classic-sheet/sheet-formatter';
@@ -19,7 +18,6 @@ import './kit-panel.scss';
 interface Props {
 	kit: Kit;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	hero?: Hero;
 	mode?: PanelMode;
 }
@@ -65,7 +63,7 @@ export const KitPanel = (props: Props) => {
 	const getFeatures = () => {
 		return (
 			<>
-				{props.kit.features.map(f => <FeaturePanel key={f.id} feature={f} options={props.options} hero={props.hero} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />)}
+				{props.kit.features.map(f => <FeaturePanel key={f.id} feature={f} hero={props.hero} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />)}
 			</>
 		);
 	};

--- a/src/components/panels/elements/monster-group-panel/monster-group-panel.tsx
+++ b/src/components/panels/elements/monster-group-panel/monster-group-panel.tsx
@@ -7,7 +7,6 @@ import { Markdown } from '@/components/controls/markdown/markdown';
 import { Monster } from '@/models/monster';
 import { MonsterGroup } from '@/models/monster-group';
 import { MonsterPanel } from '@/components/panels/elements/monster-panel/monster-panel';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Segmented } from 'antd';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
@@ -21,7 +20,6 @@ import './monster-group-panel.scss';
 
 interface Props {
 	monsterGroup: MonsterGroup;
-	options: Options;
 	sourcebooks: Sourcebook[];
 	mode?: PanelMode;
 	onSelectMonster?: (monster: Monster) => void;
@@ -74,7 +72,6 @@ export const MonsterGroupPanel = (props: Props) => {
 								<SelectablePanel key={m.id}>
 									<FeaturePanel
 										feature={m}
-										options={props.options}
 										mode={PanelMode.Full}
 										cost={cost}
 										repeatable={m.type === FeatureType.Malice ? m.data.repeatable : undefined}
@@ -98,7 +95,7 @@ export const MonsterGroupPanel = (props: Props) => {
 				{
 					props.monsterGroup.monsters.map(m =>
 						<SelectablePanel key={m.id} onSelect={props.onSelectMonster ? () => props.onSelectMonster!(m) : undefined}>
-							<MonsterPanel monster={m} monsterGroup={props.monsterGroup} sourcebooks={props.sourcebooks} options={props.options} />
+							<MonsterPanel monster={m} monsterGroup={props.monsterGroup} sourcebooks={props.sourcebooks} />
 						</SelectablePanel>
 					)
 				}
@@ -116,7 +113,7 @@ export const MonsterGroupPanel = (props: Props) => {
 				{
 					props.monsterGroup.addOns.map(a =>
 						<SelectablePanel key={a.id}>
-							<FeaturePanel feature={a} options={props.options} cost={a.data.cost} mode={PanelMode.Full} />
+							<FeaturePanel feature={a} cost={a.data.cost} mode={PanelMode.Full} />
 						</SelectablePanel>
 					)
 				}

--- a/src/components/panels/elements/monster-panel/monster-panel.tsx
+++ b/src/components/panels/elements/monster-panel/monster-panel.tsx
@@ -23,7 +23,6 @@ import { MonsterLabel } from '@/components/panels/monster-label/monster-label';
 import { MonsterLogic } from '@/logic/monster-logic';
 import { MonsterOrganizationType } from '@/enums/monster-organization-type';
 import { MonsterToken } from '@/components/panels/token/token';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
 import { SheetFormatter } from '@/logic/classic-sheet/sheet-formatter';
@@ -40,7 +39,6 @@ interface Props {
 	monsterGroup?: MonsterGroup;
 	summon?: SummoningInfo;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	mode?: PanelMode;
 	style?: CSSProperties;
 	extra?: ReactNode;
@@ -272,7 +270,6 @@ export const MonsterPanel = (props: Props) => {
 																	<FeaturePanel
 																		key={f.feature.id}
 																		feature={f.feature}
-																		options={props.options}
 																		mode={PanelMode.Full}
 																	/>
 																))

--- a/src/components/panels/elements/montage-panel/montage-panel.tsx
+++ b/src/components/panels/elements/montage-panel/montage-panel.tsx
@@ -1,10 +1,10 @@
 import { Flex, Segmented, Space } from 'antd';
 import { Montage, MontageChallenge, MontageSection } from '@/models/montage';
+import { useHeroes, useOptions } from '@/contexts/data-context';
 import { CheckIcon } from '@/components/controls/check-icon/check-icon';
 import { ErrorBoundary } from '@/components/controls/error-boundary/error-boundary';
 import { Field } from '@/components/controls/field/field';
 import { HeaderText } from '@/components/controls/header-text/header-text';
-import { Hero } from '@/models/hero';
 import { Markdown } from '@/components/controls/markdown/markdown';
 import { MontageLogic } from '@/logic/montage-logic';
 import { PanelMode } from '@/enums/panel-mode';
@@ -14,14 +14,12 @@ import { Sourcebook } from '@/models/sourcebook';
 import { SourcebookLogic } from '@/logic/sourcebook-logic';
 import { SourcebookType } from '@/enums/sourcebook-type';
 import { StatsRow } from '@/components/panels/stats-row/stats-row';
-import { useOptions } from '@/contexts/data-context';
 import { useState } from 'react';
 
 import './montage-panel.scss';
 
 interface Props {
 	montage: Montage;
-	heroes: Hero[];
 	sourcebooks: Sourcebook[];
 	mode?: PanelMode;
 }
@@ -29,6 +27,7 @@ interface Props {
 export const MontagePanel = (props: Props) => {
 	const [ page, setPage ] = useState<string>('overview');
 	const options = useOptions();
+	const heroes = useHeroes();
 
 	const getOverview = () => {
 		return (
@@ -45,7 +44,7 @@ export const MontagePanel = (props: Props) => {
 						label='Success Limit'
 						value={(
 							<Space>
-								{MontageLogic.getSuccessLimit(props.montage, props.heroes, options)}
+								{MontageLogic.getSuccessLimit(props.montage, heroes, options)}
 								<CheckIcon state='success' />
 							</Space>
 						)}
@@ -55,7 +54,7 @@ export const MontagePanel = (props: Props) => {
 						label='Failure Limit'
 						value={(
 							<Space>
-								{MontageLogic.getFailureLimit(props.montage, props.heroes, options)}
+								{MontageLogic.getFailureLimit(props.montage, heroes, options)}
 								<CheckIcon state='failure' />
 							</Space>
 						)}

--- a/src/components/panels/elements/montage-panel/montage-panel.tsx
+++ b/src/components/panels/elements/montage-panel/montage-panel.tsx
@@ -7,7 +7,6 @@ import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { Markdown } from '@/components/controls/markdown/markdown';
 import { MontageLogic } from '@/logic/montage-logic';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Pill } from '@/components/controls/pill/pill';
 import { SheetFormatter } from '@/logic/classic-sheet/sheet-formatter';
@@ -15,6 +14,7 @@ import { Sourcebook } from '@/models/sourcebook';
 import { SourcebookLogic } from '@/logic/sourcebook-logic';
 import { SourcebookType } from '@/enums/sourcebook-type';
 import { StatsRow } from '@/components/panels/stats-row/stats-row';
+import { useOptions } from '@/contexts/data-context';
 import { useState } from 'react';
 
 import './montage-panel.scss';
@@ -23,12 +23,12 @@ interface Props {
 	montage: Montage;
 	heroes: Hero[];
 	sourcebooks: Sourcebook[];
-	options: Options;
 	mode?: PanelMode;
 }
 
 export const MontagePanel = (props: Props) => {
 	const [ page, setPage ] = useState<string>('overview');
+	const options = useOptions();
 
 	const getOverview = () => {
 		return (
@@ -45,7 +45,7 @@ export const MontagePanel = (props: Props) => {
 						label='Success Limit'
 						value={(
 							<Space>
-								{MontageLogic.getSuccessLimit(props.montage, props.heroes, props.options)}
+								{MontageLogic.getSuccessLimit(props.montage, props.heroes, options)}
 								<CheckIcon state='success' />
 							</Space>
 						)}
@@ -55,7 +55,7 @@ export const MontagePanel = (props: Props) => {
 						label='Failure Limit'
 						value={(
 							<Space>
-								{MontageLogic.getFailureLimit(props.montage, props.heroes, props.options)}
+								{MontageLogic.getFailureLimit(props.montage, props.heroes, options)}
 								<CheckIcon state='failure' />
 							</Space>
 						)}

--- a/src/components/panels/elements/negotiation-panel/negotiation-panel.tsx
+++ b/src/components/panels/elements/negotiation-panel/negotiation-panel.tsx
@@ -4,7 +4,6 @@ import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Markdown } from '@/components/controls/markdown/markdown';
 import { Negotiation } from '@/models/negotiation';
 import { NegotiationLogic } from '@/logic/negotiation-logic';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Segmented } from 'antd';
 import { SheetFormatter } from '@/logic/classic-sheet/sheet-formatter';
@@ -19,7 +18,6 @@ import './negotiation-panel.scss';
 interface Props {
 	negotiation: Negotiation;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	mode?: PanelMode;
 }
 

--- a/src/components/panels/elements/perk-panel/perk-panel.tsx
+++ b/src/components/panels/elements/perk-panel/perk-panel.tsx
@@ -1,7 +1,6 @@
 import { ErrorBoundary } from '@/components/controls/error-boundary/error-boundary';
 import { FeaturePanel } from '@/components/panels/elements/feature-panel/feature-panel';
 import { Hero } from '@/models/hero';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Perk } from '@/models/perk';
 import { SheetFormatter } from '@/logic/classic-sheet/sheet-formatter';
@@ -12,7 +11,6 @@ import './perk-panel.scss';
 interface Props {
 	perk: Perk;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	hero?: Hero;
 	mode?: PanelMode;
 }
@@ -21,7 +19,7 @@ export const PerkPanel = (props: Props) => {
 	return (
 		<ErrorBoundary>
 			<div className={props.mode === PanelMode.Full ? 'perk-panel' : 'perk-panel compact'} id={props.mode === PanelMode.Full ? SheetFormatter.getPageId('perk', props.perk.id) : undefined}>
-				<FeaturePanel feature={props.perk} options={props.options} hero={props.hero} sourcebooks={props.sourcebooks} mode={props.mode} />
+				<FeaturePanel feature={props.perk} hero={props.hero} sourcebooks={props.sourcebooks} mode={props.mode} />
 			</div>
 		</ErrorBoundary>
 	);

--- a/src/components/panels/elements/plot-panel/plot-panel.tsx
+++ b/src/components/panels/elements/plot-panel/plot-panel.tsx
@@ -11,7 +11,6 @@ import { ErrorBoundary } from '@/components/controls/error-boundary/error-bounda
 import { Format } from '@/utils/format';
 import { FormatLogic } from '@/logic/format-logic';
 import { HeaderText } from '@/components/controls/header-text/header-text';
-import { Hero } from '@/models/hero';
 import { Markdown } from '@/components/controls/markdown/markdown';
 import { MontagePanel } from '@/components/panels/elements/montage-panel/montage-panel';
 import { NegotiationPanel } from '@/components/panels/elements/negotiation-panel/negotiation-panel';
@@ -31,7 +30,6 @@ interface PlotPanelProps {
 	plot: Plot;
 	adventure: Adventure;
 	sourcebooks: Sourcebook[];
-	heroes: Hero[];
 	mode?: PanelMode;
 	onSelect: (plot: Plot) => void;
 	onStart: (kind: SourcebookElementKind, element: Element, party: string) => void;
@@ -81,7 +79,6 @@ export const PlotPanel = (props: PlotPanelProps) => {
 									<EncounterPanel
 										encounter={encounter}
 										sourcebooks={props.sourcebooks}
-										heroes={props.heroes}
 									/>
 									<SashPanel monogram='Encounter' />
 								</SelectablePanel>
@@ -96,7 +93,6 @@ export const PlotPanel = (props: PlotPanelProps) => {
 								<SelectablePanel style={{ overflow: 'hidden' }} onSelect={() => navigation.goToLibrary('montage', montage.id)}>
 									<MontagePanel
 										montage={montage}
-										heroes={props.heroes}
 										sourcebooks={props.sourcebooks}
 									/>
 									<SashPanel monogram='Montage' />

--- a/src/components/panels/elements/plot-panel/plot-panel.tsx
+++ b/src/components/panels/elements/plot-panel/plot-panel.tsx
@@ -15,7 +15,6 @@ import { Hero } from '@/models/hero';
 import { Markdown } from '@/components/controls/markdown/markdown';
 import { MontagePanel } from '@/components/panels/elements/montage-panel/montage-panel';
 import { NegotiationPanel } from '@/components/panels/elements/negotiation-panel/negotiation-panel';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { PowerRollPanel } from '@/components/panels/power-roll/power-roll-panel';
 import { SashPanel } from '@/components/panels/sash/sash-panel';
@@ -33,7 +32,6 @@ interface PlotPanelProps {
 	adventure: Adventure;
 	sourcebooks: Sourcebook[];
 	heroes: Hero[];
-	options: Options;
 	mode?: PanelMode;
 	onSelect: (plot: Plot) => void;
 	onStart: (kind: SourcebookElementKind, element: Element, party: string) => void;
@@ -84,7 +82,6 @@ export const PlotPanel = (props: PlotPanelProps) => {
 										encounter={encounter}
 										sourcebooks={props.sourcebooks}
 										heroes={props.heroes}
-										options={props.options}
 									/>
 									<SashPanel monogram='Encounter' />
 								</SelectablePanel>
@@ -101,7 +98,6 @@ export const PlotPanel = (props: PlotPanelProps) => {
 										montage={montage}
 										heroes={props.heroes}
 										sourcebooks={props.sourcebooks}
-										options={props.options}
 									/>
 									<SashPanel monogram='Montage' />
 								</SelectablePanel>
@@ -117,7 +113,6 @@ export const PlotPanel = (props: PlotPanelProps) => {
 									<NegotiationPanel
 										negotiation={negotiation}
 										sourcebooks={props.sourcebooks}
-										options={props.options}
 									/>
 									<SashPanel monogram='Negotiation' />
 								</SelectablePanel>
@@ -136,7 +131,6 @@ export const PlotPanel = (props: PlotPanelProps) => {
 											map={map}
 											display={TacticalMapDisplayType.Thumbnail}
 											sourcebooks={props.sourcebooks}
-											options={props.options}
 										/>
 									</div>
 									<SashPanel monogram='Map' />
@@ -285,7 +279,6 @@ export const PlotPanel = (props: PlotPanelProps) => {
 							category={selectedReference.type}
 							element={SourcebookLogic.getElement(selectedReference.contentID, props.sourcebooks) as Element}
 							sourcebooks={props.sourcebooks}
-							options={props.options}
 							onClose={() => setSelectedReference(null)}
 						/>
 						: null

--- a/src/components/panels/elements/sourcebook-panel/sourcebook-panel.tsx
+++ b/src/components/panels/elements/sourcebook-panel/sourcebook-panel.tsx
@@ -11,7 +11,6 @@ import { Expander } from '@/components/controls/expander/expander';
 import { Field } from '@/components/controls/field/field';
 import { Format } from '@/utils/format';
 import { HeaderText } from '@/components/controls/header-text/header-text';
-import { Hero } from '@/models/hero';
 import { LanguageType } from '@/enums/language-type';
 import { NameDescEditPanel } from '../../edit/name-desc-edit/name-desc-edit-panel';
 import { NameSuggestions } from '@/components/panels/name-suggestions/name-suggestions';
@@ -22,12 +21,12 @@ import { SourcebookLogic } from '@/logic/sourcebook-logic';
 import { SourcebookType } from '@/enums/sourcebook-type';
 import { TextInput } from '@/components/controls/text-input/text-input';
 import { Utils } from '@/utils/utils';
+import { useHeroes } from '@/contexts/data-context';
 
 import './sourcebook-panel.scss';
 
 interface Props {
 	sourcebook: Sourcebook;
-	heroes: Hero[];
 	sourcebooks: Sourcebook[];
 	visibility?: {
 		visible: boolean;
@@ -41,6 +40,7 @@ interface Props {
 export const SourcebookPanel = (props: Props) => {
 	const [ sourcebook, setSourcebook ] = useState<Sourcebook>(Utils.copy(props.sourcebook));
 	const [ isEditing, setIsEditing ] = useState<boolean>(false);
+	const allHeroes = useHeroes();
 
 	const getContent = () => {
 		if (props.mode !== PanelMode.Full) {
@@ -401,7 +401,7 @@ export const SourcebookPanel = (props: Props) => {
 					/>
 				);
 
-				const heroes = props.heroes.filter(h => h.sourcebookIDs.includes(sourcebook.id));
+				const heroes = allHeroes.filter(h => h.sourcebookIDs.includes(sourcebook.id));
 
 				const used: { element: Element, type: string, container: Element }[] = [];
 				const elements = [

--- a/src/components/panels/elements/subclass-panel/subclass-panel.tsx
+++ b/src/components/panels/elements/subclass-panel/subclass-panel.tsx
@@ -9,7 +9,6 @@ import { Field } from '@/components/controls/field/field';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { Markdown } from '@/components/controls/markdown/markdown';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Segmented } from 'antd';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
@@ -24,7 +23,6 @@ import './subclass-panel.scss';
 interface Props {
 	subclass: SubClass;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	hero?: Hero;
 	mode?: PanelMode;
 	style?: CSSProperties;
@@ -56,7 +54,7 @@ export const SubclassPanel = (props: Props) => {
 							>
 								{
 									...lvl.features.map(f =>
-										<FeaturePanel key={f.id} feature={f} options={props.options} hero={props.hero} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
+										<FeaturePanel key={f.id} feature={f} hero={props.hero} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
 									)
 								}
 							</Expander>

--- a/src/components/panels/elements/tactical-map-panel/tactical-map-panel.tsx
+++ b/src/components/panels/elements/tactical-map-panel/tactical-map-panel.tsx
@@ -26,7 +26,6 @@ import { MonsterGroup } from '@/models/monster-group';
 import { MonsterModal } from '@/components/modals/monster/monster-modal';
 import { MonsterOrganizationType } from '@/enums/monster-organization-type';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Radial } from '@/components/controls/radial/radial';
 import { SheetFormatter } from '@/logic/classic-sheet/sheet-formatter';
@@ -38,6 +37,7 @@ import { TacticalMapLogic } from '@/logic/tactical-map-logic';
 import { TextInput } from '@/components/controls/text-input/text-input';
 import { Toggle } from '@/components/controls/toggle/toggle';
 import { Utils } from '@/utils/utils';
+import { useOptions } from '@/contexts/data-context';
 
 import './tactical-map-panel.scss';
 
@@ -59,7 +59,6 @@ interface SelectedMonsterInfo {
 interface Props {
 	map: TacticalMap;
 	display: TacticalMapDisplayType;
-	options: Options;
 	heroes?: Hero[];
 	encounters?: Encounter[];
 	sourcebooks: Sourcebook[];
@@ -70,6 +69,7 @@ interface Props {
 }
 
 export const TacticalMapPanel = (props: Props) => {
+	const options = useOptions();
 	const [ map, setMap ] = useState<TacticalMap>(Utils.copy(props.map));
 	const [ editMode, setEditMode ] = useState<TacticalMapEditMode>(TacticalMapEditMode.Map);
 	const [ editAdding, setEditAdding ] = useState<boolean>(false);
@@ -94,7 +94,7 @@ export const TacticalMapPanel = (props: Props) => {
 	const [ selectedMonster, setSelectedMonster ] = useState<SelectedMonsterInfo | null>(null);
 
 	const zLevel = 0;
-	const size = props.display === 'thumbnail' ? 5 : props.options.gridSize;
+	const size = props.display === 'thumbnail' ? 5 : options.gridSize;
 
 	const updateMapItem = (item: MapItem) => {
 		const copy = Utils.copy(map);
@@ -1543,7 +1543,6 @@ export const TacticalMapPanel = (props: Props) => {
 							monsterGroup={selectedMonster.monsterGroup}
 							encounter={selectedMonster.encounter}
 							sourcebooks={props.sourcebooks}
-							options={props.options}
 							onClose={() => setSelectedMonster(null)}
 							updateMonster={monster => {
 								const mini = map.items.filter(item => item.type === 'mini').find(mini => mini.id === selectedMapItemID);

--- a/src/components/panels/elements/title-panel/title-panel.tsx
+++ b/src/components/panels/elements/title-panel/title-panel.tsx
@@ -7,7 +7,6 @@ import { FeatureType } from '@/enums/feature-type';
 import { Field } from '@/components/controls/field/field';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { SheetFormatter } from '@/logic/classic-sheet/sheet-formatter';
 import { Sourcebook } from '@/models/sourcebook';
@@ -23,7 +22,6 @@ import './title-panel.scss';
 interface Props {
 	title: Title;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	hero?: Hero;
 	mode?: PanelMode;
 	onChange?: (title: Title) => void;
@@ -107,7 +105,6 @@ export const TitlePanel = (props: Props) => {
 											<FeaturePanel
 												key={f.id}
 												feature={f}
-												options={props.options}
 												hero={props.hero}
 												sourcebooks={props.sourcebooks}
 												mode={PanelMode.Full}

--- a/src/components/panels/encounter-difficulty/encounter-difficulty-panel.tsx
+++ b/src/components/panels/encounter-difficulty/encounter-difficulty-panel.tsx
@@ -1,34 +1,33 @@
 import { Alert, Slider } from 'antd';
+import { useHeroes, useOptions } from '@/contexts/data-context';
 import { Encounter } from '@/models/encounter';
 import { EncounterDifficultyLogic } from '@/logic/encounter-difficulty-logic';
 import { EncounterLogic } from '@/logic/encounter-logic';
 import { ErrorBoundary } from '@/components/controls/error-boundary/error-boundary';
 import { Field } from '@/components/controls/field/field';
 import { HeaderText } from '@/components/controls/header-text/header-text';
-import { Hero } from '@/models/hero';
 import { Info } from '@/components/controls/info/info';
 import { OptionsLogic } from '@/logic/options-logic';
 import { ReactNode } from 'react';
 import { Sourcebook } from '@/models/sourcebook';
 import { SourcebookLogic } from '@/logic/sourcebook-logic';
 import { StatsRow } from '@/components/panels/stats-row/stats-row';
-import { useOptions } from '@/contexts/data-context';
 
 import './encounter-difficulty-panel.scss';
 
 interface Props {
 	encounter: Encounter;
 	sourcebooks: Sourcebook[];
-	heroes: Hero[];
 	showHeader?: boolean;
 }
 
 export const EncounterDifficultyPanel = (props: Props) => {
 	const options = useOptions();
+	const heroes = useHeroes();
 	const count = EncounterLogic.getMonsterCount(props.encounter, props.sourcebooks);
-	const budgets = EncounterDifficultyLogic.getBudgets(options, props.heroes);
+	const budgets = EncounterDifficultyLogic.getBudgets(options, heroes);
 	const strength = EncounterDifficultyLogic.getStrength(props.encounter, props.sourcebooks);
-	const difficulty = EncounterDifficultyLogic.getDifficulty(strength, options, props.heroes);
+	const difficulty = EncounterDifficultyLogic.getDifficulty(strength, options, heroes);
 	const victories = EncounterDifficultyLogic.getVictories(difficulty);
 
 	const marks: Record<string | number, ReactNode> = {};

--- a/src/components/panels/encounter-difficulty/encounter-difficulty-panel.tsx
+++ b/src/components/panels/encounter-difficulty/encounter-difficulty-panel.tsx
@@ -7,12 +7,12 @@ import { Field } from '@/components/controls/field/field';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { Info } from '@/components/controls/info/info';
-import { Options } from '@/models/options';
 import { OptionsLogic } from '@/logic/options-logic';
 import { ReactNode } from 'react';
 import { Sourcebook } from '@/models/sourcebook';
 import { SourcebookLogic } from '@/logic/sourcebook-logic';
 import { StatsRow } from '@/components/panels/stats-row/stats-row';
+import { useOptions } from '@/contexts/data-context';
 
 import './encounter-difficulty-panel.scss';
 
@@ -20,15 +20,15 @@ interface Props {
 	encounter: Encounter;
 	sourcebooks: Sourcebook[];
 	heroes: Hero[];
-	options: Options;
 	showHeader?: boolean;
 }
 
 export const EncounterDifficultyPanel = (props: Props) => {
+	const options = useOptions();
 	const count = EncounterLogic.getMonsterCount(props.encounter, props.sourcebooks);
-	const budgets = EncounterDifficultyLogic.getBudgets(props.options, props.heroes);
+	const budgets = EncounterDifficultyLogic.getBudgets(options, props.heroes);
 	const strength = EncounterDifficultyLogic.getStrength(props.encounter, props.sourcebooks);
-	const difficulty = EncounterDifficultyLogic.getDifficulty(strength, props.options, props.heroes);
+	const difficulty = EncounterDifficultyLogic.getDifficulty(strength, options, props.heroes);
 	const victories = EncounterDifficultyLogic.getVictories(difficulty);
 
 	const marks: Record<string | number, ReactNode> = {};
@@ -44,13 +44,13 @@ export const EncounterDifficultyPanel = (props: Props) => {
 		.map(s => SourcebookLogic.getMonster(props.sourcebooks, s.monsterID))
 		.filter(m => !!m)
 		.map(m => m.level);
-	if (Math.max(...levels) > props.options.heroLevel + 2) {
+	if (Math.max(...levels) > options.heroLevel + 2) {
 		warnings.push(
 			<Alert
 				key='too-high-level'
 				type='warning'
 				showIcon={true}
-				title={`This encounter contains a monster of level ${Math.max(...levels)}; for this party, anything above level ${props.options.heroLevel + 2} may cause problems.`}
+				title={`This encounter contains a monster of level ${Math.max(...levels)}; for this party, anything above level ${options.heroLevel + 2} may cause problems.`}
 			/>
 		);
 	}
@@ -60,7 +60,7 @@ export const EncounterDifficultyPanel = (props: Props) => {
 			<div className='encounter-difficulty-panel'>
 				{props.showHeader !== false ? <HeaderText level={1}>Encounter Difficulty</HeaderText> : null}
 				<div className='ds-text'>
-					Difficulty for {OptionsLogic.getPartyDescription(props.options)}.
+					Difficulty for {OptionsLogic.getPartyDescription(options)}.
 					<Info>
 						<p>You can change the party size and level in Settings.</p>
 					</Info>

--- a/src/components/panels/encounter-group/encounter-group-panel.tsx
+++ b/src/components/panels/encounter-group/encounter-group-panel.tsx
@@ -14,7 +14,6 @@ import { HeroLogic } from '@/logic/hero-logic';
 import { Monster } from '@/models/monster';
 import { MonsterLogic } from '@/logic/monster-logic';
 import { MonsterOrganizationType } from '@/enums/monster-organization-type';
-import { Options } from '@/models/options';
 import { Sourcebook } from '@/models/sourcebook';
 import { SourcebookLogic } from '@/logic/sourcebook-logic';
 import { Terrain } from '@/models/terrain';
@@ -34,7 +33,6 @@ interface EncounterGroupHeroProps {
 	hero: Hero;
 	encounter: Encounter;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	onSelect: (hero: Hero) => void;
 	onSelectMonster: (monster: Monster, monsterGroupID: string) => void;
 	onSelectMinionSlot: (slot: EncounterSlot) => void;

--- a/src/components/panels/feature-config-panel/feature-config-panel.tsx
+++ b/src/components/panels/feature-config-panel/feature-config-panel.tsx
@@ -10,7 +10,6 @@ import { FeatureType } from '@/enums/feature-type';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { Markdown } from '@/components/controls/markdown/markdown';
-import { Options } from '@/models/options';
 import { Perk } from '@/models/perk';
 import { Sourcebook } from '@/models/sourcebook';
 import { useState } from 'react';
@@ -19,7 +18,6 @@ import './feature-config-panel.scss';
 
 interface Props {
 	feature: Feature | Perk;
-	options: Options;
 	hero: Hero;
 	sourcebooks: Sourcebook[];
 	setData: (featureID: string, data: FeatureData) => void;
@@ -89,7 +87,6 @@ export const FeatureConfigPanel = (props: Props) => {
 					feature={props.feature}
 					hero={props.hero}
 					sourcebooks={props.sourcebooks}
-					options={props.options}
 					setData={data => props.setData(props.feature.id, data)}
 				/>
 			</div>

--- a/src/components/panels/hero/abilities/abilities-panel.tsx
+++ b/src/components/panels/hero/abilities/abilities-panel.tsx
@@ -7,10 +7,10 @@ import { Empty } from '@/components/controls/empty/empty';
 import { ErrorBoundary } from '@/components/controls/error-boundary/error-boundary';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
 import { useIsSmall } from '@/hooks/use-is-small';
+import { useOptions } from '@/contexts/data-context';
 
 import './abilities-panel.scss';
 
@@ -18,12 +18,12 @@ interface Props {
 	title: string;
 	abilities: { ability: Ability, source: string, level: number | undefined }[];
 	hero: Hero;
-	options: Options;
 	onSelectAbility: (ability: Ability) => void;
 }
 
 export const AbilitiesPanel = (props: Props) => {
 	const isSmall = useIsSmall();
+	const options = useOptions();
 
 	if (props.abilities.length === 0) {
 		return null;
@@ -35,7 +35,7 @@ export const AbilitiesPanel = (props: Props) => {
 				<div><b>{data.ability.name}</b></div>
 				<div>{data.ability.distance.map(d => AbilityLogic.getDistance(d, data.ability, props.hero)).join(' or ')}</div>
 				<div>{data.ability.target}</div>
-				{props.options.showSources ? <Tag variant='outlined'>{data.source}</Tag> : null}
+				{options.showSources ? <Tag variant='outlined'>{data.source}</Tag> : null}
 				{
 					data.ability.cost === 'signature' ?
 						<Pill>Signature</Pill>
@@ -50,18 +50,18 @@ export const AbilitiesPanel = (props: Props) => {
 	const nonStandard = props.abilities.filter(a => a.source !== 'Standard');
 	const standard = props.abilities.filter(a => a.source === 'Standard');
 
-	const useRows = props.options.compactView;
+	const useRows = options.compactView;
 
 	return (
 		<ErrorBoundary>
 			<div className='abilities-section'>
-				{useRows ? <HeaderText level={props.options.compactView ? 3 : 1}>{props.title}</HeaderText> : null}
+				{useRows ? <HeaderText level={options.compactView ? 3 : 1}>{props.title}</HeaderText> : null}
 				{
 					(nonStandard.length === 0) && (standard.length === 0) ?
 						<Empty />
 						: null
 				}
-				<div className={`abilities-grid ${useRows ? 'compact' : ''} ${props.options.abilityWidth.toLowerCase().replace(' ', '-')}`}>
+				<div className={`abilities-grid ${useRows ? 'compact' : ''} ${options.abilityWidth.toLowerCase().replace(' ', '-')}`}>
 					{
 						nonStandard.map(a =>
 							useRows ?
@@ -71,9 +71,8 @@ export const AbilitiesPanel = (props: Props) => {
 									<AbilityPanel
 										ability={a.ability}
 										hero={props.hero}
-										options={props.options}
 										mode={PanelMode.Full}
-										tags={props.options.showSources ? [ a.level ? `${a.source} (level ${a.level})` : a.source ] : undefined}
+										tags={options.showSources ? [ a.level ? `${a.source} (level ${a.level})` : a.source ] : undefined}
 									/>
 								</SelectablePanel>
 						)
@@ -84,7 +83,7 @@ export const AbilitiesPanel = (props: Props) => {
 						<Divider />
 						: null
 				}
-				<div className={`abilities-grid ${useRows ? 'compact' : ''} ${props.options.abilityWidth.toLowerCase().replace(' ', '-')}`}>
+				<div className={`abilities-grid ${useRows ? 'compact' : ''} ${options.abilityWidth.toLowerCase().replace(' ', '-')}`}>
 					{
 						standard.map(a =>
 							useRows ?
@@ -94,9 +93,8 @@ export const AbilitiesPanel = (props: Props) => {
 									<AbilityPanel
 										ability={a.ability}
 										hero={props.hero}
-										options={props.options}
 										mode={PanelMode.Full}
-										tags={props.options.showSources ? [ a.source ] : undefined}
+										tags={options.showSources ? [ a.source ] : undefined}
 									/>
 								</SelectablePanel>
 						)

--- a/src/components/panels/hero/choices/choices-panel.tsx
+++ b/src/components/panels/hero/choices/choices-panel.tsx
@@ -12,17 +12,16 @@ import { HeroClass } from '@/models/class';
 import { HeroLogic } from '@/logic/hero-logic';
 import { HeroModalType } from '@/enums/hero-modal-type';
 import { Kit } from '@/models/kit';
-import { Options } from '@/models/options';
 import { ProjectLogic } from '@/logic/project-logic';
 import { Sourcebook } from '@/models/sourcebook';
 import { Title } from '@/models/title';
+import { useOptions } from '@/contexts/data-context';
 
 import './choices-panel.scss';
 
 interface Props {
 	hero: Hero;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	onSelectAncestry: (ancestry: Ancestry) => void;
 	onSelectCulture: (culture: Culture) => void;
 	onSelectCareer: (career: Career) => void;
@@ -35,12 +34,13 @@ interface Props {
 }
 
 export const ChoicesPanel = (props: Props) => {
+	const options = useOptions();
 	let incitingIncident: Element | null = null;
 	if (props.hero.career) {
 		incitingIncident = props.hero.career.incitingIncidents.selected;
 	}
 
-	const useRows = props.options.compactView;
+	const useRows = options.compactView;
 
 	return (
 		<ErrorBoundary>

--- a/src/components/panels/hero/features/features-panel.tsx
+++ b/src/components/panels/hero/features/features-panel.tsx
@@ -10,13 +10,13 @@ import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { HeroLogic } from '@/logic/hero-logic';
 import { LabelControl } from '@/components/controls/label-control/label-control';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { SearchBox } from '@/components/controls/text-input/text-input';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
 import { Sourcebook } from '@/models/sourcebook';
 import { Toggle } from '@/components/controls/toggle/toggle';
 import { Utils } from '@/utils/utils';
+import { useOptions } from '@/contexts/data-context';
 import { useState } from 'react';
 
 import './features-panel.scss';
@@ -24,7 +24,6 @@ import './features-panel.scss';
 interface Props {
 	hero: Hero;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	onSelectFeature: (feature: Feature) => void;
 }
 
@@ -32,6 +31,7 @@ export const FeaturesPanel = (props: Props) => {
 	const [ featureSearch, setFeatureSearch ] = useState<string>('');
 	const [ featureSort, setFeatureSort ] = useState<string>('az');
 	const [ featureAll, setFeatureAll ] = useState<boolean>(false);
+	const options = useOptions();
 
 	const features = HeroLogic.getFeatures(props.hero)
 		.filter(f => {
@@ -91,12 +91,12 @@ export const FeaturesPanel = (props: Props) => {
 		return (
 			<div key={data.feature.id} className='selectable-row clickable' onClick={() => props.onSelectFeature(data.feature)}>
 				<div><b>{data.feature.name}</b></div>
-				{props.options.showSources ? <Tag variant='outlined'>{data.source}</Tag> : null}
+				{options.showSources ? <Tag variant='outlined'>{data.source}</Tag> : null}
 			</div>
 		);
 	};
 
-	const useRows = props.options.compactView;
+	const useRows = options.compactView;
 
 	const controls = (
 		<ButtonGroup
@@ -155,8 +155,7 @@ export const FeaturesPanel = (props: Props) => {
 											<SelectablePanel key={f.feature.id} onSelect={() => props.onSelectFeature(f.feature)}>
 												<FeaturePanel
 													feature={f.feature}
-													source={props.options.showSources ? (f.level ? `${f.source} (level ${f.level})` : f.source) : undefined}
-													options={props.options}
+													source={options.showSources ? (f.level ? `${f.source} (level ${f.level})` : f.source) : undefined}
 													hero={props.hero}
 													sourcebooks={props.sourcebooks}
 													mode={PanelMode.Full}

--- a/src/components/panels/hero/hero-panel.tsx
+++ b/src/components/panels/hero/hero-panel.tsx
@@ -23,7 +23,6 @@ import { HeroModalType } from '@/enums/hero-modal-type';
 import { Kit } from '@/models/kit';
 import { Monster } from '@/models/monster';
 import { NamePanel } from '@/components/panels/hero/name/name-panel';
-import { Options } from '@/models/options';
 import { RetinuePanel } from '@/components/panels/hero/retinue/retinue-panel';
 import { RulesPage } from '@/enums/rules-page';
 import { SheetFormatter } from '@/logic/classic-sheet/sheet-formatter';
@@ -34,6 +33,7 @@ import { StatsSidebarPanel } from '@/components/panels/hero/stats-sidebar/stats-
 import { SummoningInfo } from '@/models/summon';
 import { Title } from '@/models/title';
 import { useIsSmall } from '@/hooks/use-is-small';
+import { useOptions } from '@/contexts/data-context';
 import { useState } from 'react';
 
 import './hero-panel.scss';
@@ -41,7 +41,6 @@ import './hero-panel.scss';
 interface Props {
 	hero: Hero;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	onSelectAncestry: (ancestry: Ancestry) => void;
 	onSelectCulture: (culture: Culture) => void;
 	onSelectCareer: (career: Career) => void;
@@ -68,6 +67,7 @@ interface Props {
 export const HeroPanel = (props: Props) => {
 	const isSmall = useIsSmall();
 	const [ tab, setTab ] = useState<string>('Hero');
+	const options = useOptions();
 
 	const getTabs = () => {
 		const tabs: string[] = [];
@@ -75,8 +75,8 @@ export const HeroPanel = (props: Props) => {
 		tabs.push('Hero');
 		tabs.push('Features');
 
-		const abilities = HeroLogic.getAbilities(props.hero, props.sourcebooks, props.options.shownStandardAbilities);
-		if (props.options.compactView) {
+		const abilities = HeroLogic.getAbilities(props.hero, props.sourcebooks, options.shownStandardAbilities);
+		if (options.compactView) {
 			if (abilities.length > 0) {
 				tabs.push('Abilities');
 			}
@@ -114,7 +114,7 @@ export const HeroPanel = (props: Props) => {
 	};
 
 	const getContent = (tab: string) => {
-		const abilities = HeroLogic.getAbilities(props.hero, props.sourcebooks, props.options.shownStandardAbilities);
+		const abilities = HeroLogic.getAbilities(props.hero, props.sourcebooks, options.shownStandardAbilities);
 		const mains = abilities.filter(a => a.ability.type.usage === AbilityUsage.MainAction);
 		const maneuvers = abilities.filter(a => a.ability.type.usage === AbilityUsage.Maneuver);
 		const moves = abilities.filter(a => a.ability.type.usage === AbilityUsage.Move);
@@ -127,7 +127,6 @@ export const HeroPanel = (props: Props) => {
 					title={title}
 					abilities={abilities}
 					hero={props.hero}
-					options={props.options}
 					onSelectAbility={props.onSelectAbility}
 				/>
 			);
@@ -139,14 +138,12 @@ export const HeroPanel = (props: Props) => {
 					<>
 						<StatsPanel
 							hero={props.hero}
-							options={props.options}
 							onSelectCharacteristic={props.onSelectCharacteristic}
 							onShowState={props.onShowState}
 						/>
 						<ChoicesPanel
 							hero={props.hero}
 							sourcebooks={props.sourcebooks}
-							options={props.options}
 							onSelectAncestry={props.onSelectAncestry}
 							onSelectCulture={props.onSelectCulture}
 							onSelectCareer={props.onSelectCareer}
@@ -158,11 +155,10 @@ export const HeroPanel = (props: Props) => {
 							onShowState={props.onShowState}
 						/>
 						{
-							isSmall || props.options.singlePage ?
+							isSmall || options.singlePage ?
 								<SidebarPanel
 									hero={props.hero}
 									sourcebooks={props.sourcebooks}
-									options={props.options}
 									setTab={setTab}
 									onShowState={props.onShowState}
 									onShowReference={props.onShowReference}
@@ -181,7 +177,6 @@ export const HeroPanel = (props: Props) => {
 					<FeaturesPanel
 						hero={props.hero}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 						onSelectFeature={props.onSelectFeature}
 					/>
 				);
@@ -220,7 +215,6 @@ export const HeroPanel = (props: Props) => {
 					<RetinuePanel
 						hero={props.hero}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 						onSelectMonster={props.onSelectMonster}
 						onSelectFollower={props.onSelectFollower}
 						onSelectFixture={props.onSelectFixture}
@@ -236,14 +230,13 @@ export const HeroPanel = (props: Props) => {
 			<div className='hero-panel' id={SheetFormatter.getPageId('hero', props.hero.id)}>
 				<NamePanel
 					hero={props.hero}
-					options={props.options}
 					onShowState={props.onShowState}
 				/>
 				<div className='hero-main-section'>
-					{!isSmall && !props.options.singlePage ? <StatsSidebarPanel hero={props.hero} showStats={tab !== 'Hero'} /> : null}
+					{!isSmall && !options.singlePage ? <StatsSidebarPanel hero={props.hero} showStats={tab !== 'Hero'} /> : null}
 					<div className='hero-center-column'>
 						{
-							props.options.singlePage ?
+							options.singlePage ?
 								null
 								:
 								<div className='center-top'>
@@ -282,7 +275,7 @@ export const HeroPanel = (props: Props) => {
 						}
 						<div className='center-content'>
 							{
-								props.options.singlePage ?
+								options.singlePage ?
 									getTabs().map(tab => <div key={tab}>{getContent(tab)}</div>)
 									:
 									getContent(tab)
@@ -290,11 +283,10 @@ export const HeroPanel = (props: Props) => {
 						</div>
 					</div>
 					{
-						!isSmall && !props.options.singlePage ?
+						!isSmall && !options.singlePage ?
 							<SidebarPanel
 								hero={props.hero}
 								sourcebooks={props.sourcebooks}
-								options={props.options}
 								setTab={setTab}
 								onShowState={props.onShowState}
 								onShowReference={props.onShowReference}

--- a/src/components/panels/hero/name/name-panel.tsx
+++ b/src/components/panels/hero/name/name-panel.tsx
@@ -5,25 +5,25 @@ import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { HeroModalType } from '@/enums/hero-modal-type';
 import { HeroToken } from '../../token/token';
-import { Options } from '@/models/options';
 import { useIsSmall } from '@/hooks/use-is-small';
+import { useOptions } from '@/contexts/data-context';
 import { useState } from 'react';
 
 interface Props {
 	hero: Hero;
-	options: Options;
 	onShowState: (type: HeroModalType) => void;
 }
 
 export const NamePanel = (props: Props) => {
 	const isSmall = useIsSmall();
+	const options = useOptions();
 	const [ open, setOpen ] = useState(false);
 
 	return (
 		<HeaderText
 			style={{ margin: '0 5px 10px 5px' }}
-			level={props.options.compactView ? 2 : 1}
-			ribbon={props.hero.picture ? <HeroToken hero={props.hero} size={props.options.compactView ? 21 : 34} /> : null}
+			level={options.compactView ? 2 : 1}
+			ribbon={props.hero.picture ? <HeroToken hero={props.hero} size={options.compactView ? 21 : 34} /> : null}
 			tags={props.hero.folder ? [ props.hero.folder ] : []}
 			extra={
 				isSmall ?

--- a/src/components/panels/hero/retinue/retinue-panel.tsx
+++ b/src/components/panels/hero/retinue/retinue-panel.tsx
@@ -9,24 +9,24 @@ import { Hero } from '@/models/hero';
 import { HeroLogic } from '@/logic/hero-logic';
 import { Monster } from '@/models/monster';
 import { MonsterPanel } from '@/components/panels/elements/monster-panel/monster-panel';
-import { Options } from '@/models/options';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
 import { Sourcebook } from '@/models/sourcebook';
 import { SummoningInfo } from '@/models/summon';
+import { useOptions } from '@/contexts/data-context';
 
 import './retinue-panel.scss';
 
 interface Props {
 	hero: Hero;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	onSelectMonster: (hero: Hero, monster: Monster, summon?: SummoningInfo) => void;
 	onSelectFollower: (hero: Hero, follower: Follower) => void;
 	onSelectFixture: (fixture: Fixture) => void;
 }
 
 export const RetinuePanel = (props: Props) => {
-	const useRows = props.options.compactView;
+	const options = useOptions();
+	const useRows = options.compactView;
 
 	const monsters: { monster: Monster, summon?: SummoningInfo }[] = [
 		...HeroLogic.getCompanions(props.hero).map(m => ({ monster: m, summon: undefined })),
@@ -43,7 +43,7 @@ export const RetinuePanel = (props: Props) => {
 				{
 					monsters.length > 0 ?
 						<>
-							<div className={`retinue-grid ${useRows ? 'compact' : ''} ${props.options.abilityWidth.toLowerCase().replace(' ', '-')}`}>
+							<div className={`retinue-grid ${useRows ? 'compact' : ''} ${options.abilityWidth.toLowerCase().replace(' ', '-')}`}>
 								{
 									Collections.sort(monsters, m => m.monster.name).map(m =>
 										useRows ?
@@ -52,7 +52,7 @@ export const RetinuePanel = (props: Props) => {
 											</div>
 											:
 											<SelectablePanel key={m.monster.id} onSelect={() => props.onSelectMonster(props.hero, m.monster, m.summon)}>
-												<MonsterPanel monster={m.monster} summon={m.summon} sourcebooks={props.sourcebooks} options={props.options} />
+												<MonsterPanel monster={m.monster} summon={m.summon} sourcebooks={props.sourcebooks} />
 											</SelectablePanel>
 									)
 								}
@@ -63,8 +63,8 @@ export const RetinuePanel = (props: Props) => {
 				{
 					followers.length > 0 ?
 						<>
-							<HeaderText level={props.options.compactView ? 3 : 1}>Followers</HeaderText>
-							<div className={`retinue-grid ${useRows ? 'compact' : ''} ${props.options.abilityWidth.toLowerCase().replace(' ', '-')}`}>
+							<HeaderText level={options.compactView ? 3 : 1}>Followers</HeaderText>
+							<div className={`retinue-grid ${useRows ? 'compact' : ''} ${options.abilityWidth.toLowerCase().replace(' ', '-')}`}>
 								{
 									followers.map(follower =>
 										useRows ?
@@ -84,8 +84,8 @@ export const RetinuePanel = (props: Props) => {
 				{
 					fixtures.length > 0 ?
 						<>
-							<HeaderText level={props.options.compactView ? 3 : 1}>Fixtures</HeaderText>
-							<div className={`retinue-grid ${useRows ? 'compact' : ''} ${props.options.abilityWidth.toLowerCase().replace(' ', '-')}`}>
+							<HeaderText level={options.compactView ? 3 : 1}>Fixtures</HeaderText>
+							<div className={`retinue-grid ${useRows ? 'compact' : ''} ${options.abilityWidth.toLowerCase().replace(' ', '-')}`}>
 								{
 									fixtures.map(fixture =>
 										useRows ?
@@ -94,7 +94,7 @@ export const RetinuePanel = (props: Props) => {
 											</div>
 											:
 											<SelectablePanel key={fixture.id} onSelect={() => props.onSelectFixture(fixture)}>
-												<FixturePanel fixture={fixture} hero={props.hero} sourcebooks={props.sourcebooks} options={props.options} />
+												<FixturePanel fixture={fixture} hero={props.hero} sourcebooks={props.sourcebooks} />
 											</SelectablePanel>
 									)
 								}

--- a/src/components/panels/hero/sidebar/sidebar-panel.tsx
+++ b/src/components/panels/hero/sidebar/sidebar-panel.tsx
@@ -16,19 +16,18 @@ import { HeroLogic } from '@/logic/hero-logic';
 import { HeroModalType } from '@/enums/hero-modal-type';
 import { Markdown } from '@/components/controls/markdown/markdown';
 import { Monster } from '@/models/monster';
-import { Options } from '@/models/options';
 import { Pill } from '@/components/controls/pill/pill';
 import { RulesPage } from '@/enums/rules-page';
 import { Skill } from '@/models/skill';
 import { SkillList } from '@/enums/skill-list';
 import { Sourcebook } from '@/models/sourcebook';
+import { useOptions } from '@/contexts/data-context';
 
 import './sidebar-panel.scss';
 
 interface Props {
 	hero: Hero;
 	sourcebooks: Sourcebook[];
-	options: Options;
 	setTab: (tab: string) => void;
 	onShowState: (type: HeroModalType) => void;
 	onShowReference: (page: RulesPage) => void;
@@ -40,6 +39,7 @@ interface Props {
 }
 
 export const SidebarPanel = (props: Props) => {
+	const options = useOptions();
 	const onShowStats = () => {
 		if (props.onShowState) {
 			props.onShowState(HeroModalType.Resources);
@@ -75,12 +75,12 @@ export const SidebarPanel = (props: Props) => {
 	const damageImmunities = damageModifiers.filter(dm => dm.modifierType === DamageModifierType.Immunity);
 	const damageWeaknesses = damageModifiers.filter(dm => dm.modifierType === DamageModifierType.Weakness);
 
-	const abilities = HeroLogic.getAbilities(props.hero, props.sourcebooks, props.options.shownStandardAbilities);
+	const abilities = HeroLogic.getAbilities(props.hero, props.sourcebooks, options.shownStandardAbilities);
 	const heroicResources = HeroLogic.getHeroicResources(props.hero);
 	const triggers = abilities.filter(a => a.ability.type.usage === AbilityUsage.Trigger);
 	const languages = HeroLogic.getLanguages(props.hero, props.sourcebooks);
 
-	const useRows = props.options.singlePage && props.options.compactView;
+	const useRows = options.singlePage && options.compactView;
 
 	const getTrigger = (ability: Ability) => {
 		const showTarget = ability.type.trigger.toLowerCase().includes('the target');
@@ -131,7 +131,7 @@ export const SidebarPanel = (props: Props) => {
 					{
 						skills.map(s => (
 							<div key={s.name} className='ds-text'>
-								{s.name} {props.options.showSkillsInGroups ? null : <Tag variant='outlined'>{s.list}</Tag>}
+								{s.name} {options.showSkillsInGroups ? null : <Tag variant='outlined'>{s.list}</Tag>}
 							</div>
 						))
 					}
@@ -140,7 +140,7 @@ export const SidebarPanel = (props: Props) => {
 	};
 
 	let display = 'column';
-	if (props.options.singlePage) {
+	if (options.singlePage) {
 		display = 'grid';
 	}
 	if (useRows) {
@@ -203,7 +203,7 @@ export const SidebarPanel = (props: Props) => {
 						</div>
 				}
 				{
-					(heroicResources.length > 0) && !props.options.singlePage ?
+					(heroicResources.length > 0) && !options.singlePage ?
 						<>
 							{
 								heroicResources.map(hr =>
@@ -242,7 +242,7 @@ export const SidebarPanel = (props: Props) => {
 					onSelectControlledSquad={props.onSelectControlledSquad!}
 				/>
 				{
-					(triggers.length > 0) && !props.options.singlePage ?
+					(triggers.length > 0) && !options.singlePage ?
 						useRows ?
 							<div className='selectable-row clickable' onClick={() => props.setTab('Triggers')}>
 								<div>Triggers: <b>{triggers.map(t => t.ability.name).join(', ')}</b></div>
@@ -312,7 +312,7 @@ export const SidebarPanel = (props: Props) => {
 						</div>
 				}
 				{
-					(props.options.showSkillsInGroups || false) ?
+					(options.showSkillsInGroups || false) ?
 						[ SkillList.Crafting, SkillList.Exploration, SkillList.Interpersonal, SkillList.Intrigue, SkillList.Lore, SkillList.Custom ]
 							.map(list => getSkills(`${list} Skills`, HeroLogic.getSkills(props.hero, props.sourcebooks).filter(s => s.list === list)))
 						:

--- a/src/components/panels/hero/stats/stats-panel.tsx
+++ b/src/components/panels/hero/stats/stats-panel.tsx
@@ -6,25 +6,25 @@ import { FormatLogic } from '@/logic/format-logic';
 import { Hero } from '@/models/hero';
 import { HeroLogic } from '@/logic/hero-logic';
 import { HeroModalType } from '@/enums/hero-modal-type';
-import { Options } from '@/models/options';
 import { StatsRow } from '@/components/panels/stats-row/stats-row';
 import { useIsSmall } from '@/hooks/use-is-small';
+import { useOptions } from '@/contexts/data-context';
 
 import './stats-panel.scss';
 
 interface Props {
 	hero: Hero;
-	options: Options;
 	onSelectCharacteristic: (characteristic: Characteristic) => void;
 	onShowState: (type: HeroModalType) => void;
 }
 
 export const StatsPanel = (props: Props) => {
 	const isSmall = useIsSmall();
+	const options = useOptions();
 
-	const useRows = props.options.compactView;
+	const useRows = options.compactView;
 
-	const xpSuffix = HeroLogic.canLevelUp(props.hero, props.options) ? <ArrowUpOutlined /> : undefined;
+	const xpSuffix = HeroLogic.canLevelUp(props.hero, options) ? <ArrowUpOutlined /> : undefined;
 
 	const size = HeroLogic.getSize(props.hero);
 	const sizeSuffix = size.mod || undefined;

--- a/src/components/panels/malice/malice-panel.tsx
+++ b/src/components/panels/malice/malice-panel.tsx
@@ -3,7 +3,6 @@ import { ErrorBoundary } from '@/components/controls/error-boundary/error-bounda
 import { Feature } from '@/models/feature';
 import { FeaturePanel } from '@/components/panels/elements/feature-panel/feature-panel';
 import { FeatureType } from '@/enums/feature-type';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { ResourcePill } from '@/components/controls/pill/pill';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
@@ -12,7 +11,6 @@ import './malice-panel.scss';
 
 interface Props {
 	malice: Feature;
-	options: Options;
 	currentMalice?: number
 	updateCurrentMalice?: (value: number) => void;
 }
@@ -34,7 +32,6 @@ export const MalicePanel = (props: Props) => {
 				<div className='malice-panel'>
 					<FeaturePanel
 						feature={props.malice}
-						options={props.options}
 						cost={cost}
 						repeatable={props.malice.type === FeatureType.Malice ? props.malice.data.repeatable : undefined}
 						mode={PanelMode.Full}

--- a/src/components/panels/print-sheet/print-sheet.tsx
+++ b/src/components/panels/print-sheet/print-sheet.tsx
@@ -20,7 +20,6 @@ import { Field } from '@/components/controls/field/field';
 import { Format } from '@/utils/format';
 import { FormatLogic } from '@/logic/format-logic';
 import { HeaderText } from '@/components/controls/header-text/header-text';
-import { Hero } from '@/models/hero';
 import { HeroClass } from '@/models/class';
 import { Imbuement } from '@/models/imbuement';
 import { Item } from '@/models/item';
@@ -45,7 +44,6 @@ interface Props {
 	type: string;
 	element: Element;
 	sourcebooks: Sourcebook[];
-	heroes: Hero[];
 }
 
 export const PrintSheet = (props: Props) => {

--- a/src/components/panels/print-sheet/print-sheet.tsx
+++ b/src/components/panels/print-sheet/print-sheet.tsx
@@ -30,7 +30,6 @@ import { Monster } from '@/models/monster';
 import { MonsterGroup } from '@/models/monster-group';
 import { MonsterLogic } from '@/logic/monster-logic';
 import { MonsterOrganizationType } from '@/enums/monster-organization-type';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { Perk } from '@/models/perk';
 import { Pill } from '@/components/controls/pill/pill';
@@ -47,7 +46,6 @@ interface Props {
 	element: Element;
 	sourcebooks: Sourcebook[];
 	heroes: Hero[];
-	options: Options;
 }
 
 export const PrintSheet = (props: Props) => {
@@ -58,7 +56,6 @@ export const PrintSheet = (props: Props) => {
 				<AncestrySheet
 					ancestry={props.element as Ancestry}
 					sourcebooks={props.sourcebooks}
-					options={props.options}
 				/>
 			);
 			break;
@@ -67,7 +64,6 @@ export const PrintSheet = (props: Props) => {
 				<CareerSheet
 					career={props.element as Career}
 					sourcebooks={props.sourcebooks}
-					options={props.options}
 				/>
 			);
 			break;
@@ -76,7 +72,6 @@ export const PrintSheet = (props: Props) => {
 				<ClassSheet
 					heroClass={props.element as HeroClass}
 					sourcebooks={props.sourcebooks}
-					options={props.options}
 				/>
 			);
 			break;
@@ -85,7 +80,6 @@ export const PrintSheet = (props: Props) => {
 				<ComplicationSheet
 					complication={props.element as Complication}
 					sourcebooks={props.sourcebooks}
-					options={props.options}
 				/>
 			);
 			break;
@@ -94,7 +88,6 @@ export const PrintSheet = (props: Props) => {
 				<CultureSheet
 					culture={props.element as Culture}
 					sourcebooks={props.sourcebooks}
-					options={props.options}
 				/>
 			);
 			break;
@@ -103,7 +96,6 @@ export const PrintSheet = (props: Props) => {
 				<DomainSheet
 					domain={props.element as Domain}
 					sourcebooks={props.sourcebooks}
-					options={props.options}
 				/>
 			);
 			break;
@@ -112,7 +104,6 @@ export const PrintSheet = (props: Props) => {
 				<ImbuementSheet
 					imbuement={props.element as Imbuement}
 					sourcebooks={props.sourcebooks}
-					options={props.options}
 				/>
 			);
 			break;
@@ -121,7 +112,6 @@ export const PrintSheet = (props: Props) => {
 				<ItemSheet
 					item={props.element as Item}
 					sourcebooks={props.sourcebooks}
-					options={props.options}
 				/>
 			);
 			break;
@@ -130,7 +120,6 @@ export const PrintSheet = (props: Props) => {
 				<KitSheet
 					kit={props.element as Kit}
 					sourcebooks={props.sourcebooks}
-					options={props.options}
 				/>
 			);
 			break;
@@ -139,7 +128,6 @@ export const PrintSheet = (props: Props) => {
 				<MonsterGroupSheet
 					monsterGroup={props.element as MonsterGroup}
 					sourcebooks={props.sourcebooks}
-					options={props.options}
 				/>
 			);
 			break;
@@ -149,7 +137,6 @@ export const PrintSheet = (props: Props) => {
 					monster={props.element as Monster}
 					monsterGroup={SourcebookLogic.getMonsterGroup(props.sourcebooks, props.element.id) as MonsterGroup}
 					sourcebooks={props.sourcebooks}
-					options={props.options}
 				/>
 			);
 			break;
@@ -158,7 +145,6 @@ export const PrintSheet = (props: Props) => {
 				<PerkSheet
 					perk={props.element as Perk}
 					sourcebooks={props.sourcebooks}
-					options={props.options}
 				/>
 			);
 			break;
@@ -167,7 +153,6 @@ export const PrintSheet = (props: Props) => {
 				<ProjectSheet
 					project={props.element as Project}
 					sourcebooks={props.sourcebooks}
-					options={props.options}
 				/>
 			);
 			break;
@@ -176,7 +161,6 @@ export const PrintSheet = (props: Props) => {
 				<SubclassSheet
 					subclass={props.element as SubClass}
 					sourcebooks={props.sourcebooks}
-					options={props.options}
 				/>
 			);
 			break;
@@ -185,7 +169,6 @@ export const PrintSheet = (props: Props) => {
 				<TerrainSheet
 					terrain={props.element as Terrain}
 					sourcebooks={props.sourcebooks}
-					options={props.options}
 				/>
 			);
 			break;
@@ -194,7 +177,6 @@ export const PrintSheet = (props: Props) => {
 				<TitleSheet
 					title={props.element as Title}
 					sourcebooks={props.sourcebooks}
-					options={props.options}
 				/>
 			);
 			break;
@@ -214,7 +196,6 @@ export const PrintSheet = (props: Props) => {
 interface AncestryProps {
 	ancestry: Ancestry;
 	sourcebooks: Sourcebook[];
-	options: Options;
 };
 
 const AncestrySheet = (props: AncestryProps) => {
@@ -227,19 +208,19 @@ const AncestrySheet = (props: AncestryProps) => {
 			<HeaderText level={1}>Signature Traits</HeaderText>
 			{
 				AncestryLogic.getSignatureFeatures(props.ancestry).map(f => (
-					<FeaturePanel key={f.id} feature={f} options={props.options} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
+					<FeaturePanel key={f.id} feature={f} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
 				))
 			}
 			<HeaderText level={1}>Purchased Traits</HeaderText>
 			<Field label='Ancestry Points' value={props.ancestry.ancestryPoints} />
 			{
 				AncestryLogic.getPurchasedFeatures(props.ancestry).map(f => (
-					<FeaturePanel key={f.feature.id} feature={f.feature} cost={f.value} options={props.options} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
+					<FeaturePanel key={f.feature.id} feature={f.feature} cost={f.value} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
 				))
 			}
 			{
 				props.ancestry.culture ?
-					<CultureSheet culture={props.ancestry.culture} sourcebooks={props.sourcebooks} options={props.options} />
+					<CultureSheet culture={props.ancestry.culture} sourcebooks={props.sourcebooks} />
 					: null
 			}
 		</>
@@ -249,7 +230,6 @@ const AncestrySheet = (props: AncestryProps) => {
 interface CareerProps {
 	career: Career;
 	sourcebooks: Sourcebook[];
-	options: Options;
 };
 
 const CareerSheet = (props: CareerProps) => {
@@ -261,7 +241,7 @@ const CareerSheet = (props: CareerProps) => {
 			<Markdown text={props.career.description} />
 			{
 				props.career.features.map(f => (
-					<FeaturePanel key={f.id} feature={f} options={props.options} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
+					<FeaturePanel key={f.id} feature={f} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
 				))
 			}
 			<HeaderText>Inciting Incidents</HeaderText>
@@ -277,7 +257,6 @@ const CareerSheet = (props: CareerProps) => {
 interface ClassProps {
 	heroClass: HeroClass;
 	sourcebooks: Sourcebook[];
-	options: Options;
 };
 
 const ClassSheet = (props: ClassProps) => {
@@ -296,7 +275,7 @@ const ClassSheet = (props: ClassProps) => {
 							<HeaderText level={1}>Level {lvl.level.toString()}</HeaderText>
 							{
 								lvl.features.map(f => (
-									<FeaturePanel key={f.id} feature={f} options={props.options} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
+									<FeaturePanel key={f.id} feature={f} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
 								))
 							}
 						</div>
@@ -311,7 +290,7 @@ const ClassSheet = (props: ClassProps) => {
 			<HeaderText level={1}>Subclasses</HeaderText>
 			{
 				props.heroClass.subclasses.map(sc => (
-					<SubclassSheet key={sc.id} subclass={sc} sourcebooks={props.sourcebooks} options={props.options} />
+					<SubclassSheet key={sc.id} subclass={sc} sourcebooks={props.sourcebooks} />
 				))
 			}
 		</>
@@ -321,7 +300,6 @@ const ClassSheet = (props: ClassProps) => {
 interface ComplicationProps {
 	complication: Complication;
 	sourcebooks: Sourcebook[];
-	options: Options;
 };
 
 const ComplicationSheet = (props: ComplicationProps) => {
@@ -333,7 +311,7 @@ const ComplicationSheet = (props: ComplicationProps) => {
 			<Markdown text={props.complication.description} />
 			{
 				props.complication.features.map(f => (
-					<FeaturePanel key={f.id} feature={f} options={props.options} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
+					<FeaturePanel key={f.id} feature={f} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
 				))
 			}
 		</>
@@ -343,7 +321,6 @@ const ComplicationSheet = (props: ComplicationProps) => {
 interface CultureProps {
 	culture: Culture;
 	sourcebooks: Sourcebook[];
-	options: Options;
 };
 
 const CultureSheet = (props: CultureProps) => {
@@ -353,10 +330,10 @@ const CultureSheet = (props: CultureProps) => {
 				{props.culture.name || 'Unnamed Culture'}
 			</HeaderText>
 			<Markdown text={props.culture.description} />
-			<FeaturePanel feature={props.culture.language} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} />
-			{props.culture.environment ? <FeaturePanel feature={props.culture.environment} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} /> : null}
-			{props.culture.organization ? <FeaturePanel feature={props.culture.organization} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} /> : null}
-			{props.culture.upbringing ? <FeaturePanel feature={props.culture.upbringing} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} /> : null}
+			<FeaturePanel feature={props.culture.language} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
+			{props.culture.environment ? <FeaturePanel feature={props.culture.environment} sourcebooks={props.sourcebooks} mode={PanelMode.Full} /> : null}
+			{props.culture.organization ? <FeaturePanel feature={props.culture.organization} sourcebooks={props.sourcebooks} mode={PanelMode.Full} /> : null}
+			{props.culture.upbringing ? <FeaturePanel feature={props.culture.upbringing} sourcebooks={props.sourcebooks} mode={PanelMode.Full} /> : null}
 		</>
 	);
 };
@@ -364,7 +341,6 @@ const CultureSheet = (props: CultureProps) => {
 interface DomainProps {
 	domain: Domain;
 	sourcebooks: Sourcebook[];
-	options: Options;
 };
 
 const DomainSheet = (props: DomainProps) => {
@@ -382,7 +358,7 @@ const DomainSheet = (props: DomainProps) => {
 							<HeaderText level={1}>Level {lvl.level.toString()}</HeaderText>
 							{
 								lvl.features.map(f => (
-									<FeaturePanel key={f.id} feature={f} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} />
+									<FeaturePanel key={f.id} feature={f} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
 								))
 							}
 						</Space>
@@ -395,7 +371,6 @@ const DomainSheet = (props: DomainProps) => {
 interface ImbuementProps {
 	imbuement: Imbuement;
 	sourcebooks: Sourcebook[];
-	options: Options;
 };
 
 const ImbuementSheet = (props: ImbuementProps) => {
@@ -408,7 +383,6 @@ const ImbuementSheet = (props: ImbuementProps) => {
 			<FeaturePanel
 				feature={props.imbuement.feature}
 				sourcebooks={props.sourcebooks}
-				options={props.options}
 				mode={PanelMode.Full}
 			/>
 		</>
@@ -418,7 +392,6 @@ const ImbuementSheet = (props: ImbuementProps) => {
 interface ItemProps {
 	item: Item;
 	sourcebooks: Sourcebook[];
-	options: Options;
 };
 
 const ItemSheet = (props: ItemProps) => {
@@ -445,7 +418,6 @@ const ItemSheet = (props: ItemProps) => {
 									<FeaturePanel
 										key={f.id}
 										feature={f}
-										options={props.options}
 										mode={PanelMode.Full}
 									/>
 								))
@@ -460,7 +432,6 @@ const ItemSheet = (props: ItemProps) => {
 interface KitProps {
 	kit: Kit;
 	sourcebooks: Sourcebook[];
-	options: Options;
 };
 
 const KitSheet = (props: KitProps) => {
@@ -490,7 +461,7 @@ const KitSheet = (props: KitProps) => {
 			{props.kit.disengage > 0 ? <Field label='Disengage' value={`+${props.kit.disengage}`} /> : null}
 			{
 				props.kit.features.map(f => (
-					<FeaturePanel key={f.id} feature={f} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} />
+					<FeaturePanel key={f.id} feature={f} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
 				))
 			}
 		</>
@@ -500,7 +471,6 @@ const KitSheet = (props: KitProps) => {
 interface MonsterGroupProps {
 	monsterGroup: MonsterGroup;
 	sourcebooks: Sourcebook[];
-	options: Options;
 };
 
 const MonsterGroupSheet = (props: MonsterGroupProps) => {
@@ -540,7 +510,6 @@ const MonsterGroupSheet = (props: MonsterGroupProps) => {
 									<FeaturePanel
 										key={m.id}
 										feature={m}
-										options={props.options}
 										mode={PanelMode.Full}
 										cost={cost}
 										repeatable={m.type === FeatureType.Malice ? m.data.repeatable : undefined}
@@ -553,13 +522,13 @@ const MonsterGroupSheet = (props: MonsterGroupProps) => {
 			}
 			{
 				props.monsterGroup.monsters.map(m =>
-					<MonsterSheet key={m.id} monster={m} monsterGroup={props.monsterGroup} sourcebooks={props.sourcebooks} options={props.options} />
+					<MonsterSheet key={m.id} monster={m} monsterGroup={props.monsterGroup} sourcebooks={props.sourcebooks} />
 				)
 			}
 			{props.monsterGroup.addOns.length > 0 ? <HeaderText level={1}>Customization</HeaderText> : null}
 			{
 				props.monsterGroup.addOns.map(a =>
-					<FeaturePanel key={a.id} feature={a} options={props.options} cost={a.data.cost} mode={PanelMode.Full} />
+					<FeaturePanel key={a.id} feature={a} cost={a.data.cost} mode={PanelMode.Full} />
 				)
 			}
 		</>
@@ -570,7 +539,6 @@ interface MonsterProps {
 	monster: Monster;
 	monsterGroup: MonsterGroup;
 	sourcebooks: Sourcebook[];
-	options: Options;
 };
 
 const MonsterSheet = (props: MonsterProps) => {
@@ -685,7 +653,7 @@ const MonsterSheet = (props: MonsterProps) => {
 							props.monster.retainer.level4 && (props.monster.retainer.level < 4) ?
 								<>
 									<HeaderText level={1}>Level 4</HeaderText>
-									<FeaturePanel key={props.monster.retainer.level4.id} feature={props.monster.retainer.level4}options={props.options} mode={PanelMode.Full} />
+									<FeaturePanel key={props.monster.retainer.level4.id} feature={props.monster.retainer.level4} mode={PanelMode.Full} />
 								</>
 								: null
 						}
@@ -693,7 +661,7 @@ const MonsterSheet = (props: MonsterProps) => {
 							props.monster.retainer.level7 && (props.monster.retainer.level < 7) ?
 								<>
 									<HeaderText level={1}>Level 7</HeaderText>
-									<FeaturePanel key={props.monster.retainer.level7.id} feature={props.monster.retainer.level7}options={props.options} mode={PanelMode.Full} />
+									<FeaturePanel key={props.monster.retainer.level7.id} feature={props.monster.retainer.level7} mode={PanelMode.Full} />
 								</>
 								: null
 						}
@@ -701,7 +669,7 @@ const MonsterSheet = (props: MonsterProps) => {
 							props.monster.retainer.level10 && (props.monster.retainer.level < 10) ?
 								<>
 									<HeaderText level={1}>Level 10</HeaderText>
-									<FeaturePanel key={props.monster.retainer.level10.id} feature={props.monster.retainer.level10}options={props.options} mode={PanelMode.Full} />
+									<FeaturePanel key={props.monster.retainer.level10.id} feature={props.monster.retainer.level10} mode={PanelMode.Full} />
 								</>
 								: null
 						}
@@ -715,19 +683,17 @@ const MonsterSheet = (props: MonsterProps) => {
 interface PerkProps {
 	perk: Perk;
 	sourcebooks: Sourcebook[];
-	options: Options;
 };
 
 const PerkSheet = (props: PerkProps) => {
 	return (
-		<FeaturePanel feature={props.perk} options={props.options} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
+		<FeaturePanel feature={props.perk} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
 	);
 };
 
 interface ProjectProps {
 	project: Project;
 	sourcebooks: Sourcebook[];
-	options: Options;
 };
 
 const ProjectSheet = (props: ProjectProps) => {
@@ -748,7 +714,6 @@ const ProjectSheet = (props: ProjectProps) => {
 interface SubclassProps {
 	subclass: SubClass;
 	sourcebooks: Sourcebook[];
-	options: Options;
 };
 
 const SubclassSheet = (props: SubclassProps) => {
@@ -766,7 +731,7 @@ const SubclassSheet = (props: SubclassProps) => {
 							<HeaderText level={1}>Level {lvl.level.toString()}</HeaderText>
 							{
 								lvl.features.map(f => (
-									<FeaturePanel key={f.id} feature={f} sourcebooks={props.sourcebooks} options={props.options} mode={PanelMode.Full} />
+									<FeaturePanel key={f.id} feature={f} sourcebooks={props.sourcebooks} mode={PanelMode.Full} />
 								))
 							}
 						</Space>
@@ -790,7 +755,6 @@ const SubclassSheet = (props: SubclassProps) => {
 interface TerrainProps {
 	terrain: Terrain;
 	sourcebooks: Sourcebook[];
-	options: Options;
 };
 
 const TerrainSheet = (props: TerrainProps) => {
@@ -874,7 +838,6 @@ const TerrainSheet = (props: TerrainProps) => {
 interface TitleProps {
 	title: Title;
 	sourcebooks: Sourcebook[];
-	options: Options;
 };
 
 const TitleSheet = (props: TitleProps) => {
@@ -895,7 +858,6 @@ const TitleSheet = (props: TitleProps) => {
 						key={f.id}
 						feature={f}
 						sourcebooks={props.sourcebooks}
-						options={props.options}
 						mode={PanelMode.Full}
 					/>
 				))

--- a/src/components/panels/run/encounter-run/encounter-run-panel.tsx
+++ b/src/components/panels/run/encounter-run/encounter-run-panel.tsx
@@ -55,7 +55,6 @@ interface SelectedMonsterInfo {
 interface Props {
 	encounter: Encounter;
 	sourcebooks: Sourcebook[];
-	heroes: Hero[];
 	onChange: (encounter: Encounter) => void;
 	showTools?: (tool: string) => void;
 }
@@ -713,7 +712,6 @@ export const EncounterRunPanel = (props: Props) => {
 				<EncounterDifficultyPanel
 					encounter={encounter}
 					sourcebooks={props.sourcebooks}
-					heroes={props.heroes}
 					showHeader={false}
 				/>
 			</div>
@@ -782,7 +780,6 @@ export const EncounterRunPanel = (props: Props) => {
 			</div>
 			<Drawer open={addingHeroes} onClose={() => setAddingHeroes(false)} closeIcon={null} size={500}>
 				<HeroSelectModal
-					heroes={props.heroes}
 					sourcebooks={props.sourcebooks}
 					onClose={() => setAddingHeroes(false)}
 					onSelect={heroes => {

--- a/src/components/panels/run/encounter-run/encounter-run-panel.tsx
+++ b/src/components/panels/run/encounter-run/encounter-run-panel.tsx
@@ -32,7 +32,6 @@ import { MonsterOrganizationType } from '@/enums/monster-organization-type';
 import { MonsterPanel } from '@/components/panels/elements/monster-panel/monster-panel';
 import { MonsterSelectModal } from '@/components/modals/select/monster-select/monster-select-modal';
 import { NumberSpin } from '@/components/controls/number-spin/number-spin';
-import { Options } from '@/models/options';
 import { PanelMode } from '@/enums/panel-mode';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
 import { Sourcebook } from '@/models/sourcebook';
@@ -42,6 +41,7 @@ import { Terrain } from '@/models/terrain';
 import { TerrainModal } from '@/components/modals/terrain/terrain-modal';
 import { Utils } from '@/utils/utils';
 import { useIsSmall } from '@/hooks/use-is-small';
+import { useOptions } from '@/contexts/data-context';
 import { useState } from 'react';
 
 import './encounter-run-panel.scss';
@@ -56,13 +56,13 @@ interface Props {
 	encounter: Encounter;
 	sourcebooks: Sourcebook[];
 	heroes: Hero[];
-	options: Options;
 	onChange: (encounter: Encounter) => void;
 	showTools?: (tool: string) => void;
 }
 
 export const EncounterRunPanel = (props: Props) => {
 	const isSmall = useIsSmall();
+	const options = useOptions();
 	const [ encounter, setEncounter ] = useState<Encounter>(Utils.copy(props.encounter));
 	const [ tab, setTab ] = useState<string>('combatants');
 	const [ showSidebar, setShowSidebar ] = useState<boolean>(true);
@@ -335,7 +335,6 @@ export const EncounterRunPanel = (props: Props) => {
 					hero={hero}
 					encounter={encounter}
 					sourcebooks={props.sourcebooks}
-					options={props.options}
 					onSelect={setSelectedHero}
 					onSelectMonster={(monster, monsterGroupID) => {
 						const group = SourcebookLogic.getMonsterGroups(props.sourcebooks).find(g => g.id === monsterGroupID);
@@ -352,7 +351,7 @@ export const EncounterRunPanel = (props: Props) => {
 		};
 
 		const sections = [ 'current', 'ready', 'finished' ];
-		if (props.options.showDefeatedCombatants) {
+		if (options.showDefeatedCombatants) {
 			sections.push('defeated');
 		}
 
@@ -490,7 +489,6 @@ export const EncounterRunPanel = (props: Props) => {
 										key={m.monster.id}
 										monster={m.monster}
 										sourcebooks={props.sourcebooks}
-										options={props.options}
 										mode={PanelMode.Full}
 										style={{ padding: '0 5px' }}
 										extra={[
@@ -520,7 +518,6 @@ export const EncounterRunPanel = (props: Props) => {
 											.map(malice => (
 												<MalicePanel
 													malice={malice}
-													options={props.options}
 													currentMalice={encounter.malice}
 													updateCurrentMalice={value => {
 														const copy = Utils.copy(encounter);
@@ -631,7 +628,6 @@ export const EncounterRunPanel = (props: Props) => {
 									<FeaturePanel
 										key={`${t.id} ${copy.id}`}
 										feature={copy}
-										options={props.options}
 										mode={PanelMode.Full}
 									/>
 								);
@@ -669,7 +665,6 @@ export const EncounterRunPanel = (props: Props) => {
 										key={`${s.id} ${copy.id}`}
 										item={copy}
 										sourcebooks={props.sourcebooks}
-										options={props.options}
 										mode={PanelMode.Full}
 										style={{ paddingLeft: '0', paddingRight: '0' }}
 									/>
@@ -719,7 +714,6 @@ export const EncounterRunPanel = (props: Props) => {
 					encounter={encounter}
 					sourcebooks={props.sourcebooks}
 					heroes={props.heroes}
-					options={props.options}
 					showHeader={false}
 				/>
 			</div>
@@ -790,7 +784,6 @@ export const EncounterRunPanel = (props: Props) => {
 				<HeroSelectModal
 					heroes={props.heroes}
 					sourcebooks={props.sourcebooks}
-					options={props.options}
 					onClose={() => setAddingHeroes(false)}
 					onSelect={heroes => {
 						setAddingHeroes(false);
@@ -802,7 +795,6 @@ export const EncounterRunPanel = (props: Props) => {
 				<MonsterSelectModal
 					monsters={props.sourcebooks.flatMap(sb => sb.monsterGroups).flatMap(g => g.monsters)}
 					sourcebooks={props.sourcebooks}
-					options={props.options}
 					onClose={() => setAddingMonsters(false)}
 					onSelect={m => {
 						setAddingMonsters(false);
@@ -832,7 +824,6 @@ export const EncounterRunPanel = (props: Props) => {
 							monsterGroup={selectedMonster.monsterGroup}
 							encounter={selectedMonster.isTeamHero ? undefined : encounter}
 							sourcebooks={props.sourcebooks}
-							options={props.options}
 							onClose={() => setSelectedMonster(null)}
 							updateMonster={monster => {
 								const copy = Utils.copy(encounter);

--- a/src/components/panels/run/montage-run/montage-run-panel.tsx
+++ b/src/components/panels/run/montage-run/montage-run-panel.tsx
@@ -1,31 +1,30 @@
 import { Button, Flex, Space } from 'antd';
 import { CheckOutlined, CloseOutlined, SyncOutlined } from '@ant-design/icons';
 import { Montage, MontageChallenge, MontageSection } from '@/models/montage';
+import { useHeroes, useOptions } from '@/contexts/data-context';
 import { CheckIcon } from '@/components/controls/check-icon/check-icon';
 import { Collections } from '@/utils/collections';
 import { ErrorBoundary } from '@/components/controls/error-boundary/error-boundary';
 import { Field } from '@/components/controls/field/field';
 import { HeaderText } from '@/components/controls/header-text/header-text';
-import { Hero } from '@/models/hero';
 import { Markdown } from '@/components/controls/markdown/markdown';
 import { MontageLogic } from '@/logic/montage-logic';
 import { Pill } from '@/components/controls/pill/pill';
 import { StatsRow } from '@/components/panels/stats-row/stats-row';
 import { Utils } from '@/utils/utils';
-import { useOptions } from '@/contexts/data-context';
 import { useState } from 'react';
 
 import './montage-run-panel.scss';
 
 interface Props {
 	montage: Montage;
-	heroes: Hero[];
 	onChange: (montage: Montage) => void;
 }
 
 export const MontageRunPanel = (props: Props) => {
 	const [ montage, setMontage ] = useState<Montage>(Utils.copy(props.montage));
 	const options = useOptions();
+	const heroes = useHeroes();
 
 	const getChallenge = (challenge: MontageChallenge, sectionIndex: number, challengeIndex: number) => {
 		const addSuccess = () => {
@@ -162,9 +161,9 @@ export const MontageRunPanel = (props: Props) => {
 
 	const successes = Collections.sum(montage.sections, s => Collections.sum(s.challenges, c => c.successes));
 	const failures = Collections.sum(montage.sections, s => Collections.sum(s.challenges, c => c.failures));
-	const successLimit = MontageLogic.getSuccessLimit(props.montage, props.heroes, options);
-	const failureLimit = MontageLogic.getFailureLimit(props.montage, props.heroes, options);
-	const outcome = MontageLogic.getOutcome(props.montage, props.heroes, options);
+	const successLimit = MontageLogic.getSuccessLimit(props.montage, heroes, options);
+	const failureLimit = MontageLogic.getFailureLimit(props.montage, heroes, options);
+	const outcome = MontageLogic.getOutcome(props.montage, heroes, options);
 
 	return (
 		<ErrorBoundary>

--- a/src/components/panels/run/montage-run/montage-run-panel.tsx
+++ b/src/components/panels/run/montage-run/montage-run-panel.tsx
@@ -9,10 +9,10 @@ import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Hero } from '@/models/hero';
 import { Markdown } from '@/components/controls/markdown/markdown';
 import { MontageLogic } from '@/logic/montage-logic';
-import { Options } from '@/models/options';
 import { Pill } from '@/components/controls/pill/pill';
 import { StatsRow } from '@/components/panels/stats-row/stats-row';
 import { Utils } from '@/utils/utils';
+import { useOptions } from '@/contexts/data-context';
 import { useState } from 'react';
 
 import './montage-run-panel.scss';
@@ -20,12 +20,12 @@ import './montage-run-panel.scss';
 interface Props {
 	montage: Montage;
 	heroes: Hero[];
-	options: Options;
 	onChange: (montage: Montage) => void;
 }
 
 export const MontageRunPanel = (props: Props) => {
 	const [ montage, setMontage ] = useState<Montage>(Utils.copy(props.montage));
+	const options = useOptions();
 
 	const getChallenge = (challenge: MontageChallenge, sectionIndex: number, challengeIndex: number) => {
 		const addSuccess = () => {
@@ -162,9 +162,9 @@ export const MontageRunPanel = (props: Props) => {
 
 	const successes = Collections.sum(montage.sections, s => Collections.sum(s.challenges, c => c.successes));
 	const failures = Collections.sum(montage.sections, s => Collections.sum(s.challenges, c => c.failures));
-	const successLimit = MontageLogic.getSuccessLimit(props.montage, props.heroes, props.options);
-	const failureLimit = MontageLogic.getFailureLimit(props.montage, props.heroes, props.options);
-	const outcome = MontageLogic.getOutcome(props.montage, props.heroes, props.options);
+	const successLimit = MontageLogic.getSuccessLimit(props.montage, props.heroes, options);
+	const failureLimit = MontageLogic.getFailureLimit(props.montage, props.heroes, options);
+	const outcome = MontageLogic.getOutcome(props.montage, props.heroes, options);
 
 	return (
 		<ErrorBoundary>

--- a/src/contexts/data-context.tsx
+++ b/src/contexts/data-context.tsx
@@ -5,26 +5,51 @@ import { Options } from '@/models/options';
 export const OptionsContext = createContext<Options | null>(null);
 export const OptionsDispatchContext = createContext<ActionDispatch<[OptionsAction]>>(() => {});
 
-interface OptionsProps {
-	initialOptions: Options,
-	dataService: DataService
-}
-
 export enum OptionsActionKind {
 	UPDATE = 'Update'
 }
 
 interface OptionsAction {
-	type: OptionsActionKind,
-	payload: Options
+	type: OptionsActionKind;
+	payload: Options;
 }
 
-export function OptionsProvider(props: PropsWithChildren<OptionsProps>) {
-	const [ options, dispatch ] = useReducer(OptionsReducer, props.initialOptions);
+export class DataManager {
+	private readonly dataService: DataService;
+	private readonly optionsDispatch: ActionDispatch<[OptionsAction]>;
+
+	constructor(service: DataService,
+		optionsDispatch: ActionDispatch<[OptionsAction]>) {
+		this.dataService = service;
+		this.optionsDispatch = optionsDispatch;
+	};
+
+	saveOptions(options: Options) {
+		this.dataService.saveOptions(options)
+			.then(options => {
+				this.optionsDispatch({
+					type: OptionsActionKind.UPDATE,
+					payload: options
+				});
+			});
+	}
+}
+
+interface DataManagerProps {
+	dataService: DataService;
+	initialOptions: Options;
+}
+
+export function DataManagerProvider(props: PropsWithChildren<DataManagerProps>) {
+	const dataService = props.dataService;
+
+	const [ options, optionsDispatch ] = useReducer(OptionsReducer, props.initialOptions);
+
+	const dataManager = new DataManager(dataService, optionsDispatch);
 
 	function OptionsReducer(options: Options, action: OptionsAction) {
 		switch (action.type) {
-			case 'Update': {
+			case OptionsActionKind.UPDATE: {
 				return action.payload;
 			}
 		}
@@ -32,12 +57,23 @@ export function OptionsProvider(props: PropsWithChildren<OptionsProps>) {
 	}
 
 	return (
-		<OptionsContext value={options}>
-			<OptionsDispatchContext value={dispatch}>
+		<DataManagerContext value={dataManager}>
+			<OptionsContext value={options}>
 				{props.children}
-			</OptionsDispatchContext>
-		</OptionsContext>
+			</OptionsContext>
+		</DataManagerContext>
 	);
+}
+
+export const DataManagerContext = createContext<DataManager | null>(null);
+export function useDataManager() {
+	const context = useContext(DataManagerContext);
+
+	if (!context) {
+		throw new Error('useDataManager may only be used within <DataManagerContext>');
+	}
+
+	return context;
 }
 
 export function useOptions() {
@@ -48,14 +84,4 @@ export function useOptions() {
 	}
 
 	return optionsContext;
-}
-
-export function useOptionsDispatch() {
-	const optionsDispatchContext = useContext(OptionsDispatchContext);
-
-	if (!optionsDispatchContext) {
-		throw new Error('useOptionsDispatch may only be used within <OptionsDispatchContext>');
-	}
-
-	return optionsDispatchContext;
 }

--- a/src/contexts/data-context.tsx
+++ b/src/contexts/data-context.tsx
@@ -5,6 +5,8 @@ import { DataService } from '@/services/data-service';
 import { Hero } from '@/models/hero';
 import { Options } from '@/models/options';
 import { Session } from '@/models/session';
+import { Sourcebook } from '@/models/sourcebook';
+import { SourcebookLogic } from '@/logic/sourcebook-logic';
 import { Utils } from '@/utils/utils';
 
 interface DataManagerDispatchers {
@@ -12,6 +14,7 @@ interface DataManagerDispatchers {
 	session: ActionDispatch<[ReducerAction<Session>]>;
 	hiddenSourcebooks: ActionDispatch<[ReducerAction<string[]>]>;
 	hero: ActionDispatch<[ReducerAction<Hero>]>;
+	sourcebooks: ActionDispatch<[ReducerAction<Sourcebook>]>;
 }
 
 export class DataManager {
@@ -20,6 +23,7 @@ export class DataManager {
 	private readonly sessionDispatch: ActionDispatch<[ReducerAction<Session>]>;
 	private readonly hiddenSourcebooksDispatch:	ActionDispatch<[ReducerAction<string[]>]>;
 	private readonly heroDispatch: ActionDispatch<[ReducerAction<Hero>]>;
+	private readonly sourcebookDispatch: ActionDispatch<[ReducerAction<Sourcebook>]>;
 
 	constructor(service: DataService, dispatchers: DataManagerDispatchers) {
 		this.dataService = service;
@@ -27,6 +31,7 @@ export class DataManager {
 		this.sessionDispatch = dispatchers.session;
 		this.hiddenSourcebooksDispatch = dispatchers.hiddenSourcebooks;
 		this.heroDispatch = dispatchers.hero;
+		this.sourcebookDispatch = dispatchers.sourcebooks;
 	};
 
 	async saveOptions(options: Options) {
@@ -78,6 +83,26 @@ export class DataManager {
 				});
 			});
 	}
+
+	async saveSourcebook(sourcebook: Sourcebook) {
+		return this.dataService.saveSourcebook(sourcebook)
+			.then(sourcebook => {
+				this.sourcebookDispatch({
+					type: ReducerActionKind.UPDATE,
+					payload: sourcebook
+				});
+			});
+	}
+
+	async deleteSourcebook(sourcebook: Sourcebook) {
+		return this.dataService.deleteSourcebook(sourcebook.id)
+			.then(() => {
+				this.sourcebookDispatch({
+					type: ReducerActionKind.DELETE,
+					payload: sourcebook
+				});
+			});
+	}
 }
 
 enum ReducerActionKind {
@@ -96,12 +121,14 @@ interface DataManagerProps {
 	initialSession: Session;
 	initialHiddenSourcebookIDs: string[];
 	initialHeroes: Hero[];
+	initialHomebrewSourcebooks: Sourcebook[];
 }
 
 export const OptionsContext = createContext<Options | null>(null);
 export const HiddenSourcebookIDsContext = createContext<string[] | null>(null);
 export const SessionContext = createContext<Session | null>(null);
 export const HeroesContext = createContext<Hero[] | null>(null);
+export const HomebrewSourcebooksContext = createContext<Sourcebook[] | null>(null);
 
 export function DataManagerProvider(props: PropsWithChildren<DataManagerProps>) {
 	const dataService = props.dataService;
@@ -110,12 +137,14 @@ export function DataManagerProvider(props: PropsWithChildren<DataManagerProps>) 
 	const [ session, sessionDispatch ] = useReducer(UpdateOnlyReducer<Session>, props.initialSession);
 	const [ hiddenSourcebookIDs, hiddenSourcebookIDsDispatch ] = useReducer(UpdateOnlyReducer<string[]>, props.initialHiddenSourcebookIDs);
 	const [ heroes, heroDispatch ] = useReducer(HeroesReducer, props.initialHeroes);
+	const [ sourcebooks, sourcebookDispatch ] = useReducer(SourcebooksReducer, props.initialHomebrewSourcebooks);
 
 	const dataManager = new DataManager(dataService, {
 		options: optionsDispatch,
 		session: sessionDispatch,
 		hiddenSourcebooks: hiddenSourcebookIDsDispatch,
-		hero: heroDispatch
+		hero: heroDispatch,
+		sourcebooks: sourcebookDispatch
 	});
 
 	function UpdateOnlyReducer<T>(_oldState: T, action: ReducerAction<T>) {
@@ -160,14 +189,43 @@ export function DataManagerProvider(props: PropsWithChildren<DataManagerProps>) 
 		}
 	}
 
+	function SourcebooksReducer(currentSourcebooks: Sourcebook[], action: ReducerAction<Sourcebook>) {
+		let newHomebrew: Sourcebook[];
+		switch (action.type) {
+			case ReducerActionKind.UPDATE: {
+				const sourcebook = action.payload;
+				const copy = Utils.copy(currentSourcebooks);
+				if (currentSourcebooks.some(sb => sb.id === sourcebook.id)) {
+					const list = copy.map(sb => sb.id === sourcebook.id ? sourcebook : sb);
+					newHomebrew = list;
+				} else {
+					copy.push(sourcebook);
+					Collections.sort(copy, h => h.name);
+					newHomebrew = copy;
+				}
+				return newHomebrew;
+			}
+			case ReducerActionKind.DELETE: {
+				const sourcebook = action.payload;
+				const newHeroes = Utils.copy(currentSourcebooks.filter(sb => sb.id !== sourcebook.id));
+				return newHeroes;
+			}
+			default: {
+				throw Error(`Unknown or unsupported action: ${action.type}`);
+			}
+		}
+	}
+
 	return (
 		<DataManagerContext value={dataManager}>
 			<OptionsContext value={options}>
 				<SessionContext value={session}>
 					<HiddenSourcebookIDsContext value={hiddenSourcebookIDs}>
-						<HeroesContext value={heroes}>
-							{props.children}
-						</HeroesContext>
+						<HomebrewSourcebooksContext value={sourcebooks}>
+							<HeroesContext value={heroes}>
+								{props.children}
+							</HeroesContext>
+						</HomebrewSourcebooksContext>
 					</HiddenSourcebookIDsContext>
 				</SessionContext>
 			</OptionsContext>
@@ -178,50 +236,56 @@ export function DataManagerProvider(props: PropsWithChildren<DataManagerProps>) 
 export const DataManagerContext = createContext<DataManager | null>(null);
 export function useDataManager() {
 	const context = useContext(DataManagerContext);
-
 	if (!context) {
 		throw new Error('useDataManager may only be used within <DataManagerContext>');
 	}
-
 	return context;
 }
 
 export function useOptions() {
 	const context = useContext(OptionsContext);
-
 	if (!context) {
 		throw new Error('useOptions may only be used within <OptionsContext>');
 	}
-
 	return context;
 }
 
 export function useSession() {
 	const context = useContext(SessionContext);
-
 	if (!context) {
 		throw new Error('useSession may only be used within <SessionContext>');
 	}
-
 	return context;
 }
 
 export function useHiddenSourcebookIDs() {
 	const context = useContext(HiddenSourcebookIDsContext);
-
 	if (!context) {
 		throw new Error('useHiddenSourcebookIDs may only be used within <HiddenSourcebookIDsContext>');
 	}
-
 	return context;
 }
 
 export function useHeroes() {
 	const context = useContext(HeroesContext);
-
 	if (!context) {
 		throw new Error('useHeroes may only be used within <HeroesContext>');
 	}
-
 	return context;
+}
+
+export function useHomebrewSourcebooks() {
+	const context = useContext(HomebrewSourcebooksContext);
+	if (!context) {
+		throw new Error('useHomebrewSourcebooks may only be used within <HomebrewSourcebooksContext>');
+	}
+	return context;
+}
+
+export function useAllSourcebooks() {
+	const homebrewSourcebooks = useContext(HomebrewSourcebooksContext);
+	if (!homebrewSourcebooks) {
+		throw new Error('useAllSourcebooks may only be used within <HomebrewSourcebooksContext>');
+	}
+	return SourcebookLogic.getSourcebooks(homebrewSourcebooks);
 }

--- a/src/contexts/data-context.tsx
+++ b/src/contexts/data-context.tsx
@@ -2,9 +2,6 @@ import { ActionDispatch, PropsWithChildren, createContext, useContext, useReduce
 import { DataService } from '@/services/data-service';
 import { Options } from '@/models/options';
 
-export const OptionsContext = createContext<Options | null>(null);
-export const OptionsDispatchContext = createContext<ActionDispatch<[OptionsAction]>>(() => {});
-
 export enum OptionsActionKind {
 	UPDATE = 'Update'
 }
@@ -14,14 +11,26 @@ interface OptionsAction {
 	payload: Options;
 }
 
+export enum HiddenSourcebookIDsActionKind {
+	UPDATE = 'Update'
+}
+
+interface HiddenSourcebookIDsAction {
+	type: HiddenSourcebookIDsActionKind;
+	payload: string[];
+}
+
 export class DataManager {
 	private readonly dataService: DataService;
 	private readonly optionsDispatch: ActionDispatch<[OptionsAction]>;
+	private readonly hiddenSourcebooksDispatch: ActionDispatch<[HiddenSourcebookIDsAction]>;
 
 	constructor(service: DataService,
-		optionsDispatch: ActionDispatch<[OptionsAction]>) {
+		optionsDispatch: ActionDispatch<[OptionsAction]>,
+		hiddenSourcebooksDispatch: ActionDispatch<[HiddenSourcebookIDsAction]>) {
 		this.dataService = service;
 		this.optionsDispatch = optionsDispatch;
+		this.hiddenSourcebooksDispatch = hiddenSourcebooksDispatch;
 	};
 
 	saveOptions(options: Options) {
@@ -33,19 +42,34 @@ export class DataManager {
 				});
 			});
 	}
+
+	saveHiddenSourcebookIDs(hiddenSourcebookIDs: string[]) {
+		this.dataService.saveHiddenSourcebookIDs(hiddenSourcebookIDs)
+			.then(ids => {
+				this.hiddenSourcebooksDispatch({
+					type: HiddenSourcebookIDsActionKind.UPDATE,
+					payload: ids
+				});
+			});
+	}
 }
+
+export const OptionsContext = createContext<Options | null>(null);
+export const HiddenSourcebookIDsContext = createContext<string[] | null>(null);
 
 interface DataManagerProps {
 	dataService: DataService;
 	initialOptions: Options;
+	initialHiddenSourcebookIDs: string[];
 }
 
 export function DataManagerProvider(props: PropsWithChildren<DataManagerProps>) {
 	const dataService = props.dataService;
 
 	const [ options, optionsDispatch ] = useReducer(OptionsReducer, props.initialOptions);
+	const [ hiddenSourcebookIDs, hiddenSourcebookIDsDispatch ] = useReducer(HiddenSourcebookIDsReducer, props.initialHiddenSourcebookIDs);
 
-	const dataManager = new DataManager(dataService, optionsDispatch);
+	const dataManager = new DataManager(dataService, optionsDispatch, hiddenSourcebookIDsDispatch);
 
 	function OptionsReducer(options: Options, action: OptionsAction) {
 		switch (action.type) {
@@ -56,10 +80,21 @@ export function DataManagerProvider(props: PropsWithChildren<DataManagerProps>) 
 		return options;
 	}
 
+	function HiddenSourcebookIDsReducer(hiddenIDs: string[], action: HiddenSourcebookIDsAction) {
+		switch (action.type) {
+			case HiddenSourcebookIDsActionKind.UPDATE: {
+				return action.payload;
+			}
+		}
+		return hiddenIDs;
+	}
+
 	return (
 		<DataManagerContext value={dataManager}>
 			<OptionsContext value={options}>
-				{props.children}
+				<HiddenSourcebookIDsContext value={hiddenSourcebookIDs}>
+					{props.children}
+				</HiddenSourcebookIDsContext>
 			</OptionsContext>
 		</DataManagerContext>
 	);
@@ -84,4 +119,14 @@ export function useOptions() {
 	}
 
 	return optionsContext;
+}
+
+export function useHiddenSourcebookIDs() {
+	const context = useContext(HiddenSourcebookIDsContext);
+
+	if (!context) {
+		throw new Error('useHiddenSourcebookIDs may only be used within <HiddenSourcebookIDsContext>');
+	}
+
+	return context;
 }

--- a/src/contexts/data-context.tsx
+++ b/src/contexts/data-context.tsx
@@ -1,6 +1,7 @@
 import { ActionDispatch, PropsWithChildren, createContext, useContext, useReducer } from 'react';
 import { DataService } from '@/services/data-service';
 import { Options } from '@/models/options';
+import { Session } from '@/models/session';
 
 export enum OptionsActionKind {
 	UPDATE = 'Update'
@@ -11,6 +12,8 @@ interface OptionsAction {
 	payload: Options;
 }
 
+export const OptionsContext = createContext<Options | null>(null);
+
 export enum HiddenSourcebookIDsActionKind {
 	UPDATE = 'Update'
 }
@@ -20,21 +23,37 @@ interface HiddenSourcebookIDsAction {
 	payload: string[];
 }
 
+export const HiddenSourcebookIDsContext = createContext<string[] | null>(null);
+
+export enum SessionActionKind {
+	UPDATE = 'Update'
+}
+
+interface SessionAction {
+	type: SessionActionKind;
+	payload: Session;
+}
+
+export const SessionContext = createContext<Session | null>(null);
+
 export class DataManager {
 	private readonly dataService: DataService;
 	private readonly optionsDispatch: ActionDispatch<[OptionsAction]>;
+	private readonly sessionDispatch: ActionDispatch<[SessionAction]>;
 	private readonly hiddenSourcebooksDispatch: ActionDispatch<[HiddenSourcebookIDsAction]>;
 
 	constructor(service: DataService,
 		optionsDispatch: ActionDispatch<[OptionsAction]>,
+		sessionDispatch: ActionDispatch<[SessionAction]>,
 		hiddenSourcebooksDispatch: ActionDispatch<[HiddenSourcebookIDsAction]>) {
 		this.dataService = service;
 		this.optionsDispatch = optionsDispatch;
+		this.sessionDispatch = sessionDispatch;
 		this.hiddenSourcebooksDispatch = hiddenSourcebooksDispatch;
 	};
 
-	saveOptions(options: Options) {
-		this.dataService.saveOptions(options)
+	async saveOptions(options: Options) {
+		return this.dataService.saveOptions(options)
 			.then(options => {
 				this.optionsDispatch({
 					type: OptionsActionKind.UPDATE,
@@ -43,8 +62,18 @@ export class DataManager {
 			});
 	}
 
-	saveHiddenSourcebookIDs(hiddenSourcebookIDs: string[]) {
-		this.dataService.saveHiddenSourcebookIDs(hiddenSourcebookIDs)
+	async saveSession(session: Session) {
+		return this.dataService.saveSession(session)
+			.then(session => {
+				this.sessionDispatch({
+					type: SessionActionKind.UPDATE,
+					payload: session
+				});
+			});
+	}
+
+	async saveHiddenSourcebookIDs(hiddenSourcebookIDs: string[]) {
+		return this.dataService.saveHiddenSourcebookIDs(hiddenSourcebookIDs)
 			.then(ids => {
 				this.hiddenSourcebooksDispatch({
 					type: HiddenSourcebookIDsActionKind.UPDATE,
@@ -54,12 +83,10 @@ export class DataManager {
 	}
 }
 
-export const OptionsContext = createContext<Options | null>(null);
-export const HiddenSourcebookIDsContext = createContext<string[] | null>(null);
-
 interface DataManagerProps {
 	dataService: DataService;
 	initialOptions: Options;
+	initiaSession: Session;
 	initialHiddenSourcebookIDs: string[];
 }
 
@@ -67,9 +94,13 @@ export function DataManagerProvider(props: PropsWithChildren<DataManagerProps>) 
 	const dataService = props.dataService;
 
 	const [ options, optionsDispatch ] = useReducer(OptionsReducer, props.initialOptions);
+	const [ session, sessionDispatch ] = useReducer(SessionReducer, props.initiaSession);
 	const [ hiddenSourcebookIDs, hiddenSourcebookIDsDispatch ] = useReducer(HiddenSourcebookIDsReducer, props.initialHiddenSourcebookIDs);
 
-	const dataManager = new DataManager(dataService, optionsDispatch, hiddenSourcebookIDsDispatch);
+	const dataManager = new DataManager(dataService,
+		optionsDispatch,
+		sessionDispatch,
+		hiddenSourcebookIDsDispatch);
 
 	function OptionsReducer(options: Options, action: OptionsAction) {
 		switch (action.type) {
@@ -78,6 +109,15 @@ export function DataManagerProvider(props: PropsWithChildren<DataManagerProps>) 
 			}
 		}
 		return options;
+	}
+
+	function SessionReducer(session: Session, action: SessionAction) {
+		switch (action.type) {
+			case SessionActionKind.UPDATE: {
+				return action.payload;
+			}
+		}
+		return session;
 	}
 
 	function HiddenSourcebookIDsReducer(hiddenIDs: string[], action: HiddenSourcebookIDsAction) {
@@ -92,9 +132,11 @@ export function DataManagerProvider(props: PropsWithChildren<DataManagerProps>) 
 	return (
 		<DataManagerContext value={dataManager}>
 			<OptionsContext value={options}>
-				<HiddenSourcebookIDsContext value={hiddenSourcebookIDs}>
-					{props.children}
-				</HiddenSourcebookIDsContext>
+				<SessionContext value={session}>
+					<HiddenSourcebookIDsContext value={hiddenSourcebookIDs}>
+						{props.children}
+					</HiddenSourcebookIDsContext>
+				</SessionContext>
 			</OptionsContext>
 		</DataManagerContext>
 	);
@@ -112,13 +154,23 @@ export function useDataManager() {
 }
 
 export function useOptions() {
-	const optionsContext = useContext(OptionsContext);
+	const context = useContext(OptionsContext);
 
-	if (!optionsContext) {
+	if (!context) {
 		throw new Error('useOptions may only be used within <OptionsContext>');
 	}
 
-	return optionsContext;
+	return context;
+}
+
+export function useSession() {
+	const context = useContext(SessionContext);
+
+	if (!context) {
+		throw new Error('useSession may only be used within <SessionContext>');
+	}
+
+	return context;
 }
 
 export function useHiddenSourcebookIDs() {

--- a/src/contexts/data-context.tsx
+++ b/src/contexts/data-context.tsx
@@ -1,62 +1,39 @@
 import { ActionDispatch, PropsWithChildren, createContext, useContext, useReducer } from 'react';
+import { Analytics } from '@/utils/analytics';
+import { Collections } from '@/utils/collections';
 import { DataService } from '@/services/data-service';
+import { Hero } from '@/models/hero';
 import { Options } from '@/models/options';
 import { Session } from '@/models/session';
+import { Utils } from '@/utils/utils';
 
-export enum OptionsActionKind {
-	UPDATE = 'Update'
+interface DataManagerDispatchers {
+	options: ActionDispatch<[ReducerAction<Options>]>;
+	session: ActionDispatch<[ReducerAction<Session>]>;
+	hiddenSourcebooks: ActionDispatch<[ReducerAction<string[]>]>;
+	hero: ActionDispatch<[ReducerAction<Hero>]>;
 }
-
-interface OptionsAction {
-	type: OptionsActionKind;
-	payload: Options;
-}
-
-export const OptionsContext = createContext<Options | null>(null);
-
-export enum HiddenSourcebookIDsActionKind {
-	UPDATE = 'Update'
-}
-
-interface HiddenSourcebookIDsAction {
-	type: HiddenSourcebookIDsActionKind;
-	payload: string[];
-}
-
-export const HiddenSourcebookIDsContext = createContext<string[] | null>(null);
-
-export enum SessionActionKind {
-	UPDATE = 'Update'
-}
-
-interface SessionAction {
-	type: SessionActionKind;
-	payload: Session;
-}
-
-export const SessionContext = createContext<Session | null>(null);
 
 export class DataManager {
 	private readonly dataService: DataService;
-	private readonly optionsDispatch: ActionDispatch<[OptionsAction]>;
-	private readonly sessionDispatch: ActionDispatch<[SessionAction]>;
-	private readonly hiddenSourcebooksDispatch: ActionDispatch<[HiddenSourcebookIDsAction]>;
+	private readonly optionsDispatch: ActionDispatch<[ReducerAction<Options>]>;
+	private readonly sessionDispatch: ActionDispatch<[ReducerAction<Session>]>;
+	private readonly hiddenSourcebooksDispatch:	ActionDispatch<[ReducerAction<string[]>]>;
+	private readonly heroDispatch: ActionDispatch<[ReducerAction<Hero>]>;
 
-	constructor(service: DataService,
-		optionsDispatch: ActionDispatch<[OptionsAction]>,
-		sessionDispatch: ActionDispatch<[SessionAction]>,
-		hiddenSourcebooksDispatch: ActionDispatch<[HiddenSourcebookIDsAction]>) {
+	constructor(service: DataService, dispatchers: DataManagerDispatchers) {
 		this.dataService = service;
-		this.optionsDispatch = optionsDispatch;
-		this.sessionDispatch = sessionDispatch;
-		this.hiddenSourcebooksDispatch = hiddenSourcebooksDispatch;
+		this.optionsDispatch = dispatchers.options;
+		this.sessionDispatch = dispatchers.session;
+		this.hiddenSourcebooksDispatch = dispatchers.hiddenSourcebooks;
+		this.heroDispatch = dispatchers.hero;
 	};
 
 	async saveOptions(options: Options) {
 		return this.dataService.saveOptions(options)
 			.then(options => {
 				this.optionsDispatch({
-					type: OptionsActionKind.UPDATE,
+					type: ReducerActionKind.UPDATE,
 					payload: options
 				});
 			});
@@ -66,7 +43,7 @@ export class DataManager {
 		return this.dataService.saveSession(session)
 			.then(session => {
 				this.sessionDispatch({
-					type: SessionActionKind.UPDATE,
+					type: ReducerActionKind.UPDATE,
 					payload: session
 				});
 			});
@@ -76,57 +53,111 @@ export class DataManager {
 		return this.dataService.saveHiddenSourcebookIDs(hiddenSourcebookIDs)
 			.then(ids => {
 				this.hiddenSourcebooksDispatch({
-					type: HiddenSourcebookIDsActionKind.UPDATE,
+					type: ReducerActionKind.UPDATE,
 					payload: ids
+				});
+			});
+	}
+
+	async saveHero(hero: Hero) {
+		return this.dataService.saveHero(hero)
+			.then(hero => {
+				this.heroDispatch({
+					type: ReducerActionKind.UPDATE,
+					payload: hero
+				});
+			});
+	}
+
+	async deleteHero(hero: Hero) {
+		return this.dataService.deleteHero(hero.id)
+			.then(() => {
+				this.heroDispatch({
+					type: ReducerActionKind.DELETE,
+					payload: hero
 				});
 			});
 	}
 }
 
+enum ReducerActionKind {
+	UPDATE = 'Update',
+	DELETE = 'Delete'
+}
+
+interface ReducerAction<T> {
+	type: ReducerActionKind;
+	payload: T;
+}
+
 interface DataManagerProps {
 	dataService: DataService;
 	initialOptions: Options;
-	initiaSession: Session;
+	initialSession: Session;
 	initialHiddenSourcebookIDs: string[];
+	initialHeroes: Hero[];
 }
+
+export const OptionsContext = createContext<Options | null>(null);
+export const HiddenSourcebookIDsContext = createContext<string[] | null>(null);
+export const SessionContext = createContext<Session | null>(null);
+export const HeroesContext = createContext<Hero[] | null>(null);
 
 export function DataManagerProvider(props: PropsWithChildren<DataManagerProps>) {
 	const dataService = props.dataService;
 
-	const [ options, optionsDispatch ] = useReducer(OptionsReducer, props.initialOptions);
-	const [ session, sessionDispatch ] = useReducer(SessionReducer, props.initiaSession);
-	const [ hiddenSourcebookIDs, hiddenSourcebookIDsDispatch ] = useReducer(HiddenSourcebookIDsReducer, props.initialHiddenSourcebookIDs);
+	const [ options, optionsDispatch ] = useReducer(UpdateOnlyReducer<Options>, props.initialOptions);
+	const [ session, sessionDispatch ] = useReducer(UpdateOnlyReducer<Session>, props.initialSession);
+	const [ hiddenSourcebookIDs, hiddenSourcebookIDsDispatch ] = useReducer(UpdateOnlyReducer<string[]>, props.initialHiddenSourcebookIDs);
+	const [ heroes, heroDispatch ] = useReducer(HeroesReducer, props.initialHeroes);
 
-	const dataManager = new DataManager(dataService,
-		optionsDispatch,
-		sessionDispatch,
-		hiddenSourcebookIDsDispatch);
+	const dataManager = new DataManager(dataService, {
+		options: optionsDispatch,
+		session: sessionDispatch,
+		hiddenSourcebooks: hiddenSourcebookIDsDispatch,
+		hero: heroDispatch
+	});
 
-	function OptionsReducer(options: Options, action: OptionsAction) {
+	function UpdateOnlyReducer<T>(_oldState: T, action: ReducerAction<T>) {
 		switch (action.type) {
-			case OptionsActionKind.UPDATE: {
+			case ReducerActionKind.UPDATE: {
 				return action.payload;
 			}
+			default: {
+				throw Error(`Unknown or unsupported action: ${action.type}`);
+			}
 		}
-		return options;
 	}
 
-	function SessionReducer(session: Session, action: SessionAction) {
+	function HeroesReducer(currentHeroes: Hero[], action: ReducerAction<Hero>) {
+		let newHeroes: Hero[];
 		switch (action.type) {
-			case SessionActionKind.UPDATE: {
-				return action.payload;
-			}
-		}
-		return session;
-	}
+			case ReducerActionKind.UPDATE: {
+				const hero = action.payload;
+				const copy = Utils.copy(currentHeroes);
+				if (currentHeroes.some(h => h.id === hero.id)) {
+					Analytics.logHeroEdited(hero);
 
-	function HiddenSourcebookIDsReducer(hiddenIDs: string[], action: HiddenSourcebookIDsAction) {
-		switch (action.type) {
-			case HiddenSourcebookIDsActionKind.UPDATE: {
-				return action.payload;
+					const list = copy.map(h => h.id === hero.id ? hero : h);
+					newHeroes = list;
+				} else {
+					Analytics.logHeroCreated(hero);
+
+					copy.push(hero);
+					Collections.sort(copy, h => h.name);
+					newHeroes = copy;
+				}
+				return newHeroes;
+			}
+			case ReducerActionKind.DELETE: {
+				const hero = action.payload;
+				const newHeroes = Utils.copy(currentHeroes.filter(h => h.id !== hero.id));
+				return newHeroes;
+			}
+			default: {
+				throw Error(`Unknown or unsupported action: ${action.type}`);
 			}
 		}
-		return hiddenIDs;
 	}
 
 	return (
@@ -134,7 +165,9 @@ export function DataManagerProvider(props: PropsWithChildren<DataManagerProps>) 
 			<OptionsContext value={options}>
 				<SessionContext value={session}>
 					<HiddenSourcebookIDsContext value={hiddenSourcebookIDs}>
-						{props.children}
+						<HeroesContext value={heroes}>
+							{props.children}
+						</HeroesContext>
 					</HiddenSourcebookIDsContext>
 				</SessionContext>
 			</OptionsContext>
@@ -178,6 +211,16 @@ export function useHiddenSourcebookIDs() {
 
 	if (!context) {
 		throw new Error('useHiddenSourcebookIDs may only be used within <HiddenSourcebookIDsContext>');
+	}
+
+	return context;
+}
+
+export function useHeroes() {
+	const context = useContext(HeroesContext);
+
+	if (!context) {
+		throw new Error('useHeroes may only be used within <HeroesContext>');
 	}
 
 	return context;

--- a/src/contexts/data-context.tsx
+++ b/src/contexts/data-context.tsx
@@ -1,0 +1,61 @@
+import { ActionDispatch, PropsWithChildren, createContext, useContext, useReducer } from 'react';
+import { DataService } from '@/services/data-service';
+import { Options } from '@/models/options';
+
+export const OptionsContext = createContext<Options | null>(null);
+export const OptionsDispatchContext = createContext<ActionDispatch<[OptionsAction]>>(() => {});
+
+interface OptionsProps {
+	initialOptions: Options,
+	dataService: DataService
+}
+
+export enum OptionsActionKind {
+	UPDATE = 'Update'
+}
+
+interface OptionsAction {
+	type: OptionsActionKind,
+	payload: Options
+}
+
+export function OptionsProvider(props: PropsWithChildren<OptionsProps>) {
+	const [ options, dispatch ] = useReducer(OptionsReducer, props.initialOptions);
+
+	function OptionsReducer(options: Options, action: OptionsAction) {
+		switch (action.type) {
+			case 'Update': {
+				return action.payload;
+			}
+		}
+		return options;
+	}
+
+	return (
+		<OptionsContext value={options}>
+			<OptionsDispatchContext value={dispatch}>
+				{props.children}
+			</OptionsDispatchContext>
+		</OptionsContext>
+	);
+}
+
+export function useOptions() {
+	const optionsContext = useContext(OptionsContext);
+
+	if (!optionsContext) {
+		throw new Error('useOptions may only be used within <OptionsContext>');
+	}
+
+	return optionsContext;
+}
+
+export function useOptionsDispatch() {
+	const optionsDispatchContext = useContext(OptionsDispatchContext);
+
+	if (!optionsDispatchContext) {
+		throw new Error('useOptionsDispatch may only be used within <OptionsDispatchContext>');
+	}
+
+	return optionsDispatchContext;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -36,10 +36,10 @@ root.render(
 										initialOptions={data.options}
 										initialSession={data.session}
 										initialHeroes={data.heroes}
+										initialHomebrewSourcebooks={data.homebrewSourcebooks}
 										initialHiddenSourcebookIDs={data.hiddenSourcebookIDs}
 									>
 										<Main
-											homebrewSourcebooks={data.homebrewSourcebooks}
 											connectionSettings={data.connectionSettings}
 											dataService={data.service}
 										/>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -34,11 +34,11 @@ root.render(
 									<DataManagerProvider
 										dataService={data.service}
 										initialOptions={data.options}
+										initialHiddenSourcebookIDs={data.hiddenSourcebookIDs}
 									>
 										<Main
 											heroes={data.heroes}
 											homebrewSourcebooks={data.homebrewSourcebooks}
-											hiddenSourcebookIDs={data.hiddenSourcebookIDs}
 											session={data.session}
 											connectionSettings={data.connectionSettings}
 											dataService={data.service}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -34,11 +34,11 @@ root.render(
 									<DataManagerProvider
 										dataService={data.service}
 										initialOptions={data.options}
-										initiaSession={data.session}
+										initialSession={data.session}
+										initialHeroes={data.heroes}
 										initialHiddenSourcebookIDs={data.hiddenSourcebookIDs}
 									>
 										<Main
-											heroes={data.heroes}
 											homebrewSourcebooks={data.homebrewSourcebooks}
 											connectionSettings={data.connectionSettings}
 											dataService={data.service}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,5 @@
 import { DataLoader } from '@/components/panels/data-loader/data-loader';
+import { DataManagerProvider } from './contexts/data-context';
 import { ErrorBoundary } from '@/components/controls/error-boundary/error-boundary';
 import { HashRouter } from 'react-router';
 import { Main } from '@/components/main/main.tsx';
@@ -30,15 +31,19 @@ root.render(
 						<ErrorBoundary>
 							<StrictMode>
 								<HashRouter>
-									<Main
-										heroes={data.heroes}
-										homebrewSourcebooks={data.homebrewSourcebooks}
-										hiddenSourcebookIDs={data.hiddenSourcebookIDs}
-										session={data.session}
-										options={data.options}
-										connectionSettings={data.connectionSettings}
+									<DataManagerProvider
 										dataService={data.service}
-									/>
+										initialOptions={data.options}
+									>
+										<Main
+											heroes={data.heroes}
+											homebrewSourcebooks={data.homebrewSourcebooks}
+											hiddenSourcebookIDs={data.hiddenSourcebookIDs}
+											session={data.session}
+											connectionSettings={data.connectionSettings}
+											dataService={data.service}
+										/>
+									</DataManagerProvider>
 								</HashRouter>
 							</StrictMode>
 						</ErrorBoundary>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -34,12 +34,12 @@ root.render(
 									<DataManagerProvider
 										dataService={data.service}
 										initialOptions={data.options}
+										initiaSession={data.session}
 										initialHiddenSourcebookIDs={data.hiddenSourcebookIDs}
 									>
 										<Main
 											heroes={data.heroes}
 											homebrewSourcebooks={data.homebrewSourcebooks}
-											session={data.session}
 											connectionSettings={data.connectionSettings}
 											dataService={data.service}
 										/>


### PR DESCRIPTION
## Overview
- Adds a DataManager class that serves as a single point of access/manipulation for user data.
- Adds Contexts and Dispatchers for the various user data elements that previously were getting passed via props all throughout the app
   - Instead of passing e.g. `Options` via props, any components can now just declare: `const options = useOptions();` and have access to the current `Options` object and state.
   - Available contexts:
      - `useOptions`
      - `useSession`
      - `useHiddenSourcebookIDs`
      - `useHeroes`
      - `useHomebrewSourcebooks`
      - `useAllSourcebooks`

In most cases, I have gone through the app and removed the props injection in favor of using the contexts. However, because of the ambiguity of most of the `Sourcebook[]` props being interchangeable between homebrew-specific or *all* Sourcebooks, I have left all of the props-passing from `Main` intact for now.