### PR TITLE
Encounter Builder and classic sheet updates

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+ignore-scripts=true
+min-release-age=7

--- a/src/components/main/main.tsx
+++ b/src/components/main/main.tsx
@@ -174,7 +174,6 @@ export const Main = (props: Props) => {
 	const persistHomebrewSourcebook = (homebrew: Sourcebook) => {
 		return dataManager
 			.saveSourcebook(homebrew)
-			// .then(() => setHomebrewSourcebooks(newHomebrew))
 			.catch(err => {
 				console.error(err);
 				notify.error({

--- a/src/components/panels/classic-sheet/encounter-roster/encounter-roster.tsx
+++ b/src/components/panels/classic-sheet/encounter-roster/encounter-roster.tsx
@@ -34,13 +34,6 @@ export const EncounterRosterCard = (props: Props) => {
 				</thead>
 				<tbody>
 					{encounter.groups?.map((group, i) => {
-						const slotEv = group.slots.reduce((ev, slot) => {
-							const monster = slot.monster;
-							if (!monster) {
-								return ev;
-							}
-							return ev + (monster.encounterValue * slot.count);
-						}, 0);
 						const groupMonsters = group.slots.map(slot => slot.monster).filter(m => !!m);
 						const minionSlots = groupMonsters.filter(m => m.role.organization === MonsterOrganizationType.Minion).length;
 						const nonMinionSlots = groupMonsters.filter(m => m.role.organization !== MonsterOrganizationType.Minion).length;
@@ -78,7 +71,7 @@ export const EncounterRosterCard = (props: Props) => {
 												);
 											})
 										}
-										<div className='ev'>EV:<span className='ev-value'>{slotEv}</span></div>
+										<div className='ev'>EV:<span className='ev-value'>{group.groupEv}</span></div>
 									</div>
 								</td>
 								<td className='stamina-tracker'>

--- a/src/components/panels/edit/encounter-edit/encounter-edit-panel.scss
+++ b/src/components/panels/edit/encounter-edit/encounter-edit-panel.scss
@@ -34,7 +34,8 @@
 				}
 
 				.actions {
-					flex: 0 0 120px;
+					min-width: 120px;
+					flex: 0 0 auto;
 				}
 
 				&.customizing {
@@ -157,7 +158,8 @@ html[data-theme="dark"] {
 			.encounter-group-panel,
 			.encounter-terrain-panel {
 				.slot-row,
-				.terrain-row {
+				.terrain-row,
+				.customize-panel {
 					background-color: rgba(0, 0, 0);
 					color: rgba(255, 255, 255, 0.88);
 				}

--- a/src/components/panels/edit/encounter-edit/encounter-edit-panel.tsx
+++ b/src/components/panels/edit/encounter-edit/encounter-edit-panel.tsx
@@ -97,12 +97,7 @@ export const EncounterEditPanel = (props: Props) => {
 		if (encounterGroupID) {
 			const group = copy.groups.find(g => g.id === encounterGroupID);
 			if (group) {
-				const slot = group.slots.find(s => s.monsterID === monster.id);
-				if (slot) {
-					slot.count += 1;
-				} else {
-					group.slots.push(FactoryLogic.createEncounterSlot(monster.id));
-				}
+				group.slots.push(FactoryLogic.createEncounterSlot(monster.id));
 			};
 		} else {
 			const group = FactoryLogic.createEncounterGroup();

--- a/src/logic/encounter-difficulty-logic.test.ts
+++ b/src/logic/encounter-difficulty-logic.test.ts
@@ -1,0 +1,246 @@
+import { Encounter, EncounterGroup, TerrainSlot } from '@/models/encounter';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { EncounterDifficultyLogic } from './encounter-difficulty-logic';
+import { EncounterLogic } from './encounter-logic';
+import { EncounterSlot } from '@/models/encounter-slot';
+import { FeatureAddOn } from '@/models/feature';
+import { Monster } from '@/models/monster';
+import { MonsterGroup } from '@/models/monster-group';
+import { MonsterOrganizationType } from '@/enums/monster-organization-type';
+import { SourcebookLogic } from './sourcebook-logic';
+
+const mockMonster1 = {
+	id: 'test-monster1',
+	encounterValue: 3,
+	role: { organization: MonsterOrganizationType.Horde }
+} as Monster;
+
+const mockMonster2 = {
+	id: 'test-monster2',
+	encounterValue: 4,
+	role: { organization: MonsterOrganizationType.Horde }
+} as Monster;
+
+const mockMinion = {
+	id: 'test-minion1',
+	encounterValue: 3,
+	role: { organization: MonsterOrganizationType.Minion }
+} as Monster;
+
+describe('getGroupStrength', () => {
+	afterEach(() => {
+		vi.resetAllMocks();
+	});
+
+	test('correctly calculates the strength of an empty group', () => {
+		const group = {
+			slots: [] as EncounterSlot[]
+		} as EncounterGroup;
+
+		const result = EncounterDifficultyLogic.getGroupStrength(group, []);
+
+		expect(result).toBe(0);
+	});
+
+	/**
+	 * A single slot of 2 monsters with an EV of 3 per monster
+	 */
+	test('correctly calculates strength of a basic group of monsters', () => {
+		vi.spyOn(EncounterLogic, 'getCustomizedMonster').mockReturnValue(mockMonster1);
+
+		// No addOns
+		const mockGroup = {
+			addOns: [] as FeatureAddOn[]
+		} as MonsterGroup;
+		vi.spyOn(SourcebookLogic, 'getMonsterGroup').mockReturnValue(mockGroup);
+
+		const slot = {
+			monsterID: 'test-monster1',
+			count: 2
+		} as EncounterSlot;
+		const group = {
+			slots: [ slot ]
+		} as EncounterGroup;
+
+		const result = EncounterDifficultyLogic.getGroupStrength(group, []);
+
+		expect(result).toBe(6);
+	});
+
+	/**
+	 * - slot 1: 2 monsters with an EV of 3 per monster
+	 * - slot 2: 1 monster with an EV of 4 per monster
+	 */
+	test('correctly calculates strength of a group with various monsters', () => {
+		vi.spyOn(EncounterLogic, 'getCustomizedMonster')
+			.mockReturnValueOnce(mockMonster1)
+			.mockReturnValueOnce(mockMonster2);
+
+		// No addOns
+		const mockGroup = {
+			addOns: [] as FeatureAddOn[]
+		} as MonsterGroup;
+		vi.spyOn(SourcebookLogic, 'getMonsterGroup').mockReturnValue(mockGroup);
+
+		const slot1 = {
+			monsterID: 'test-monster1',
+			count: 2
+		} as EncounterSlot;
+		const slot2 = {
+			monsterID: 'test-monster2',
+			count: 1
+		} as EncounterSlot;
+		const group = {
+			slots: [ slot1, slot2 ]
+		} as EncounterGroup;
+
+		const result = EncounterDifficultyLogic.getGroupStrength(group, []);
+
+		expect(result).toBe(10);
+	});
+
+	/**
+	 * A single slot of 4 minions (1 minion group)
+	 */
+	test('correctly calculates strength of a basic group of minions', () => {
+		vi.spyOn(EncounterLogic, 'getCustomizedMonster').mockReturnValue(mockMinion);
+
+		// No addOns
+		const mockGroup = {
+			addOns: [] as FeatureAddOn[]
+		} as MonsterGroup;
+		vi.spyOn(SourcebookLogic, 'getMonsterGroup').mockReturnValue(mockGroup);
+
+		const slot = {
+			monsterID: 'test-minion1',
+			count: 1,
+			customization: { minionCountAdjustment: 0 }
+		} as EncounterSlot;
+		const group = {
+			slots: [ slot ]
+		} as EncounterGroup;
+
+		const result = EncounterDifficultyLogic.getGroupStrength(group, []);
+
+		expect(result).toBe(3);
+	});
+
+	/**
+	 * A single slot of 8 minions (1 minion group with 4 added via customization)
+	 */
+	test('correctly calculates strength of a customized group of minions', () => {
+		vi.spyOn(EncounterLogic, 'getCustomizedMonster').mockReturnValue(mockMinion);
+
+		// No addOns
+		const mockGroup = {
+			addOns: [] as FeatureAddOn[]
+		} as MonsterGroup;
+		vi.spyOn(SourcebookLogic, 'getMonsterGroup').mockReturnValue(mockGroup);
+
+		const slot = {
+			monsterID: 'test-minion1',
+			count: 1,
+			customization: { minionCountAdjustment: 4 }
+		} as EncounterSlot;
+		const group = {
+			slots: [ slot ]
+		} as EncounterGroup;
+
+		const result = EncounterDifficultyLogic.getGroupStrength(group, []);
+
+		expect(result).toBe(6);
+	});
+
+	/**
+	 * 2 slots of 6 minions each (3 minion groups across 2 slots)
+	 */
+	test('correctly calculates strength of complex group of minions', () => {
+		vi.spyOn(EncounterLogic, 'getCustomizedMonster').mockReturnValue(mockMinion);
+
+		// No addOns
+		const mockGroup = {
+			addOns: [] as FeatureAddOn[]
+		} as MonsterGroup;
+		vi.spyOn(SourcebookLogic, 'getMonsterGroup').mockReturnValue(mockGroup);
+
+		const slot = {
+			monsterID: 'test-minion1',
+			count: 1,
+			customization: { minionCountAdjustment: 2 }
+		} as EncounterSlot;
+		const group = {
+			slots: [ slot, slot ]
+		} as EncounterGroup;
+
+		const result = EncounterDifficultyLogic.getGroupStrength(group, []);
+
+		expect(result).toBe(9);
+	});
+});
+
+describe('getTerrainStrength', () => {
+	test('correctly calculates the strength of an empty terrain slot', () => {
+		const slot = {} as TerrainSlot;
+		const result = EncounterDifficultyLogic.getTerrainStrength(slot, []);
+
+		expect(result).toBe(0);
+	});
+});
+
+describe('getStrength', () => {
+	afterEach(() => {
+		vi.resetAllMocks();
+	});
+
+	test('correctly calculates the strength of an empty encounter', () => {
+		const encounter = {
+			groups: [] as EncounterGroup[],
+			terrain: [] as TerrainSlot[]
+		} as Encounter;
+		const result = EncounterDifficultyLogic.getStrength(encounter, [], 0);
+
+		expect(result).toBe(0);
+	});
+
+	test('correctly calculates the strength of a simple encounter', () => {
+		vi.spyOn(EncounterLogic, 'getCustomizedMonster').mockReturnValue(mockMonster1);
+
+		const slot = {
+			monsterID: 'test-monster1',
+			count: 1
+		} as EncounterSlot;
+		const group = {
+			slots: [ slot ]
+		} as EncounterGroup;
+		const encounter = {
+			groups: [ group ] as EncounterGroup[],
+			terrain: [] as TerrainSlot[]
+		} as Encounter;
+		const result = EncounterDifficultyLogic.getStrength(encounter, [], 0);
+
+		expect(result).toBe(3);
+	});
+
+	/**
+	 * 2 groups with 6 minions each - 3 total groups
+	 */
+	test('correctly calculates the strength of an encounter with minions split across groups', () => {
+		vi.spyOn(EncounterLogic, 'getCustomizedMonster').mockReturnValue(mockMinion);
+
+		const slot = {
+			monsterID: 'test-minion1',
+			count: 1,
+			customization: { minionCountAdjustment: 2 }
+		} as EncounterSlot;
+		const group = {
+			slots: [ slot ]
+		} as EncounterGroup;
+		const encounter = {
+			groups: [ group, group ] as EncounterGroup[],
+			terrain: [] as TerrainSlot[]
+		} as Encounter;
+		const result = EncounterDifficultyLogic.getStrength(encounter, [], 0);
+
+		expect(result).toBe(9);
+	});
+});

--- a/src/logic/encounter-difficulty-logic.ts
+++ b/src/logic/encounter-difficulty-logic.ts
@@ -3,6 +3,8 @@ import { Collections } from '@/utils/collections';
 import { EncounterDifficulty } from '@/enums/encounter-difficulty';
 import { EncounterLogic } from '@/logic/encounter-logic';
 import { Hero } from '@/models/hero';
+import { MonsterLogic } from './monster-logic';
+import { MonsterOrganizationType } from '@/enums/monster-organization-type';
 import { Options } from '@/models/options';
 import { OptionsLogic } from './options-logic';
 import { Sourcebook } from '@/models/sourcebook';
@@ -17,19 +19,27 @@ export class EncounterDifficultyLogic {
 
 		const monsters = Collections.sum(groups, g => EncounterDifficultyLogic.getGroupStrength(g, sourcebooks));
 		const terrain = Collections.sum(encounter.terrain, t => EncounterDifficultyLogic.getTerrainStrength(t, sourcebooks));
-		return monsters + terrain;
+		return Math.floor(monsters + terrain);
 	};
 
 	static getGroupStrength = (group: EncounterGroup, sourcebooks: Sourcebook[]) => {
 		return Collections.sum(group.slots, slot => {
 			const monster = EncounterLogic.getCustomizedMonster(slot.monsterID, slot.customization, sourcebooks);
 
-			const group = SourcebookLogic.getMonsterGroup(sourcebooks, slot.monsterID);
-			const addOns = group ? group.addOns.filter(a => slot.customization.addOnIDs.includes(a.id)) : [];
-			const addOnPoints = Collections.sum(addOns, a => a.data.cost);
-			const addOnCost = addOnPoints > 4 ? (addOnPoints - 4) * 2 : 0;
+			if (monster) {
+				const group = SourcebookLogic.getMonsterGroup(sourcebooks, slot.monsterID);
+				const addOns = group ? group.addOns.filter(a => slot.customization.addOnIDs.includes(a.id)) : [];
+				const addOnPoints = Collections.sum(addOns, a => a.data.cost);
+				const addOnCost = addOnPoints > 4 ? (addOnPoints - 4) * 2 : 0;
 
-			return monster ? (monster.encounterValue + addOnCost) * slot.count : 0;
+				let count = slot.count;
+				if (monster.role.organization === MonsterOrganizationType.Minion) {
+					count += slot.customization.minionCountAdjustment / MonsterLogic.getRoleMultiplier(monster.role.organization);
+				}
+
+				return (monster.encounterValue + addOnCost) * count;
+			}
+			return 0;
 		});
 	};
 

--- a/src/logic/playbook-sheets/encounter-sheet-builder.ts
+++ b/src/logic/playbook-sheets/encounter-sheet-builder.ts
@@ -112,10 +112,13 @@ export class EncounterSheetBuilder {
 			}
 		});
 
+		const groupEv = EncounterDifficultyLogic.getGroupStrength(group, sourcebooks);
+
 		const sheet: EncounterGroupSheet = {
 			id: group.id,
 			name: group.name,
-			slots: adjustedSlots
+			slots: adjustedSlots,
+			groupEv: groupEv
 		};
 
 		return sheet;
@@ -134,6 +137,10 @@ export class EncounterSheetBuilder {
 			isMinion: monster.role.organization === MonsterOrganizationType.Minion,
 			count: roleMult * slot.count
 		};
+
+		if (sheet.isMinion) {
+			sheet.count += slot.customization.minionCountAdjustment;
+		}
 
 		return sheet;
 	};

--- a/src/models/classic-sheets/encounter-sheet.ts
+++ b/src/models/classic-sheets/encounter-sheet.ts
@@ -34,6 +34,7 @@ export interface EncounterGroupSheet {
 	id: string;
 	name: string;
 	slots: EncounterSlotSheet[];
+	groupEv: number;
 }
 
 export interface EncounterSlotSheet {


### PR DESCRIPTION
# Overview
- Adds the ability to have the same *kind* of monster in multiple slots within the same group.  (Resolves #710 )
- Fixes the EV calculation when there is minion count customization
- Fixes the classic Encounter sheet to account for minion count customization
- Adds an `.npmrc` file with a couple settings that should help minimize the risk of npm supply chain attacks
