### PR TITLE
[#830] EncounterSheet properly display terrain objects in encounters

### DIFF
--- a/src/assets/icons/activation.svg
+++ b/src/assets/icons/activation.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="-10 0 1012 1000">
+   <path fill="currentColor"
+d="M499 879c-53 0 -96 -43 -96 -97c0 -53 43 -96 96 -96s96 43 96 96c0 54 -43 97 -96 97zM566 565c0 16 -14 29 -30 29h-77c-16 0 -29 -13 -29 -29l-24 -403c0 -16 13 -29 29 -29h125c16 0 29 13 29 29zM50 853c0 51 45 97 96 97h701c51 0 95 -46 95 -98v-701
+c0 -51 -45 -95 -96 -95h-701c-51 0 -95 45 -95 96v701zM0 892v-779c0 -57 49 -107 106 -107h779c57 0 107 49 107 106v779c0 57 -49 109 -106 109h-779c-57 0 -107 -51 -107 -108z" />
+</svg>

--- a/src/components/pages/classic-sheet/common.scss
+++ b/src/components/pages/classic-sheet/common.scss
@@ -36,7 +36,11 @@ main#classic-sheet {
         display: none;
     }
 
-    .hero-sheet, .encounter-sheet, .montage-sheet, .negotiation-sheet {
+    .hero-sheet,
+    .encounter-sheet,
+    .montage-sheet,
+    .negotiation-sheet,
+    .library-item-sheet {
         height: 100%;
         font-size: 14px;
         padding: 5px;
@@ -226,6 +230,30 @@ main#classic-sheet {
             li>em {
                 font-weight: 400;
                 font-size: round(1.1rem, 1px);
+            }
+        }
+
+        .feature-description {
+            ul {
+                list-style: none;
+                margin: 0;
+                padding: 0;
+
+                li:has(img) {
+                    margin-bottom: 2px;
+                    text-indent: 54px hanging;
+
+                    strong {
+                        margin: 0;
+                    }
+
+                    img {
+                        width: 50px;
+                        height: 26px;
+                        margin-top: -1px;
+                        margin-bottom: -9px;
+                    }
+                }
             }
         }
 

--- a/src/components/pages/library/library-list/library-list-page.tsx
+++ b/src/components/pages/library/library-list/library-list-page.tsx
@@ -37,6 +37,7 @@ import { Item } from '@/models/item';
 import { ItemPanel } from '@/components/panels/elements/item-panel/item-panel';
 import { Kit } from '@/models/kit';
 import { KitPanel } from '@/components/panels/elements/kit-panel/kit-panel';
+import { LibraryItemSheetPage } from '@/components/panels/classic-sheet/library-item-sheet/library-item-sheet-page';
 import { LibraryLogic } from '@/logic/library-logic';
 import { Monster } from '@/models/monster';
 import { MonsterFilter } from '@/models/filter';
@@ -235,6 +236,15 @@ export const LibraryListPage = (props: Props) => {
 							<div style={{ padding: '20px', overflow: 'auto' }}>
 								<NegotiationSheetPage
 									negotiation={element as Negotiation}
+								/>
+							</div>
+						);
+					case 'terrain':
+						return (
+							<div style={{ padding: '20px', overflow: 'auto' }}>
+								<LibraryItemSheetPage
+									category={category}
+									terrain={element as Terrain}
 								/>
 							</div>
 						);
@@ -634,6 +644,7 @@ export const LibraryListPage = (props: Props) => {
 				case 'encounter':
 				case 'montage':
 				case 'negotiation':
+				case 'terrain':
 					canExportAsImage = false;
 					canExportAsPDF = true;
 					break;
@@ -797,6 +808,7 @@ export const LibraryListPage = (props: Props) => {
 			case 'encounter':
 			case 'montage':
 			case 'negotiation':
+			case 'terrain':
 				return (
 					<ViewSelector
 						mode='classic'

--- a/src/components/panels/classic-sheet/components/ability-component.scss
+++ b/src/components/panels/classic-sheet/components/ability-component.scss
@@ -91,20 +91,26 @@
     p.trigger,
     .effect p {
         font-size: 15px;
-
         margin-left: 0;
         margin-right: 0;
-        margin-top: 7px;
-
-        &:last-of-type {
-            margin-bottom: 0;
-        }
 
         .potency {
             @include common.font-glyphs();
             display: inline-block;
             font-size: round(1.2rem, 1px);
         }
+    }
+
+    .effect p {
+        margin-top: 7px;
+
+        &:last-of-type {
+            margin-bottom: 0;
+        }
+    }
+
+    p.trigger {
+        margin-bottom: 7px;
     }
 
     .effect {

--- a/src/components/panels/classic-sheet/components/ability-component.tsx
+++ b/src/components/panels/classic-sheet/components/ability-component.tsx
@@ -117,8 +117,8 @@ export const AbilityComponent = (props: Props) => {
 					</div>
 				</div>
 			</div>
-			{getPowerRollSection()}
 			{getTriggerSection()}
+			{getPowerRollSection()}
 			{getEffectSection()}
 		</div>
 	);

--- a/src/components/panels/classic-sheet/encounter-roster/encounter-roster.tsx
+++ b/src/components/panels/classic-sheet/encounter-roster/encounter-roster.tsx
@@ -3,7 +3,6 @@ import { FormatLogic } from '@/logic/format-logic';
 import { MonsterLogic } from '@/logic/monster-logic';
 import { MonsterOrganizationType } from '@/enums/monster-organization-type';
 import { Sourcebook } from '@/models/sourcebook';
-import { TerrainLogic } from '@/logic/terrain-logic';
 import { useMemo } from 'react';
 
 import './encounter-roster.scss';
@@ -139,18 +138,21 @@ export const EncounterRosterCard = (props: Props) => {
 							: null
 
 					}
-					{encounter.terrain?.map(terrain => {
+					{encounter.terrainSlots?.map((slot, i) => {
+						const terrain = slot.terrain;
+						const name = slot.count > 1 ? `${terrain.name} (${slot.count})` : terrain.name;
+						const stamina = Array(slot.count).fill(terrain.stamina).join(', ');
 						return (
-							<tr className='terrain-object' key={`roster-terrain-${terrain.id}`}>
+							<tr className='terrain-object' key={`roster-terrain-${slot.id}-${i}`}>
 								<td colSpan={2}>
 									<div className='wrapper'>
-										<div className='encounter-slot'>{terrain.name}</div>
-										<div className='ev'>EV:<span className='ev-value'>{terrain.encounterValue}</span></div>
+										<div className='encounter-slot'>{name}</div>
+										<div className='ev'>EV:<span className='ev-value'>{slot.slotEv}</span></div>
 									</div>
 								</td>
 								<td className='stamina-tracker' colSpan={2}>
 									<div className='wrapper'>
-										<div className='encounter-slot'>{TerrainLogic.getStaminaValue(terrain)}</div>
+										<div className='encounter-slot'>{stamina}</div>
 									</div>
 								</td>
 								<td></td>

--- a/src/components/panels/classic-sheet/encounter-sheet/encounter-sheet-page.tsx
+++ b/src/components/panels/classic-sheet/encounter-sheet/encounter-sheet-page.tsx
@@ -10,6 +10,7 @@ import { MonsterCard } from '@/components/panels/classic-sheet/monster-card/mons
 import { NotesCard } from '@/components/panels/classic-sheet/notes-card/notes-card';
 import { SheetFormatter } from '@/logic/classic-sheet/sheet-formatter';
 import { Sourcebook } from '@/models/sourcebook';
+import { TerrainCard } from '../monster-card/terrain-card.tsx';
 import { useMemo } from 'react';
 
 import './encounter-sheet-page.scss';
@@ -68,6 +69,27 @@ export const EncounterSheetPage = (props: Props) => {
 					element: <MonsterCard monster={ms} columns={mW} key={ms.id} />,
 					width: mW,
 					height: mH,
+					shown: false
+				});
+			});
+		}
+
+		if (encounter.terrain?.length) {
+			encounter.terrain?.forEach(t => {
+				let tH = SheetFormatter.calculateTerrainSize(t, layout.cardLineLen);
+				let tW = 1;
+				if (tH > layout.linesY) {
+					tW = 2;
+					tH = SheetFormatter.calculateTerrainSize(t, layout.cardLineLen, 2);
+					if (tH > layout.linesY) {
+						console.warn('Card still larger than a full page!', t.name, tH);
+						tH = layout.linesY;
+					}
+				}
+				requiredCards.push({
+					element: <TerrainCard terrain={t} columns={tW} key={t.id} />,
+					width: tW,
+					height: tH,
 					shown: false
 				});
 			});

--- a/src/components/panels/classic-sheet/library-item-sheet/library-item-sheet-page.scss
+++ b/src/components/panels/classic-sheet/library-item-sheet/library-item-sheet-page.scss
@@ -1,0 +1,8 @@
+@use '../../../pages/classic-sheet/common.scss';
+
+main#classic-sheet .library-item-sheet {
+    .page {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+    }
+}

--- a/src/components/panels/classic-sheet/library-item-sheet/library-item-sheet-page.tsx
+++ b/src/components/panels/classic-sheet/library-item-sheet/library-item-sheet-page.tsx
@@ -1,0 +1,47 @@
+import { ClassicSheetBuilder } from '@/logic/classic-sheet/classic-sheet-builder';
+import { SheetFormatter } from '@/logic/classic-sheet/sheet-formatter';
+import { Terrain } from '@/models/terrain';
+import { TerrainCard } from '../monster-card/terrain-card';
+import { useMemo } from 'react';
+import { useOptions } from '@/contexts/data-context';
+
+import './library-item-sheet-page.scss';
+
+interface Props {
+	category: string;
+	terrain: Terrain;
+}
+
+export const LibraryItemSheetPage = (props: Props) => {
+	const terrain = useMemo(
+		() => ClassicSheetBuilder.buildTerrainSheet(props.terrain),
+		[ props.terrain ]
+	);
+
+	const options = useOptions();
+
+	const sheetClasses = useMemo(
+		() => {
+			const classes = [
+				'library-item-sheet',
+				options.classicSheetPageSize.toLowerCase()
+			];
+			if (options.colorSheet) {
+				classes.push('color');
+				classes.push(`colors-${options.colorScheme}`);
+			}
+			return classes;
+		},
+		[ options.classicSheetPageSize, options.colorSheet, options.colorScheme ]
+	);
+
+	return (
+		<main id='classic-sheet'>
+			<div className={sheetClasses.join(' ')}>
+				<div className={`page page-1 ${options.pageOrientation}`} id={SheetFormatter.getPageId('terrain', terrain.id)}>
+					<TerrainCard terrain={terrain} />
+				</div>
+			</div>
+		</main>
+	);
+};

--- a/src/components/panels/classic-sheet/monster-card/monster-card.scss
+++ b/src/components/panels/classic-sheet/monster-card/monster-card.scss
@@ -47,7 +47,9 @@
 
 
 main#classic-sheet .encounter-sheet .monster,
-main#classic-sheet .hero-sheet .monster {
+main#classic-sheet .hero-sheet .monster,
+main#classic-sheet .encounter-sheet .terrain.card,
+main#classic-sheet .library-item-sheet .terrain.card {
     padding: 10px;
     display: grid;
     justify-self: stretch;
@@ -124,6 +126,7 @@ main#classic-sheet .hero-sheet .monster {
         }
 
         .cost {
+            grid-column-start: 2;
             text-transform: none;
             text-wrap: nowrap;
             font-size: 14px;
@@ -304,7 +307,39 @@ main#classic-sheet .hero-sheet .monster {
     }
 }
 
-main#classic-sheet .color .monster.card {
+main#classic-sheet .library-item-sheet .terrain.card,
+main#classic-sheet .encounter-sheet .terrain.card {
+    
+    .details {
+        @include common.divider-plain(common.$color-medium, 1px);
+
+        .description {
+            text-align: center;
+            font-size: round(1.1rem, 1px);
+        }
+        
+        .stats {
+            grid-template-rows: 1fr;
+            grid-template-columns: 1fr;
+            padding-bottom: 4px;
+
+            .line {
+                display: flex;
+                flex-flow: row wrap;
+                justify-content: space-between;
+            }
+
+            .size,
+            .immunity {
+                text-align: right;
+                text-wrap: nowrap;
+            }
+        }
+    }
+}
+
+main#classic-sheet .color .monster.card,
+main#classic-sheet .color .terrain.card {
     &.ambusher {
         section.bordered .name-wrapper {
             @include monster-header-gradient(common.$color-ambusher);

--- a/src/components/panels/classic-sheet/monster-card/terrain-card.tsx
+++ b/src/components/panels/classic-sheet/monster-card/terrain-card.tsx
@@ -1,0 +1,163 @@
+import { AbilityComponent } from '../components/ability-component';
+import { AbilitySheet } from '@/models/classic-sheets/ability-sheet';
+import { FeatureComponent } from '../components/feature-component';
+import { FeatureText } from '@/models/feature';
+import { SheetFormatter } from '@/logic/classic-sheet/sheet-formatter';
+import { TerrainSheet } from '@/models/classic-sheets/terrain-sheet';
+import { useMemo } from 'react';
+
+import './monster-card.scss';
+
+import activateIcon from '@/assets/icons/activation.svg';
+import specialAreaIcon from '@/assets/icons/special-area.svg';
+import starIcon from '@/assets/icons/star.svg';
+import triggerIcon from '@/assets/icons/trigger-solid.svg';
+
+interface Props {
+	terrain: TerrainSheet;
+	columns?: number;
+}
+
+export const TerrainCard = (props: Props) => {
+	const terrain = useMemo(() => props.terrain, [ props.terrain ]);
+	const columns = props.columns ?? 1;
+
+	const getDetails = () => {
+		return (
+			<div className='details'>
+				<p className='description'>
+					{terrain.details}
+				</p>
+				<div className='stats'>
+					<div className='line'>
+						<div className='stat stamina'>
+							<label>Stamina:</label>
+							<span>{terrain.stamina}</span>
+						</div>
+						<div className='stat size'>
+							<label>Size:</label>
+							<span>{terrain.size}</span>
+						</div>
+					</div>
+					{
+						terrain.typicalSpace ?
+							<div className='stat typical-space'>
+								<label>Typical Space:</label>
+								<span>{terrain.typicalSpace}</span>
+							</div>
+							: null
+					}
+					{
+						terrain.direction ?
+							<div className='stat direction'>
+								<label>Direction:</label>
+								<span>{terrain.direction}</span>
+							</div>
+							: null
+					}
+					{
+						terrain.link ?
+							<div className='stat link'>
+								<label>Link:</label>
+								<span>{terrain.link}</span>
+							</div>
+							: null
+					}
+					{
+						terrain.immunity?.length ?? 0 > 0 ?
+							<div className='stat immunity'>
+								<label>Immunity:</label>
+								<span>{terrain.immunity}</span>
+							</div>
+							: null
+					}
+					{
+						terrain.weakness?.length ?? 0 > 0 ?
+							<div className='stat weakness'>
+								<label>Weakness:</label>
+								<span>{terrain.weakness}</span>
+							</div>
+							: null
+					}
+				</div>
+			</div>
+		);
+	};
+
+	const getSections = () => {
+		return (
+			<>
+				{terrain.sections?.map(section => {
+					if (Object.hasOwn(section, 'type')) {
+						return (
+							<div className='wrapper' key={section.id}>
+								{getSectionIcon(section.id)}
+								<FeatureComponent
+									feature={SheetFormatter.enhanceFeature(section as FeatureText)}
+								/>
+							</div>
+						);
+					} else {
+						return (
+							<div className='wrapper' key={section.id}>
+								{getAbilityIcon()}
+								<AbilityComponent
+									ability={section as AbilitySheet}
+								/>
+							</div>
+						);
+					}
+				})}
+			</>
+		);
+	};
+
+	const getSectionIcon = (id: string) => {
+		let icon = starIcon;
+		let alt = 'Feature';
+		switch (id) {
+			case 'deactivate':
+				icon = specialAreaIcon;
+				alt = 'Deactivate icon';
+				break;
+			case 'activate':
+			case 'activate-effect':
+				icon = activateIcon;
+				alt = 'Activate icon';
+				break;
+		}
+		return (
+			<img src={icon} alt={alt} className='icon' />
+		);
+	};
+
+	const getAbilityIcon = () => {
+		const icon = triggerIcon;
+		const alt = 'Ability';
+		return (
+			<img src={icon} alt={alt} className='icon' />
+		);
+	};
+
+	const cardClasses = [ 'terrain', 'card' ];
+	if (columns > 1) {
+		cardClasses.push('wide');
+	}
+	cardClasses.push(terrain.role.toLocaleLowerCase().split(' ').join('-'));
+
+	return (
+		<div className={cardClasses.join(' ')}>
+			<section className='bordered'>
+				<div className='name-wrapper'>
+					<h2>
+						<span className='name'>{terrain.name}</span>
+						<span className='type'>{terrain.description}</span>
+						<span className='cost'>EV {terrain.encounterValue}</span>
+					</h2>
+				</div>
+				{getDetails()}
+				{getSections()}
+			</section>
+		</div>
+	);
+};

--- a/src/data/terrain/environmental-hazards.ts
+++ b/src/data/terrain/environmental-hazards.ts
@@ -12,9 +12,10 @@ export const angryBeehive: Terrain = {
 	description: 'This beehive is full of angry bees who swarm and attack with little provocation.',
 	category: TerrainCategory.Environmental,
 	level: 2,
-	role: FactoryLogic.createTerrainRole(MonsterRoleType.Harrier, TerrainRoleType.Hazard),
+	role: FactoryLogic.createTerrainRole(MonsterRoleType.Hexer, TerrainRoleType.Hazard),
 	encounterValue: 2,
 	area: '',
+	typicalSpace: '',
 	direction: '',
 	link: '',
 	stamina: {
@@ -48,7 +49,7 @@ export const angryBeehive: Terrain = {
 	upgrades: [
 		{
 			id: 'concealed-beehive',
-			label: 'Concealed Beehive',
+			label: 'Concealed Hive',
 			cost: 1,
 			text: 'The hive is hidden until the swarm is unleashed.',
 			sections: []
@@ -76,6 +77,7 @@ export const brambles: Terrain = {
 	role: FactoryLogic.createTerrainRole(MonsterRoleType.Defender, TerrainRoleType.Fortification),
 	encounterValue: 1,
 	area: '10 x 10 thicket',
+	typicalSpace: '',
 	direction: '',
 	link: '',
 	stamina: {
@@ -130,6 +132,7 @@ export const corrosivePool: Terrain = {
 	role: FactoryLogic.createTerrainRole(MonsterRoleType.Hexer, TerrainRoleType.Hazard),
 	encounterValue: 3,
 	area: '10 x 10 pool',
+	typicalSpace: '',
 	direction: '',
 	link: '',
 	stamina: {
@@ -160,7 +163,7 @@ export const corrosivePool: Terrain = {
 				FactoryLogic.feature.create({
 					id: 'activate',
 					name: 'Activate',
-					description: 'A creature or object enters the corrosive pool or starts their turn there. The liquid in the pool is also highly volatile (see Explosive Reaction below).'
+					description: 'A creature or object enters the corrosive pool or starts their turn there. The liquid in the pool is also highly volatile (see **Explosive Reaction** below).'
 				}),
 				FactoryLogic.feature.create({
 					id: 'effect',
@@ -212,6 +215,7 @@ export const frozenPond: Terrain = {
 	role: FactoryLogic.createTerrainRole(MonsterRoleType.Hexer, TerrainRoleType.Hazard),
 	encounterValue: 1,
 	area: '10 x 10 pond',
+	typicalSpace: '',
 	direction: '',
 	link: '',
 	stamina: {
@@ -300,7 +304,7 @@ export const frozenPond: Terrain = {
 			label: 'Thin Ice',
 			cost: 1,
 			text: `
-The ice covering the pond is thin and the water is deeper. Whenever a creature or object enters or falls prone in a square of the frozen pond, that square is destroyed and replaced with icy water. The Icy Water ability replaces Slippery Surface.
+The ice covering the pond is thin and the water is deeper. Whenever a creature or object enters or falls prone in a square of the frozen pond, that square is destroyed and replaced with icy water. The **Icy Water** ability replaces **Slippery Surface**.
 
 Any creature who starts their turn in the icy water takes 1 cold damage. If the water is deep enough, a creature can swim beneath the surface of the frozen pond, but takes this cold damage while doing so.`,
 			sections: []
@@ -321,6 +325,7 @@ export const lava: Terrain = {
 	role: FactoryLogic.createTerrainRole(MonsterRoleType.Hexer, TerrainRoleType.Hazard),
 	encounterValue: 4,
 	area: '10 x 10 patch',
+	typicalSpace: '',
 	direction: '',
 	link: '',
 	stamina: {
@@ -406,6 +411,7 @@ export const quicksand: Terrain = {
 	role: FactoryLogic.createTerrainRole(MonsterRoleType.Hexer, TerrainRoleType.Hazard),
 	encounterValue: 3,
 	area: '10 x 10 patch',
+	typicalSpace: '',
 	direction: '',
 	link: '',
 	stamina: {
@@ -478,6 +484,7 @@ export const toxicPlants: Terrain = {
 	role: FactoryLogic.createTerrainRole(MonsterRoleType.Hexer, TerrainRoleType.Hazard),
 	encounterValue: 2,
 	area: '10 x 10 field',
+	typicalSpace: '',
 	direction: '',
 	link: '',
 	stamina: {

--- a/src/data/terrain/fieldworks.ts
+++ b/src/data/terrain/fieldworks.ts
@@ -16,8 +16,9 @@ export const archersStakes: Terrain = {
 		MonsterRoleType.Defender,
 		TerrainRoleType.Fortification
 	),
-	encounterValue: 1,
-	area: '4 x 1-square area',
+	encounterValue: 2,
+	area: '',
+	typicalSpace: '4 x 1-square area',
 	direction: 'One side of the stakes is defined as the front.',
 	link: '',
 	stamina: {
@@ -77,7 +78,7 @@ export const archersStakes: Terrain = {
 			id: 'sticky',
 			label: 'Sticky',
 			cost: 3,
-			text: 'A sticky slime or webbing has been applied to the stakes and the ground between them. Any creature who enters an area or stakes triggers the *Sticky Stakes* ability in addtion to suffering the stake\'s other effects.',
+			text: 'A sticky slime or webbing has been applied to the stakes and the ground between them. Any creature who enters an area or stakes triggers the **Sticky Stakes** ability in addtion to suffering the stake\'s other effects.',
 			sections: [
 				{
 					id: 'sticky',
@@ -133,6 +134,7 @@ export const bearTrap: Terrain = {
 	),
 	encounterValue: 2,
 	area: '',
+	typicalSpace: '',
 	direction: '',
 	link: '',
 	stamina: {
@@ -148,7 +150,7 @@ export const bearTrap: Terrain = {
 				FactoryLogic.feature.create({
 					id: 'deactivate',
 					name: 'Deactivate',
-					description: `As a maneuver, a creature adjacent to a bear trap can make an *Agility test.*
+					description: `As a maneuver, a creature adjacent to a bear trap can make an **Agility test.**
 
 * **11 or lower**: The creature triggers the trap and is affected as if in its space.
 * **12-16**: The trap is deactivated but the creature is slowed (EoT).
@@ -169,7 +171,7 @@ export const bearTrap: Terrain = {
 					id: 'effect',
 					name: 'Effect',
 					description:
-            'A triggering creature or object ends their movement and is targeted by the *Bear Trap* ability.'
+            'A triggering creature or object ends their movement and is targeted by the **Bear Trap** ability.'
 				}),
 				FactoryLogic.feature.createAbility({
 					ability: FactoryLogic.createAbility({
@@ -241,7 +243,8 @@ export const flammableOil: Terrain = {
 		TerrainRoleType.Trap
 	),
 	encounterValue: 2,
-	area: '10x10',
+	area: '10 x 10 patch',
+	typicalSpace: '',
 	direction: '',
 	link: '',
 	stamina: {
@@ -261,7 +264,7 @@ export const flammableOil: Terrain = {
 
 * **11 or lower**: The creature ignites the oil and is affected as if in its area.
 * **12-16**: The oil temporarily ignites before safely burning out, and the creature takes 3 fire damage and is burning (save ends).
-* * **17+**: The oil is rendered safe and can’t be ignited.`
+* **17+**: The oil is rendered safe and can’t be ignited.`
 				})
 			]
 		},
@@ -322,6 +325,7 @@ export const hideyHole: Terrain = {
 	),
 	encounterValue: 1,
 	area: '',
+	typicalSpace: '',
 	direction: '',
 	link: '',
 	stamina: {
@@ -341,7 +345,7 @@ export const hideyHole: Terrain = {
 
 * **11 or lower**: The creature is restrained (save ends).
 * **12-16**: The hidey-hole collapses but the creature is slowed (save ends).
-* * **17+**: The hidey-hole collapses and can no longer be used until repaired.`
+* **17+**: The hidey-hole collapses and can no longer be used until repaired.`
 				})
 			]
 		},
@@ -368,7 +372,7 @@ export const hideyHole: Terrain = {
 			id: 'network',
 			label: 'Network',
 			cost: 1,
-			text: 'The hidey-hole is connected to a tunnel network. A creature familiar with the network can move from one hidey-hole to any space adjacent to a connected hidey-hole if they have movement available equal to the straight-line distance to that space. A creature unfamiliar with the network can use a maneuver to make a hard *Intuition test* to discover a connected hidey-hole.',
+			text: 'The hidey-hole is connected to a tunnel network. A creature familiar with the network can move from one hidey-hole to any space adjacent to a connected hidey-hole if they have movement available equal to the straight-line distance to that space. A creature unfamiliar with the network can use a maneuver to make a **hard Intuition test** to discover a connected hidey-hole.',
 			sections: []
 		}
 	],
@@ -391,6 +395,7 @@ export const paviseShield: Terrain = {
 	),
 	encounterValue: 1,
 	area: '',
+	typicalSpace: '',
 	direction: '',
 	link: '',
 	stamina: {
@@ -408,9 +413,9 @@ export const paviseShield: Terrain = {
 					name: 'Deactivate',
 					description: `As a maneuver, a creature adjacent to a pavise shield controlled by another creature can make a **Might test**.
 			
-* **11 or lower:** The creature controlling the shield retains control of it and can make an opportunity attack against the creature making the test.
+* **11 or lower**: The creature controlling the shield retains control of it and can make an opportunity attack against the creature making the test.
 * **12-16**: The creature controlling the shield retains control of it.
-* *17+*: The creature making the test grabs the shield and takes control of it.`
+* **17+*: The creature making the test grabs the shield and takes control of it.`
 				})
 			]
 		},
@@ -452,6 +457,7 @@ export const snareTrap: Terrain = {
 	),
 	encounterValue: 1,
 	area: '',
+	typicalSpace: '',
 	direction: '',
 	link: '',
 	stamina: {
@@ -565,7 +571,8 @@ export const spikeTrap: Terrain = {
 		TerrainRoleType.Trap
 	),
 	encounterValue: 3,
-	area: '2 x 2-square area',
+	area: '',
+	typicalSpace: '2 x 2-square area',
 	direction: '',
 	link: '',
 	stamina: {

--- a/src/data/terrain/mechanisms.ts
+++ b/src/data/terrain/mechanisms.ts
@@ -19,6 +19,7 @@ export const columnOfBlades: Terrain = {
 	),
 	encounterValue: 3,
 	area: '',
+	typicalSpace: '',
 	direction: '',
 	link: '',
 	stamina: {
@@ -177,6 +178,7 @@ export const dartTrap: Terrain = {
 	),
 	encounterValue: 1,
 	area: '',
+	typicalSpace: '',
 	link: '',
 	stamina: {
 		base: 3,
@@ -296,6 +298,7 @@ export const pillar: Terrain = {
 	),
 	encounterValue: 3,
 	area: '',
+	typicalSpace: '',
 	direction: 'The pillar topples in a preset direction.',
 	link: '',
 	stamina: {
@@ -399,7 +402,8 @@ export const hiddenPortcullis: Terrain = {
 		TerrainRoleType.Trap
 	),
 	encounterValue: 4,
-	area: '2 × 1-square area, up to a 4 × 2-square area',
+	area: '',
+	typicalSpace: '2 × 1-square area, up to a 4 × 2-square area',
 	direction: '',
 	link: '',
 	stamina: {
@@ -499,7 +503,8 @@ export const pressurePlate: Terrain = {
 		TerrainRoleType.Trigger
 	),
 	encounterValue: 2,
-	area: 'One square, up to a 4 × 4-square area',
+	area: '',
+	typicalSpace: 'One square, up to a 4 × 4-square area',
 	direction: '',
 	stamina: {
 		base: 0,
@@ -585,6 +590,7 @@ export const pulley: Terrain = {
 	),
 	encounterValue: 1,
 	area: '',
+	typicalSpace: '',
 	direction: '',
 	link: '',
 	stamina: {
@@ -664,7 +670,8 @@ export const ram: Terrain = {
 		TerrainRoleType.Trap
 	),
 	encounterValue: 3,
-	area: '1 × 3-square area or a 2 × 2-square area',
+	area: '',
+	typicalSpace: '1 × 3-square area or a 2 × 2-square area',
 	link: '',
 	stamina: {
 		base: 0,
@@ -801,6 +808,7 @@ export const switchTerrain: Terrain = {
 	),
 	encounterValue: 1,
 	area: '',
+	typicalSpace: '',
 	direction: '',
 	stamina: {
 		base: 3,

--- a/src/data/terrain/power-fixtures.ts
+++ b/src/data/terrain/power-fixtures.ts
@@ -17,6 +17,7 @@ export const holyIdol: Terrain = {
 	),
 	encounterValue: 7,
 	area: '',
+	typicalSpace: '',
 	direction: '',
 	link: '',
 	stamina: {
@@ -66,6 +67,7 @@ export const psionicShard: Terrain = {
 	),
 	encounterValue: 7,
 	area: '',
+	typicalSpace: '',
 	direction: '',
 	link: '',
 	stamina: {
@@ -120,6 +122,7 @@ export const treeOfMight: Terrain = {
 	),
 	encounterValue: 14,
 	area: '',
+	typicalSpace: '',
 	direction: '',
 	link: '',
 	stamina: {

--- a/src/data/terrain/siege-engines.ts
+++ b/src/data/terrain/siege-engines.ts
@@ -15,6 +15,7 @@ export const arrowLauncher: Terrain = {
 	role: FactoryLogic.createTerrainRole(MonsterRoleType.Artillery, TerrainRoleType.SiegeEngine),
 	encounterValue: 8,
 	area: '',
+	typicalSpace: '',
 	direction: '',
 	link: '',
 	stamina: {
@@ -169,6 +170,7 @@ export const boilingOilCauldron: Terrain = {
 	role: FactoryLogic.createTerrainRole(MonsterRoleType.Defender, TerrainRoleType.Fortification),
 	encounterValue: 10,
 	area: '',
+	typicalSpace: '',
 	direction: '',
 	link: '',
 	stamina: {
@@ -251,6 +253,7 @@ export const catapult: Terrain = {
 	role: FactoryLogic.createTerrainRole(MonsterRoleType.Artillery, TerrainRoleType.SiegeEngine),
 	encounterValue: 10,
 	area: '',
+	typicalSpace: '',
 	direction: '',
 	link: '',
 	stamina: {
@@ -378,6 +381,7 @@ export const explodingMillWheel: Terrain = {
 	role: FactoryLogic.createTerrainRole(MonsterRoleType.Artillery, TerrainRoleType.SiegeEngine),
 	encounterValue: 10,
 	area: '',
+	typicalSpace: '',
 	direction: '',
 	link: '',
 	stamina: {
@@ -469,6 +473,7 @@ export const fieldBallista: Terrain = {
 	role: FactoryLogic.createTerrainRole(MonsterRoleType.Artillery, TerrainRoleType.SiegeEngine),
 	encounterValue: 8,
 	area: '',
+	typicalSpace: '',
 	direction: '',
 	link: '',
 	stamina: {
@@ -648,6 +653,7 @@ export const ironDragon: Terrain = {
 	role: FactoryLogic.createTerrainRole(MonsterRoleType.Artillery, TerrainRoleType.SiegeEngine),
 	encounterValue: 12,
 	area: '',
+	typicalSpace: '',
 	direction: '',
 	link: '',
 	stamina: {
@@ -760,6 +766,7 @@ export const watchtower: Terrain = {
 	role: FactoryLogic.createTerrainRole(MonsterRoleType.Defender, TerrainRoleType.Fortification),
 	encounterValue: 8,
 	area: '',
+	typicalSpace: '',
 	direction: '',
 	link: '',
 	stamina: {

--- a/src/data/terrain/supernatural-objects.ts
+++ b/src/data/terrain/supernatural-objects.ts
@@ -16,6 +16,7 @@ export const theBlackObelisk: Terrain = {
 	role: FactoryLogic.createTerrainRole(MonsterRoleType.Controller, TerrainRoleType.Relic),
 	encounterValue: 20,
 	area: '',
+	typicalSpace: '',
 	direction: '',
 	link: '',
 	stamina: {
@@ -95,6 +96,7 @@ export const theChronalHypercube: Terrain = {
 	role: FactoryLogic.createTerrainRole(MonsterRoleType.Controller, TerrainRoleType.Relic),
 	encounterValue: 20,
 	area: '',
+	typicalSpace: '',
 	direction: '',
 	link: '',
 	stamina: {
@@ -153,6 +155,7 @@ export const theThroneOfAAn: Terrain = {
 	role: FactoryLogic.createTerrainRole(MonsterRoleType.Controller, TerrainRoleType.Relic),
 	encounterValue: 24,
 	area: '',
+	typicalSpace: '',
 	direction: '',
 	link: '',
 	stamina: {

--- a/src/logic/classic-sheet/classic-sheet-builder.test.ts
+++ b/src/logic/classic-sheet/classic-sheet-builder.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
+import { angryBeehive, corrosivePool, frozenPond } from '@/data/terrain/environmental-hazards';
 import { Ability } from '@/models/ability';
 import { AbilityData } from '@/data/ability-data';
 import { AbilityLogic } from '@/logic/ability-logic';
@@ -176,5 +177,95 @@ describe('buildMonsterSheet', () => {
 	])('sets type correctly', (monster, expectedType) => {
 		const result = ClassicSheetBuilder.buildMonsterSheet(monster);
 		expect(result.type).toBe(expectedType);
+	});
+});
+
+describe('buildTerrainSheet', () => {
+	test.each([
+		[ frozenPond, '5 to all damage except fire damage' ],
+		[ corrosivePool, '20 to all damage except cold or fire damage' ],
+		[ angryBeehive, '' ]
+	])('pulls Immunity from sections correctly', (terrain, expectedImmunity) => {
+		const result = ClassicSheetBuilder.buildTerrainSheet(terrain);
+		expect(result.immunity).toBe(expectedImmunity);
+	});
+
+	test.each([
+		[ frozenPond, 'The **Slippery Surface** ability.' ],
+		[ corrosivePool, 'A creature or object takes' ],
+		[ angryBeehive, 'The hive is removed' ]
+	])('combines Activate and Effect into one section', (terrain, effectStart) => {
+		const result = ClassicSheetBuilder.buildTerrainSheet(terrain);
+
+		const sectionIds = result.sections.map(s => s.id);
+		expect(sectionIds).toContain('activate-effect');
+		expect(sectionIds).not.toContain('activate');
+		expect(sectionIds).not.toContain('effect');
+
+		const aeSection = result.sections.find(s => s.id === 'activate-effect');
+		expect(aeSection?.description).toContain(`\n**Effect**: ${effectStart}`);
+	});
+
+	test('Does not create an Upgrades section if none are present', () => {
+		const result = ClassicSheetBuilder.buildTerrainSheet(corrosivePool);
+		const sectionIds = result.sections.map(s => s.id);
+		expect(sectionIds).not.toContain('upgrades');
+	});
+
+	test.each([
+		[ frozenPond, 'Upgrade' ],
+		[ angryBeehive, 'Upgrades' ]
+	])('label the Upgrade section according to the number of Upgrades', (terrain, expectedSectionName) => {
+		const result = ClassicSheetBuilder.buildTerrainSheet(terrain);
+
+		const upgradeSection = result.sections.find(s => s.id === 'upgrades');
+		expect(upgradeSection?.name).toBe(expectedSectionName);
+	});
+
+	test.each([
+		[ frozenPond, [ 'Thin Ice (+1 EV)' ] ],
+		[ angryBeehive, [ 'Concealed Hive (+1 EV)', 'Killer Bees (+2 EV)' ] ]
+	])('properly combines Upgrades into a single section', (terrain, expectedUpgrades) => {
+		const result = ClassicSheetBuilder.buildTerrainSheet(terrain);
+
+		const upgradeSection = result.sections.find(s => s.id === 'upgrades');
+		expectedUpgrades.forEach(expectedUpgrade => {
+			expect(upgradeSection?.description).toContain(expectedUpgrade);
+		});
+	});
+
+	test.each([
+		[ frozenPond ],
+		[ angryBeehive ]
+	])('includes Upgrades as a section when no upgradeIds are passed', terrain => {
+		const result = ClassicSheetBuilder.buildTerrainSheet(terrain);
+
+		const sectionIds = result.sections.map(s => s.id);
+		expect(sectionIds).toContain('upgrades');
+	});
+
+	test.each([
+		[ frozenPond, [ 'thin-ice' ] ],
+		[ angryBeehive, [ 'killer-bees' ] ],
+		[ angryBeehive, [ 'killer-bees', 'concealed-beehive' ] ]
+	])('includes selected Upgrades as individual sections when passed to the builder', (terrain, upgradeIds) => {
+		const result = ClassicSheetBuilder.buildTerrainSheet(terrain, upgradeIds);
+
+		const sectionIds = result.sections.map(s => s.id);
+		expect(sectionIds).not.toContain('upgrades');
+
+		upgradeIds.forEach(upgradeId => {
+			expect(sectionIds).toContain(upgradeId);
+		});
+	});
+
+	test.each([
+		[ frozenPond, [ 'thin-ice' ], '2 per 10 x 10 pond' ],
+		[ angryBeehive, [ 'killer-bees' ], 4 ],
+		[ angryBeehive, [ 'killer-bees', 'concealed-beehive' ], 5 ]
+	])('selected upgrades increase the EV of the terrain by the correct amount', (terrain, upgradeIds, expectedEv) => {
+		const result = ClassicSheetBuilder.buildTerrainSheet(terrain, upgradeIds);
+
+		expect(result.encounterValue).toBe(expectedEv.toString());
 	});
 });

--- a/src/logic/classic-sheet/classic-sheet-builder.ts
+++ b/src/logic/classic-sheet/classic-sheet-builder.ts
@@ -8,7 +8,9 @@ import { CharacteristicsSheet } from '@/models/classic-sheets/classic-sheets';
 import { ClassicSheetLogic } from '@/logic/classic-sheet/classic-sheet-logic';
 import { CreatureLogic } from '@/logic/creature-logic';
 import { DamageModifierType } from '@/enums/damage-modifier-type';
+import { FactoryLogic } from '../factory-logic';
 import { FeatureLogic } from '@/logic/feature-logic';
+import { FeatureText } from '@/models/feature';
 import { FeatureType } from '@/enums/feature-type';
 import { Follower } from '@/models/follower';
 import { Format } from '@/utils/format';
@@ -25,6 +27,9 @@ import { MonsterSheet } from '@/models/classic-sheets/monster-sheet';
 import { Options } from '@/models/options';
 import { SheetFormatter } from '@/logic/classic-sheet/sheet-formatter';
 import { Summon } from '@/models/summon';
+import { Terrain } from '@/models/terrain';
+import { TerrainLogic } from '../terrain-logic';
+import { TerrainSheet } from '@/models/classic-sheets/terrain-sheet';
 
 export class ClassicSheetBuilder {
 	static buildCharacteristicsSheet = (creature: Hero | Monster | Follower | undefined): CharacteristicsSheet => {
@@ -104,6 +109,106 @@ export class ClassicSheetBuilder {
 			.filter(f => f.type === FeatureType.Ability)
 			.map(f => f.data.ability);
 		sheet.abilities = abilities.map(a => ClassicSheetBuilder.buildAbilitySheet(a, monster));
+
+		return sheet;
+	};
+	// #endregion
+
+	// #region Terrain Sheet
+	static buildTerrainSheet = (terrain: Terrain, upgradeIds: string[] = []): TerrainSheet => {
+		const size = typeof terrain.size === 'string' ? terrain.size : FormatLogic.getSize(terrain.size);
+		let encounterValue = terrain.encounterValue;
+
+		const immunities = TerrainLogic.getDamageModifiers(terrain, DamageModifierType.Immunity).map(mod => `${mod.damageType} ${mod.value}`);
+		const weaknesses = TerrainLogic.getDamageModifiers(terrain, DamageModifierType.Weakness).map(mod => `${mod.damageType} ${mod.value}`);
+
+		const sections: (FeatureText | AbilitySheet)[] = [];
+
+		terrain.sections.forEach(s => {
+			s.content.forEach(content => {
+				let sectionContent;
+				switch (content.type) {
+					case FeatureType.Text:
+						sectionContent = content;
+
+						// combine Activate and Effect
+						if (content.id === 'effect') {
+							const activateSection = sections.find(s => s.id === 'activate');
+							if (activateSection) {
+								activateSection.id = 'activate-effect';
+								activateSection.description += `\n**Effect**: ${content.description}`;
+								return;
+							}
+							if (sections.some(s => s.id === 'activate-effect')) {
+								return;
+							}
+						}
+
+						// All existing Terrain objects have damage immunity defined
+						// via a section instead of a DamageModifier, so pull that out
+						if (content.id === 'damage-immunity') {
+							immunities.push(content.description);
+							return;
+						}
+						break;
+					case FeatureType.Ability:
+						sectionContent = this.buildAbilitySheet(content.data.ability, undefined);
+						break;
+				}
+
+				sections.push(sectionContent);
+			});
+		});
+
+		if (upgradeIds.length) {
+			upgradeIds.forEach(id => {
+				const upgrade = terrain.upgrades.find(u => u.id === id);
+				if (upgrade) {
+					sections.push(FactoryLogic.feature.create({
+						id: upgrade.id,
+						name: upgrade.label,
+						description: upgrade.text
+					}));
+					encounterValue += upgrade.cost;
+				}
+			});
+		} else {
+			const upgrades: string[] = [];
+			terrain.upgrades.forEach(upgrade => {
+				upgrades.push(`**${upgrade.label} (${SheetFormatter.addSign(upgrade.cost)} EV)** ${upgrade.text}`);
+			});
+
+			if (upgrades.length) {
+				const name = upgrades.length > 1 ? 'Upgrades' : 'Upgrade';
+				sections.push(FactoryLogic.feature.create({
+					id: 'upgrades',
+					name: name,
+					description: upgrades.join('\n\n')
+				}));
+			}
+		}
+
+		// convert EV to display string as applicable
+		const evDisplay = terrain.area ? `${encounterValue} per ${terrain.area}` : ((encounterValue === 0) ? '-' : encounterValue);
+
+		const sheet: TerrainSheet = {
+			id: terrain.id,
+			name: terrain.name,
+			type: terrain.role.terrainType,
+			role: terrain.role.type,
+			size: size,
+			stamina: TerrainLogic.getStaminaDescription(terrain),
+			description: TerrainLogic.getTerrainDescription(terrain),
+			details: terrain.description,
+			encounterValue: evDisplay.toString(),
+			typicalSpace: terrain.typicalSpace,
+			direction: terrain.direction ?? '',
+			link: terrain.link ?? '',
+			immunity: immunities.join(', '),
+			weakness: weaknesses.join(', '),
+
+			sections: sections
+		};
 
 		return sheet;
 	};

--- a/src/logic/classic-sheet/sheet-formatter.test.ts
+++ b/src/logic/classic-sheet/sheet-formatter.test.ts
@@ -71,15 +71,19 @@ describe.concurrent('Test markdown enhancement', () => {
 		[ '|<=11|', '|![11 or less](<img>)|' ],
 		[ '|11 or less		|', '|![11 or less](<img>)|' ],
 		[ '* 11 or lower:', '* ![11 or less](<img>)' ],
+		[ '* **11 or lower**:', '* ![11 or less](<img>)' ],
+		[ '* **≤11**:', '* ![11 or less](<img>)' ],
 		[ '* ≤11:', '* ![11 or less](<img>)' ],
 		[ '<=11', '![11 or less](<img>)' ],
 		[ '\\<\\=11', '![11 or less](<img>)' ],
 		[ '* <= 11:', '* ![11 or less](<img>)' ],
 		[ '| 12-16 |', '|![12 to 16](<img>)|' ],
 		[ '* 12 - 16:', '* ![12 to 16](<img>)' ],
+		[ '* **12-16**:', '* ![12 to 16](<img>)' ],
 		[ '| 17+ |', '|![17 or greater](<img>)|' ],
 		[ '* ≥ 17:', '* ![17 or greater](<img>)' ],
 		[ '* >=17:', '* ![17 or greater](<img>)' ],
+		[ '* **17+**:', '* ![17 or greater](<img>)' ],
 		[ '* 17+:', '* ![17 or greater](<img>)' ]
 	])('Converts power roll text to glyphs', (inStr, expected) => {
 		const markdown = SheetFormatter.enhanceMarkdown(inStr);

--- a/src/logic/classic-sheet/sheet-formatter.ts
+++ b/src/logic/classic-sheet/sheet-formatter.ts
@@ -1,11 +1,11 @@
 import { Ability, AbilitySectionField, AbilitySectionPackage, AbilitySectionRoll, AbilitySectionText } from '@/models/ability';
+import { Feature, FeatureText } from '@/models/feature';
 import { FollowerSheet, ItemSheet, ProjectSheet } from '@/models/classic-sheets/hero-sheet';
 import { AbilityLogic } from '@/logic/ability-logic';
 import { AbilitySheet } from '@/models/classic-sheets/ability-sheet';
 import { Characteristic } from '@/enums/characteristic';
 import { Collections } from '@/utils/collections';
 import { CreatureLogic } from '@/logic/creature-logic';
-import { Feature } from '@/models/feature';
 import { FeatureType } from '@/enums/feature-type';
 import { Format } from '@/utils/format';
 import { Hero } from '@/models/hero';
@@ -14,6 +14,7 @@ import { Monster } from '@/models/monster';
 import { MonsterSheet } from '@/models/classic-sheets/monster-sheet';
 import { RulesItem } from '@/models/rules-item';
 import { StatBlockIcon } from '@/enums/stat-block-icon';
+import { TerrainSheet } from '@/models/classic-sheets/terrain-sheet';
 import { Title } from '@/models/title';
 import { Utils } from '@/utils/utils';
 
@@ -117,9 +118,9 @@ export class SheetFormatter {
 			.replace(/I<([svw\d])\]/g, 'i<$1]')
 			.replace(/P<([svw\d])\]/g, 'p<$1]')
 			.replace(/([marip])<([svw\d]\])/g, '<span class="potency">$1&lt;$2</span>')
-			.replace(/((≤|\\?<\\?=)\s*11|11 or (less|lower)):?/g, `![11 or less](${rollT1Icon})`)
-			.replace(/12\s*[-–]\s*16:?/g, `![12 to 16](${rollT2Icon})`)
-			.replace(/((≥|>=)\s*17|17(\+| or (more|greater))):?/g, `![17 or greater](${rollT3Icon})`)
+			.replace(/(\*\*)?((≤|\\?<\\?=)\s*11|11 or (less|lower))(\*\*)?:?/g, `![11 or less](${rollT1Icon})`)
+			.replace(/(\*\*)?12\s*[-–]\s*16(\*\*)?:?/g, `![12 to 16](${rollT2Icon})`)
+			.replace(/(\*\*)?((≥|>=)\s*17|17(\+| or (more|greater)))(\*\*)?:?/g, `![17 or greater](${rollT3Icon})`)
 			.replace(/[`]/g, '')
 			.replace(/[^\S\r\n]*\|[^\S\r\n]*/g, '|')
 			.replace(/<\/?code>/g, '');
@@ -686,6 +687,32 @@ export class SheetFormatter {
 		});
 		// ability/feature dividers
 		size += 1.6 * Math.max(0, ((monster.abilities?.length || 0) + (monster.features?.length || 0) - 1));
+		size = Math.ceil(size / columns);
+		return size;
+	};
+
+	static calculateTerrainSize = (terrain: TerrainSheet, lineWidth: number, columns: number = 1): number => {
+		let size = 0;
+		size += 4.5; // name, type, ev
+		size += this.countLines(terrain.details, lineWidth);
+		size += 1.5; // stamina, size
+		size += this.countLines(terrain.immunity, lineWidth, 0, 1.5);
+		size += this.countLines(terrain.weakness, lineWidth, 0, 1.5);
+		size += this.countLines(terrain.typicalSpace, lineWidth, 0, 1.5);
+		size += this.countLines(terrain.direction, lineWidth, 0, 1.5);
+		size += this.countLines(terrain.link, lineWidth, 0, 1.5);
+
+		terrain.sections.forEach(s => {
+			if (Object.hasOwn(s, 'type')) {
+				const featureSize = this.calculateFeatureSize(s as FeatureText, null, lineWidth, false);
+				size += featureSize;
+			} else {
+				const abilitySize = this.calculateAbilityComponentSize(s as AbilitySheet, lineWidth - 5);
+				size += abilitySize;
+			}
+		});
+		size += 1.4 * Math.max(0, (terrain.sections?.length || 0));
+
 		size = Math.ceil(size / columns);
 		return size;
 	};

--- a/src/logic/factory-logic.ts
+++ b/src/logic/factory-logic.ts
@@ -360,6 +360,7 @@ export class FactoryLogic {
 			role: FactoryLogic.createTerrainRole(MonsterRoleType.Ambusher, TerrainRoleType.Fortification),
 			encounterValue: 0,
 			area: '',
+			typicalSpace: '',
 			direction: '',
 			link: '',
 			stamina: {

--- a/src/logic/playbook-sheets/encounter-sheet-builder.ts
+++ b/src/logic/playbook-sheets/encounter-sheet-builder.ts
@@ -1,5 +1,5 @@
-import { Encounter, EncounterGroup } from '@/models/encounter';
-import { EncounterGroupSheet, EncounterSheet, EncounterSlotSheet } from '@/models/classic-sheets/encounter-sheet';
+import { Encounter, EncounterGroup, TerrainSlot } from '@/models/encounter';
+import { EncounterGroupSheet, EncounterSheet, EncounterSlotSheet, TerrainSlotSheet } from '@/models/classic-sheets/encounter-sheet';
 import { ClassicSheetBuilder } from '@/logic/classic-sheet/classic-sheet-builder';
 import { CreatureLogic } from '@/logic/creature-logic';
 import { EncounterDifficultyLogic } from '@/logic/encounter-difficulty-logic';
@@ -48,8 +48,13 @@ export class EncounterSheetBuilder {
 
 		sheet.groups = encounter.groups.map(g => this.buildEncounterGroupSheet(g, sourcebooks));
 
-		const terrain = encounter.terrain.map(slot => SourcebookLogic.getTerrains(sourcebooks).find(t => t.id === slot.terrainID)).filter(t => !!t);
-		sheet.terrain = terrain;
+		const terrainSlots = encounter.terrain
+			.map(slot => this.buildTerrainSlotSheet(slot, sourcebooks))
+			.filter(t => !!t);
+		sheet.terrainSlots = terrainSlots;
+		sheet.terrain = terrainSlots
+			.flatMap(slot => slot.terrain)
+			.filter((t, i, arr) => arr.indexOf(t) === i);
 
 		const encounterMonsters = EncounterLogic.getMonsterData(encounter)
 			.map(data => EncounterLogic.getCustomizedMonster(data.monsterID, data.customization, sourcebooks))
@@ -80,6 +85,25 @@ export class EncounterSheetBuilder {
 			.filter(mg => mg.malice.length);
 
 		return sheet;
+	};
+
+	static buildTerrainSlotSheet = (slot: TerrainSlot, sourcebooks: Sourcebook[]): TerrainSlotSheet | null => {
+		const terrain = SourcebookLogic.getTerrains(sourcebooks).find(t => t.id === slot.terrainID);
+		if (terrain) {
+			const sheet = ClassicSheetBuilder.buildTerrainSheet(terrain, slot.upgradeIDs);
+
+			const ev = Number.parseInt(sheet.encounterValue.replace(/(^\d+)(.*$)/i, '$1'));
+
+			const slotSheet: TerrainSlotSheet = {
+				id: slot.id,
+				terrain: sheet,
+				count: slot.count,
+				slotEv: slot.count * ev
+			};
+
+			return slotSheet;
+		}
+		return null;
 	};
 
 	static buildEncounterGroupSheet = (group: EncounterGroup, sourcebooks: Sourcebook[]): EncounterGroupSheet => {

--- a/src/models/classic-sheets/encounter-sheet.ts
+++ b/src/models/classic-sheets/encounter-sheet.ts
@@ -1,7 +1,7 @@
 import { Feature } from '@/models/feature';
 import { Monster } from '@/models/monster';
 import { MonsterSheet } from '@/models/classic-sheets/monster-sheet';
-import { Terrain } from '@/models/terrain';
+import { TerrainSheet } from './terrain-sheet';
 
 export interface EncounterSheet {
 	id: string;
@@ -24,8 +24,9 @@ export interface EncounterSheet {
 
 	malice?: { monster: string, malice: Feature[] }[];
 	groups?: EncounterGroupSheet[];
+	terrainSlots?: TerrainSlotSheet[];
 
-	terrain?: Terrain[];
+	terrain?: TerrainSheet[];
 	monsters?: MonsterSheet[];
 }
 
@@ -44,3 +45,10 @@ export interface EncounterSlotSheet {
 	isMinion: boolean;
 }
 // #endregion
+
+export interface TerrainSlotSheet {
+	id: string;
+	terrain: TerrainSheet;
+	count: number;
+	slotEv: number;
+}

--- a/src/models/classic-sheets/terrain-sheet.ts
+++ b/src/models/classic-sheets/terrain-sheet.ts
@@ -1,0 +1,23 @@
+import { AbilitySheet } from './ability-sheet';
+import { FeatureText } from '../feature';
+
+export interface TerrainSheet {
+	id: string;
+	name: string;
+	type: string;
+	role: string;
+	description: string;
+	encounterValue: string;
+
+	details: string;
+	size: string;
+	stamina: string;
+
+	immunity: string;
+	weakness: string;
+	typicalSpace: string;
+	direction: string;
+	link: string;
+
+	sections: (FeatureText | AbilitySheet)[];
+};

--- a/src/models/terrain.ts
+++ b/src/models/terrain.ts
@@ -22,6 +22,7 @@ export interface Terrain extends Element {
 	role: TerrainRole;
 	encounterValue: number;
 	area: string;
+	typicalSpace: string;
 	stamina: {
 		base: number;
 		perSquare: number;


### PR DESCRIPTION
Fixes #830 

# Overview
- Adds Terrain Object stat blocks to the classic Encounter Sheet display.
    <img width="917" height="669" alt="image" src="https://github.com/user-attachments/assets/e09f7e4f-5711-4bde-abbd-8736c1f30af9" />
- Fixes some small typos/bugs in various terrain object data
- In the Library view for Terrain, the previous 'print' view has been replaced with a classic view for single elements that can be exported as PDF. I anticipate expanding this type of view to other library item types in the future (e.g. monsters)
    <img width="684" height="348" alt="image" src="https://github.com/user-attachments/assets/c8278395-1b60-4973-8bb8-c1d8ae987e0d" />
