### PR TITLE
fix: preserve original image format and tactical map resolution

### DIFF
--- a/src/components/pages/library/library-list/controls/add-btn.tsx
+++ b/src/components/pages/library/library-list/controls/add-btn.tsx
@@ -16,7 +16,6 @@ import { NumberSpin } from '@/components/controls/number-spin/number-spin';
 import { Options } from '@/models/options';
 import { SourcebookLogic } from '@/logic/sourcebook-logic';
 import { TacticalMapLogic } from '@/logic/tactical-map-logic';
-import { Utils } from '@/utils/utils';
 import { useState } from 'react';
 
 interface Props {
@@ -176,11 +175,10 @@ export const AddBtn = (props: Props) => {
 								showUploadList={false}
 								beforeUpload={file => {
 									const reader = new FileReader();
-									reader.onload = async progress => {
+									reader.onload = progress => {
 										if (progress.target) {
 											const content = progress.target.result as string;
-											const resized = await Utils.getResizedImage(content);
-											setMapImportData(resized);
+											setMapImportData(content);
 										}
 									};
 									reader.readAsDataURL(file);

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -82,7 +82,8 @@ export class Utils {
 					const offsetX = (maxSize - scaledWidth) / 2;
 					const offsetY = (maxSize - scaledHeight) / 2;
 					ctx.drawImage(img, offsetX, offsetY, scaledWidth, scaledHeight);
-					resolve(canvas.toDataURL('image/png'));
+					const mime = data.match(/^data:([^;,]+)[;,]/)?.[1] || 'image/png';
+					resolve(canvas.toDataURL(mime));
 				} else {
 					resolve(data);
 				}


### PR DESCRIPTION
 Commit d3235643 ("Improve image handling") introduced `Utils.getResizedImage` and wired it into every image upload site, including tactical maps. The helper:

  - scales the image to fit a hardcoded 500×500 canvas,
  - centers it with `(maxSize - scaled) / 2` offsets, so non-square inputs get letterboxed,
  - re-encodes the output as PNG regardless of input.

  That's fine for square portrait thumbnails, but for tactical maps it crushes resolution, letterboxes the artwork inside a 500×500 transparent square. The result is unusable maps for the director view.



This restores the previous behaviour for image uploads. Two atomic commits:

  1. `getResizedImage` now reads the source mime type from the data-URL prefix and passes it back to `toDataURL`, instead of hardcoding `image/png`. Portrait uploads (hero /  monster / monster-group / plot) keep their 500-cap thumbnail behaviour but stay in their original format.

  2. The tactical-map upload in the library "Use a battlemap" flow no longer routes through `getResizedImage` at all. It now stores the raw `FileReader` data URL exactly as before commit d3235643.