### PR TITLE
Encounter Builder improvements

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+ignore-scripts=true
+min-release-age=7

--- a/src/components/main/main.tsx
+++ b/src/components/main/main.tsx
@@ -174,7 +174,6 @@ export const Main = (props: Props) => {
 	const persistHomebrewSourcebook = (homebrew: Sourcebook) => {
 		return dataManager
 			.saveSourcebook(homebrew)
-			// .then(() => setHomebrewSourcebooks(newHomebrew))
 			.catch(err => {
 				console.error(err);
 				notify.error({

--- a/src/components/modals/encounter-tools/encounter-tools-modal.tsx
+++ b/src/components/modals/encounter-tools/encounter-tools-modal.tsx
@@ -8,7 +8,6 @@ import { FormatLogic } from '@/logic/format-logic';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Modal } from '@/components/modals/modal/modal';
 import { Monster } from '@/models/monster';
-import { MonsterLogic } from '@/logic/monster-logic';
 import { SelectablePanel } from '@/components/controls/selectable-panel/selectable-panel';
 import { Sourcebook } from '@/models/sourcebook';
 import { SourcebookLogic } from '@/logic/sourcebook-logic';
@@ -28,13 +27,13 @@ export const EncounterToolsModal = (props: Props) => {
 		.forEach(slot => {
 			const existing = monsters.find(m => m.monster.id === slot.monsterID);
 			if (existing) {
-				existing.count += slot.count * MonsterLogic.getRoleMultiplier(existing.monster.role.organization);
+				existing.count += slot.count;
 			} else {
 				const monster = SourcebookLogic.getMonster(props.sourcebooks, slot.monsterID);
 				if (monster) {
 					monsters.push({
 						monster: monster,
-						count: slot.count * MonsterLogic.getRoleMultiplier(monster.role.organization)
+						count: slot.count
 					});
 				}
 			}

--- a/src/components/panels/edit/encounter-edit/encounter-edit-panel.scss
+++ b/src/components/panels/edit/encounter-edit/encounter-edit-panel.scss
@@ -34,7 +34,8 @@
 				}
 
 				.actions {
-					flex: 0 0 120px;
+					min-width: 120px;
+					flex: 0 0 auto;
 				}
 
 				&:hover {

--- a/src/components/panels/edit/encounter-edit/encounter-edit-panel.tsx
+++ b/src/components/panels/edit/encounter-edit/encounter-edit-panel.tsx
@@ -1,5 +1,5 @@
-import { Alert, Button, Divider, Flex, Popover, Select, Space, Tabs } from 'antd';
-import { CaretDownOutlined, CaretUpOutlined, CheckCircleOutlined, CloseCircleOutlined, CopyOutlined, EditFilled, EditOutlined, EllipsisOutlined, FilterFilled, FilterOutlined, InfoCircleOutlined, PlusOutlined } from '@ant-design/icons';
+import { Alert, Button, Divider, Flex, Popover, Select, Space, Tabs, Tooltip } from 'antd';
+import { CaretDownOutlined, CaretUpOutlined, CheckCircleOutlined, CloseCircleOutlined, CopyOutlined, EditFilled, EditOutlined, EllipsisOutlined, FilterFilled, FilterOutlined, InfoCircleOutlined, PlusOutlined, WarningFilled } from '@ant-design/icons';
 import { DndContext, DragEndEvent, DragOverlay, DragStartEvent, useDraggable, useDroppable } from '@dnd-kit/core';
 import { Encounter, EncounterGroup, EncounterObjective, TerrainSlot } from '@/models/encounter';
 import { Fragment, ReactNode, useState } from 'react';
@@ -92,19 +92,16 @@ export const EncounterEditPanel = (props: Props) => {
 	const addMonster = (monster: Monster, encounterGroupID: string | null) => {
 		const copy = Utils.copy(encounter);
 
+		const count = MonsterLogic.getRoleMultiplier(monster.role.organization);
+
 		if (encounterGroupID) {
 			const group = copy.groups.find(g => g.id === encounterGroupID);
 			if (group) {
-				const slot = group.slots.find(s => s.monsterID === monster.id);
-				if (slot) {
-					slot.count += 1;
-				} else {
-					group.slots.push(FactoryLogic.createEncounterSlot(monster.id));
-				}
+				group.slots.push(FactoryLogic.createEncounterSlot(monster.id, count));
 			};
 		} else {
 			const group = FactoryLogic.createEncounterGroup();
-			group.slots.push(FactoryLogic.createEncounterSlot(monster.id));
+			group.slots.push(FactoryLogic.createEncounterSlot(monster.id, count));
 			copy.groups.push(group);
 		}
 
@@ -1109,12 +1106,25 @@ const MonsterSlotPanel = (props: MonsterSlotPanelProps) => {
 			);
 		};
 
+		const getCountCheck = () => {
+			const roleMult = MonsterLogic.getRoleMultiplier(monster.role.organization);
+
+			if (props.slot.count % roleMult !== 0) {
+				return (
+					<Tooltip title='This monster expects to be in groups of multiples of 4. Make sure this count is correct.'>
+						<WarningFilled style={{ color: 'yellow' }} />
+					</Tooltip>
+				);
+			}
+		};
+
 		return (
 			<ErrorBoundary>
 				<div className='slot-row'>
 					<div className='content'>
 						<Flex align='center' justify='space-between'>
 							<MonsterInfo monster={monster} />
+							{getCountCheck()}
 							<ButtonGroup
 								buttons={[
 									{ type: 'button', icon: <InfoCircleOutlined />, tooltip: 'Show stat block', onClick: () => props.showMonster(monster, monsterGroup) },
@@ -1132,7 +1142,7 @@ const MonsterSlotPanel = (props: MonsterSlotPanelProps) => {
 					<div className='actions'>
 						<NumberSpin
 							value={props.slot.count}
-							format={value => (value * MonsterLogic.getRoleMultiplier(monster.role.organization)).toString()}
+							steps={[ ...new Set([ 1, MonsterLogic.getRoleMultiplier(monster.role.organization) ]) ]}
 							onChange={value => props.setSlotCount(props.group.id, props.slot.id, value)}
 						/>
 					</div>

--- a/src/components/panels/elements/encounter-panel/encounter-panel.tsx
+++ b/src/components/panels/elements/encounter-panel/encounter-panel.tsx
@@ -14,7 +14,6 @@ import { FeatureType } from '@/enums/feature-type';
 import { Field } from '@/components/controls/field/field';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { Markdown } from '@/components/controls/markdown/markdown';
-import { MonsterLogic } from '@/logic/monster-logic';
 import { MonsterPanel } from '@/components/panels/elements/monster-panel/monster-panel';
 import { PanelMode } from '@/enums/panel-mode';
 import { Pill } from '@/components/controls/pill/pill';
@@ -76,7 +75,7 @@ export const EncounterPanel = (props: Props) => {
 											return null;
 										}
 
-										const count = slot.count * MonsterLogic.getRoleMultiplier(monster.role.organization);
+										const count = slot.count;
 
 										return (
 											<div key={slot.id} className='encounter-slot'>

--- a/src/components/panels/encounter-difficulty/encounter-difficulty-panel.tsx
+++ b/src/components/panels/encounter-difficulty/encounter-difficulty-panel.tsx
@@ -24,7 +24,7 @@ interface Props {
 export const EncounterDifficultyPanel = (props: Props) => {
 	const options = useOptions();
 	const heroes = useHeroes();
-	const count = EncounterLogic.getMonsterCount(props.encounter, props.sourcebooks);
+	const count = EncounterLogic.getMonsterCount(props.encounter);
 	const budgets = EncounterDifficultyLogic.getBudgets(options, heroes);
 	const strength = EncounterDifficultyLogic.getStrength(props.encounter, props.sourcebooks);
 	const difficulty = EncounterDifficultyLogic.getDifficulty(strength, options, heroes);

--- a/src/components/panels/run/encounter-run/encounter-run-panel.tsx
+++ b/src/components/panels/run/encounter-run/encounter-run-panel.tsx
@@ -104,8 +104,8 @@ export const EncounterRunPanel = (props: Props) => {
 	};
 
 	const addSlot = (monster: Monster) => {
-		const slot = FactoryLogic.createEncounterSlot(monster.id);
-		slot.count = MonsterLogic.getRoleMultiplier(monster.role.organization);
+		const count = MonsterLogic.getRoleMultiplier(monster.role.organization);
+		const slot = FactoryLogic.createEncounterSlot(monster.id, count);
 
 		while (slot.monsters.length < slot.count) {
 			const monsterCopy = Utils.copy(monster);

--- a/src/logic/encounter-difficulty-logic.ts
+++ b/src/logic/encounter-difficulty-logic.ts
@@ -4,6 +4,7 @@ import { EncounterDifficulty } from '@/enums/encounter-difficulty';
 import { EncounterLogic } from '@/logic/encounter-logic';
 import { Hero } from '@/models/hero';
 import { HeroLogic } from '@/logic/hero-logic';
+import { MonsterLogic } from './monster-logic';
 import { Options } from '@/models/options';
 import { Sourcebook } from '@/models/sourcebook';
 import { SourcebookLogic } from '@/logic/sourcebook-logic';
@@ -19,12 +20,16 @@ export class EncounterDifficultyLogic {
 		return Collections.sum(group.slots, slot => {
 			const monster = EncounterLogic.getCustomizedMonster(slot.monsterID, slot.customization, sourcebooks);
 
-			const group = SourcebookLogic.getMonsterGroup(sourcebooks, slot.monsterID);
-			const addOns = group ? group.addOns.filter(a => slot.customization.addOnIDs.includes(a.id)) : [];
-			const addOnPoints = Collections.sum(addOns, a => a.data.cost);
-			const addOnCost = addOnPoints > 4 ? (addOnPoints - 4) * 2 : 0;
+			if (monster) {
+				const group = SourcebookLogic.getMonsterGroup(sourcebooks, slot.monsterID);
+				const addOns = group ? group.addOns.filter(a => slot.customization.addOnIDs.includes(a.id)) : [];
+				const addOnPoints = Collections.sum(addOns, a => a.data.cost);
+				const addOnCost = addOnPoints > 4 ? (addOnPoints - 4) * 2 : 0;
+				const roleMult = MonsterLogic.getRoleMultiplier(monster.role.organization);
 
-			return monster ? (monster.encounterValue + addOnCost) * slot.count : 0;
+				return (monster.encounterValue + addOnCost) * Math.floor(slot.count / roleMult);
+			}
+			return 0;
 		});
 	};
 

--- a/src/logic/encounter-logic.ts
+++ b/src/logic/encounter-logic.ts
@@ -13,20 +13,11 @@ import { SourcebookLogic } from '@/logic/sourcebook-logic';
 import { Utils } from '@/utils/utils';
 
 export class EncounterLogic {
-	static getMonsterCount = (encounter: Encounter, sourcebooks: Sourcebook[]) => {
+	static getMonsterCount = (encounter: Encounter) => {
 		let total = 0;
 
 		encounter.groups.forEach(g => {
-			g.slots.forEach(s => {
-				let count = s.count;
-
-				const monster = SourcebookLogic.getMonster(sourcebooks, s.monsterID);
-				if (monster) {
-					count *= MonsterLogic.getRoleMultiplier(monster.role.organization);
-				}
-
-				total += count;
-			});
+			g.slots.forEach(s => total += s.count);
 		});
 
 		return total;

--- a/src/logic/factory-logic.ts
+++ b/src/logic/factory-logic.ts
@@ -678,11 +678,11 @@ export class FactoryLogic {
 		};
 	};
 
-	static createEncounterSlot = (monsterID: string): EncounterSlot => {
+	static createEncounterSlot = (monsterID: string, count: number): EncounterSlot => {
 		return {
 			id: Utils.guid(),
 			monsterID: monsterID,
-			count: 1,
+			count: count,
 			customization: {
 				addOnIDs: [],
 				itemIDs: [],

--- a/src/logic/playbook-sheets/encounter-sheet-builder.ts
+++ b/src/logic/playbook-sheets/encounter-sheet-builder.ts
@@ -7,7 +7,6 @@ import { EncounterLogic } from '@/logic/encounter-logic';
 import { EncounterSlot } from '@/models/encounter-slot';
 import { FeatureType } from '@/enums/feature-type';
 import { Hero } from '@/models/hero';
-import { MonsterLogic } from '@/logic/monster-logic';
 import { MonsterOrganizationType } from '@/enums/monster-organization-type';
 import { Options } from '@/models/options';
 import { SheetFormatter } from '@/logic/classic-sheet/sheet-formatter';
@@ -125,7 +124,7 @@ export class EncounterSheetBuilder {
 			console.error('Failed to get monster for encounter slot:', slot);
 			return null;
 		}
-		const roleMult = MonsterLogic.getRoleMultiplier(monster.role.organization);
+		const roleMult = 1;
 		const sheet: EncounterSlotSheet = {
 			id: slot.id,
 			monster: monster,

--- a/src/logic/session-logic.ts
+++ b/src/logic/session-logic.ts
@@ -28,7 +28,7 @@ export class SessionLogic {
 				const monster = EncounterLogic.getCustomizedMonster(slot.monsterID, slot.customization, sourcebooks);
 				const monsterGroup = SourcebookLogic.getMonsterGroup(sourcebooks, slot.monsterID);
 				if (monster && monsterGroup) {
-					const count = slot.count * MonsterLogic.getRoleMultiplier(monster.role.organization);
+					const count = slot.count;
 					const current = monsterInfo.find(info => info.monsterID === slot.monsterID);
 					if (current) {
 						current.count += count;
@@ -49,7 +49,7 @@ export class SessionLogic {
 			.forEach(slot => {
 				const info = monsterInfo.find(info => info.monsterID === slot.monsterID);
 				if (info) {
-					const count = slot.count * MonsterLogic.getRoleMultiplier(info.monster.role.organization);
+					const count = slot.count;
 					for (let n = 1; n <= count; ++n) {
 						const monsterCopy = Utils.copy(info.monster);
 						monsterCopy.id = Utils.guid();


### PR DESCRIPTION
# Overview
- Adds the ability to set Minion numbers in the Encounter Builder in increments less than 4. (Fixes #710 )
- Adds the ability to have the same *kind* of monster in multiple slots within the same group.
- Adds an `.npmrc` file with a couple settings that should help minimize the risk of npm supply chain attacks

## Minion Group Size
When editing an Encounter, Minion numbers can now be adjusted both by the standard group size (4), as well as in increments of 1:

<img width="803" height="85" alt="image" src="https://github.com/user-attachments/assets/18b004b8-ddc4-405e-90c3-7e1fcc9de3e5" />

Encounter EV only accounts for minion groups at the 'multiple of 4' threshold, and to help users more easily identify issues with minion counts, a warning is shown if there is a minion group that is not a multiple of 4:

<img width="463" height="142" alt="image" src="https://github.com/user-attachments/assets/50dc7c3b-1424-4107-933f-1eaa69df40e6" />

As a side effect of this change, the Encounter data model now stores the *actual* number of minions in a group, and *not* the number of 'groups of 4 minions'. As a result, **previously saved encounters with minion groups will need to be updated** to reflect the actual desired number of minions.

## Duplicate Monster slots in a group
The default behavior of combining identical monsters into a single Slot when adding from the Monster select list has been removed. As a result, it is now possible to have the same monster type in more than one Slot in an EncounterGroup:

<img width="803" height="184" alt="image" src="https://github.com/user-attachments/assets/af50ab78-2bb7-4153-8c27-daea7b235dcc" />

This allows for greater fine-tuning of monster customizations in the Encounter definition (for example, if in the example above, one of the Goblin Stinkers has some customization the other doesn't).