### PR TITLE
Library - Add classic sheet for Monster and MonsterGroup

### DIFF
--- a/src/components/pages/classic-sheet/common.scss
+++ b/src/components/pages/classic-sheet/common.scss
@@ -36,11 +36,7 @@ main#classic-sheet {
         display: none;
     }
 
-    .hero-sheet,
-    .encounter-sheet,
-    .montage-sheet,
-    .negotiation-sheet,
-    .library-item-sheet {
+    :is(.hero-sheet, .encounter-sheet, .montage-sheet, .negotiation-sheet, .library-item-sheet) {
         height: 100%;
         font-size: 14px;
         padding: 5px;

--- a/src/components/pages/classic-sheet/common.scss
+++ b/src/components/pages/classic-sheet/common.scss
@@ -435,14 +435,18 @@ main#classic-sheet {
     @mixin color-ability-card($color) {
         .bordered {
             @include borders.beveled(10px, 2px, $color);
+            @include color-ability($color);
 
-            h3,
-            .action-type {
-                color: $color;
-            }
             h3 {
                 font-weight: 450;
             }
+        }
+    }
+
+    @mixin color-ability($color) {
+        h3,
+        .action-type {
+            color: $color;
         }
     }
 
@@ -499,6 +503,26 @@ main#classic-sheet {
                     h2 {
                         @include dividers.fancy-3($move);
                     }
+                }
+            }
+
+            &:is(.encounter-sheet, .library-item-sheet) .ability {
+                &.main-action {
+                    @include color-ability($main-action);
+                }
+                &.maneuver,
+                &.free-maneuver {
+                    @include color-ability($maneuver);
+                }
+                &.triggered-action,
+                &.free-triggered-action {
+                    @include color-ability($triggered-action);
+                }
+                &.performance {
+                    @include color-ability($performance);
+                }
+                &.move-action {
+                    @include color-ability($move);
                 }
             }
 

--- a/src/components/pages/library/library-list/library-list-page.tsx
+++ b/src/components/pages/library/library-list/library-list-page.tsx
@@ -242,6 +242,7 @@ export const LibraryListPage = (props: Props) => {
 						);
 					case 'terrain':
 					case 'monster':
+					case 'monster-group':
 						return (
 							<div style={{ padding: '20px', overflow: 'auto' }}>
 								<LibraryItemSheetPage
@@ -648,6 +649,7 @@ export const LibraryListPage = (props: Props) => {
 				case 'negotiation':
 				case 'terrain':
 				case 'monster':
+				case 'monster-group':
 					canExportAsImage = false;
 					canExportAsPDF = true;
 					break;

--- a/src/components/pages/library/library-list/library-list-page.tsx
+++ b/src/components/pages/library/library-list/library-list-page.tsx
@@ -210,10 +210,11 @@ export const LibraryListPage = (props: Props) => {
 
 	const getElementPanel = () => {
 		let getPanel: (element: Element) => ReactNode = () => null;
+		const cat = ((category === 'monster-group') && showMonsters) ? 'monster' : category;
 
 		if (view === 'classic') {
 			getPanel = (element: Element) => {
-				switch (category) {
+				switch (cat) {
 					case 'encounter':
 						return (
 							<div style={{ padding: '20px', overflow: 'auto' }}>
@@ -240,11 +241,12 @@ export const LibraryListPage = (props: Props) => {
 							</div>
 						);
 					case 'terrain':
+					case 'monster':
 						return (
 							<div style={{ padding: '20px', overflow: 'auto' }}>
 								<LibraryItemSheetPage
-									category={category}
-									terrain={element as Terrain}
+									category={cat}
+									item={element}
 								/>
 							</div>
 						);
@@ -645,6 +647,7 @@ export const LibraryListPage = (props: Props) => {
 				case 'montage':
 				case 'negotiation':
 				case 'terrain':
+				case 'monster':
 					canExportAsImage = false;
 					canExportAsPDF = true;
 					break;
@@ -797,10 +800,6 @@ export const LibraryListPage = (props: Props) => {
 			return null;
 		}
 
-		if ((category === 'monster-group') && showMonsters) {
-			return null;
-		}
-
 		switch (category) {
 			case 'adventure':
 			case 'tactical-map':
@@ -809,6 +808,7 @@ export const LibraryListPage = (props: Props) => {
 			case 'montage':
 			case 'negotiation':
 			case 'terrain':
+			case 'monster-group':
 				return (
 					<ViewSelector
 						mode='classic'

--- a/src/components/panels/classic-sheet/components/ability-component.tsx
+++ b/src/components/panels/classic-sheet/components/ability-component.tsx
@@ -1,4 +1,5 @@
 import { AbilitySheet } from '@/models/classic-sheets/ability-sheet';
+import { Collections } from '@/utils/collections';
 import { DrawSteelSymbolText } from '@/components/panels/classic-sheet/components/ds-symbol-text-component';
 import { Markdown } from '@/components/controls/markdown/markdown';
 import { SheetFormatter } from '@/logic/classic-sheet/sheet-formatter';
@@ -87,8 +88,19 @@ export const AbilityComponent = (props: Props) => {
 		icon = <img src={iconSrc} className='icon' />;
 	}
 
+	const getClasses = (ability: AbilitySheet) => {
+		const classes = [ 'ability' ];
+		if (ability.actionType) {
+			classes.push(ability.actionType.toLocaleLowerCase().split(' ').join('-'));
+		}
+		if (ability.abilityType) {
+			classes.push(ability.abilityType.toLocaleLowerCase().split(' ').join('-'));
+		}
+		return Collections.distinct(classes, c => c).join(' ');
+	};
+
 	return (
-		<div className='ability'>
+		<div className={getClasses(ability)}>
 			<div className='header'>
 				<div className='name'>{ability.name}</div>
 				{ability.hasPowerRoll ?

--- a/src/components/panels/classic-sheet/encounter-sheet/encounter-sheet-page.tsx
+++ b/src/components/panels/classic-sheet/encounter-sheet/encounter-sheet-page.tsx
@@ -29,7 +29,7 @@ export const EncounterSheetPage = (props: Props) => {
 	);
 
 	const getMonsterCards = () => {
-		const layout = SheetLayout.getFollowerCardsLayout(options, true);
+		const layout = SheetLayout.getMonsterCardsLayout(options);
 
 		const requiredCards: FillerCard[] = [];
 
@@ -97,7 +97,7 @@ export const EncounterSheetPage = (props: Props) => {
 
 		requiredCards.sort((a, b) => a.height - b.height);
 
-		return SheetLayout.getMonsterCardPages(requiredCards, encounter, layout, 'monsters');
+		return SheetLayout.getMonsterCardPages(requiredCards, layout, `encounter-${encounter.id}-page-monsters`);
 	};
 
 	const sheetClasses = useMemo(

--- a/src/components/panels/classic-sheet/library-item-sheet/library-item-sheet-page.scss
+++ b/src/components/panels/classic-sheet/library-item-sheet/library-item-sheet-page.scss
@@ -8,6 +8,14 @@ main#classic-sheet .library-item-sheet {
         gap: var(--gap);
         padding: 5px;
 
+        h1 {
+            font-weight: 900;
+            font-size: round(3.85rem, 1px);
+            padding-bottom: 0;
+            text-align: left;
+            border-bottom: 2px solid common.$color-medium;
+        }
+
         .card {
             margin: 0;
             align-self: flex-start;

--- a/src/components/panels/classic-sheet/library-item-sheet/library-item-sheet-page.scss
+++ b/src/components/panels/classic-sheet/library-item-sheet/library-item-sheet-page.scss
@@ -2,7 +2,15 @@
 
 main#classic-sheet .library-item-sheet {
     .page {
-        display: grid;
-        grid-template-columns: 1fr 1fr;
+        --gap: 10px;
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--gap);
+        padding: 5px;
+
+        .card {
+            margin: 0;
+            align-self: flex-start;
+        }
     }
 }

--- a/src/components/panels/classic-sheet/library-item-sheet/library-item-sheet-page.tsx
+++ b/src/components/panels/classic-sheet/library-item-sheet/library-item-sheet-page.tsx
@@ -1,8 +1,12 @@
+import { FillerCard, SheetLayout } from '@/logic/classic-sheet/sheet-layout';
 import { ClassicSheetBuilder } from '@/logic/classic-sheet/classic-sheet-builder';
+import { GenericCard } from '../notes-card/notes-card';
+import { MaliceGroupComponent } from '../malice-card/malice-card';
+import { Markdown } from '@/components/controls/markdown/markdown';
 import { Monster } from '@/models/monster';
 import { MonsterCard } from '../monster-card/monster-card';
+import { MonsterGroup } from '@/models/monster-group';
 import { SheetFormatter } from '@/logic/classic-sheet/sheet-formatter';
-import { SheetLayout } from '@/logic/classic-sheet/sheet-layout';
 import { Terrain } from '@/models/terrain';
 import { TerrainCard } from '../monster-card/terrain-card';
 import { useMemo } from 'react';
@@ -18,7 +22,7 @@ interface Props {
 export const LibraryItemSheetPage = (props: Props) => {
 	const options = useOptions();
 	const layout = useMemo(
-		() => SheetLayout.getFollowerCardsLayout(options, false),
+		() => SheetLayout.getMonsterCardsLayout(options),
 		[ options ]
 	);
 
@@ -50,6 +54,58 @@ export const LibraryItemSheetPage = (props: Props) => {
 					<div className={pageClasses} id={SheetFormatter.getPageId('monster', sheet.id)}>
 						<MonsterCard monster={sheet} columns={w} />
 					</div>
+				);
+			}
+			case 'monster-group': {
+				const group = props.item as MonsterGroup;
+
+				const infoCards = group.information.map(info => {
+					return <GenericCard title={info.name} content={info.description} key={`info-${info.id}`} />;
+				});
+				infoCards.push(
+					<div className='malice card'>
+						<h2>Malice</h2>
+						<div className='malice-features features-container content'>
+							<MaliceGroupComponent monster={group.name} malice={group.malice} />
+						</div>
+					</div>
+				);
+
+				const monsterCards: FillerCard[] = [];
+				group.monsters.forEach(monster => {
+					const ms = ClassicSheetBuilder.buildMonsterSheet(monster);
+					let mH = SheetFormatter.calculateMonsterSize(ms, layout.cardLineLen);
+					let mW = 1;
+					if (mH > layout.linesY) {
+						mW = 2;
+						mH = SheetFormatter.calculateMonsterSize(ms, layout.cardLineLen, 2);
+						if (mH > layout.linesY) {
+							console.warn('Card still larger than a full page!', ms.name, mH);
+							mH = layout.linesY;
+						}
+					}
+					monsterCards.push({
+						element: <MonsterCard monster={ms} columns={mW} key={ms.id} />,
+						width: mW,
+						height: mH,
+						shown: false
+					});
+				});
+				monsterCards.sort((a, b) => a.height - b.height);
+
+				return (
+					<>
+						<div className={`page extra-cards row-cards-2 ${options.pageOrientation}`} id={SheetFormatter.getPageId('monster-group', group.id, 'info')}>
+							<div className='card'>
+								<h1>{group.name}</h1>
+								<div className='content'>
+									<Markdown text={group.description} />
+								</div>
+							</div>
+							{infoCards}
+						</div>
+						{SheetLayout.getMonsterCardPages(monsterCards, layout, `monster-group-${group.id}-page-monsters`)}
+					</>
 				);
 			}
 		}

--- a/src/components/panels/classic-sheet/library-item-sheet/library-item-sheet-page.tsx
+++ b/src/components/panels/classic-sheet/library-item-sheet/library-item-sheet-page.tsx
@@ -1,5 +1,8 @@
 import { ClassicSheetBuilder } from '@/logic/classic-sheet/classic-sheet-builder';
+import { Monster } from '@/models/monster';
+import { MonsterCard } from '../monster-card/monster-card';
 import { SheetFormatter } from '@/logic/classic-sheet/sheet-formatter';
+import { SheetLayout } from '@/logic/classic-sheet/sheet-layout';
 import { Terrain } from '@/models/terrain';
 import { TerrainCard } from '../monster-card/terrain-card';
 import { useMemo } from 'react';
@@ -9,16 +12,53 @@ import './library-item-sheet-page.scss';
 
 interface Props {
 	category: string;
-	terrain: Terrain;
+	item: unknown;
 }
 
 export const LibraryItemSheetPage = (props: Props) => {
-	const terrain = useMemo(
-		() => ClassicSheetBuilder.buildTerrainSheet(props.terrain),
-		[ props.terrain ]
+	const options = useOptions();
+	const layout = useMemo(
+		() => SheetLayout.getFollowerCardsLayout(options, false),
+		[ options ]
 	);
 
-	const options = useOptions();
+	const getContent = () => {
+		const pageClasses = [
+			'page',
+			options.pageOrientation,
+			`row-cards-${layout.perRow}`
+		].join(' ');
+
+		switch (props.category) {
+			case 'terrain': {
+				const sheet = ClassicSheetBuilder.buildTerrainSheet(props.item as Terrain);
+				return (
+					<div className={pageClasses} id={SheetFormatter.getPageId('terrain', sheet.id)}>
+						<TerrainCard terrain={sheet} />
+					</div>
+				);
+			}
+			case 'monster': {
+				const sheet = ClassicSheetBuilder.buildMonsterSheet(props.item as Monster);
+				const cardH = SheetFormatter.calculateMonsterSize(sheet, layout.cardLineLen);
+				let w = 1;
+				if (cardH > layout.linesY) {
+					w = 2;
+				}
+
+				return (
+					<div className={pageClasses} id={SheetFormatter.getPageId('monster', sheet.id)}>
+						<MonsterCard monster={sheet} columns={w} />
+					</div>
+				);
+			}
+		}
+	};
+
+	const content = useMemo(
+		() => getContent(),
+		[ props.item, props.category ]
+	);
 
 	const sheetClasses = useMemo(
 		() => {
@@ -38,9 +78,7 @@ export const LibraryItemSheetPage = (props: Props) => {
 	return (
 		<main id='classic-sheet'>
 			<div className={sheetClasses.join(' ')}>
-				<div className={`page page-1 ${options.pageOrientation}`} id={SheetFormatter.getPageId('terrain', terrain.id)}>
-					<TerrainCard terrain={terrain} />
-				</div>
+				{content}
 			</div>
 		</main>
 	);

--- a/src/components/panels/classic-sheet/malice-card/malice-card.scss
+++ b/src/components/panels/classic-sheet/malice-card/malice-card.scss
@@ -25,6 +25,10 @@
             border-radius: 6px 6px 0 0;
         }
 
+        .wrapper {
+            break-inside: avoid;
+        }
+
         .feature {
             .power-roll {
                 .header {
@@ -32,6 +36,16 @@
                     margin-left: 0;
                 }
             }
+        }
+    }
+}
+
+main#classic-sheet .library-item-sheet .malice.card {
+    .malice-features .wrapper:not(:last-of-type) {
+        @include common.divider-plain(common.$color-medium, 1px);
+
+        .feature-description {
+            margin-bottom: 5px;
         }
     }
 }

--- a/src/components/panels/classic-sheet/malice-card/malice-card.tsx
+++ b/src/components/panels/classic-sheet/malice-card/malice-card.tsx
@@ -1,14 +1,15 @@
 import { Fragment, useMemo } from 'react';
 import { EncounterSheet } from '@/models/classic-sheets/encounter-sheet';
+import { Feature } from '@/models/feature';
 import { FeatureComponent } from '@/components/panels/classic-sheet/components/feature-component';
 
 import './malice-card.scss';
 
-interface Props {
+interface MaliceCardProps {
 	encounter: EncounterSheet;
 }
 
-export const MaliceCard = (props: Props) => {
+export const MaliceCard = (props: MaliceCardProps) => {
 	const encounter = useMemo(() => props.encounter, [ props.encounter ]);
 
 	return (
@@ -21,17 +22,28 @@ export const MaliceCard = (props: Props) => {
 			<div className='malice-features features-container three-column'>
 				{encounter.malice?.map(m => {
 					return (
-						<Fragment key={`malice-group-${m.monster}`}>
-							{m.malice.map((malice, i) =>
-								<Fragment key={malice.id}>
-									{i === 0 ? <h3>{m.monster} Malice</h3> : null}
-									<FeatureComponent feature={malice} />
-								</Fragment>
-							)}
-						</Fragment>
+						<MaliceGroupComponent monster={m.monster} malice={m.malice} />
 					);
 				})}
 			</div>
 		</div>
+	);
+};
+
+interface MaliceComponentProps {
+	monster: string;
+	malice: Feature[];
+}
+
+export const MaliceGroupComponent = (props: MaliceComponentProps) => {
+	return (
+		<Fragment key={`malice-group-${props.monster}`}>
+			{props.malice.map((malice, i) =>
+				<div className='wrapper' key={malice.id}>
+					{i === 0 ? <h3>{props.monster} Malice</h3> : null}
+					<FeatureComponent feature={malice} />
+				</div>
+			)}
+		</Fragment>
 	);
 };

--- a/src/components/panels/classic-sheet/monster-card/monster-card.scss
+++ b/src/components/panels/classic-sheet/monster-card/monster-card.scss
@@ -76,11 +76,10 @@ main#classic-sheet :is(.encounter-sheet, .hero-sheet, .library-item-sheet) :is(.
             section.bordered {
                 column-count: 2;
                 column-gap: 25px;
-                padding-top: 10px;
 
                 .name-wrapper {
                     @include monster-header-gradient-half(common.$color-general-monster);
-                    margin-top: -8px;
+                    column-span: all;
                 }
             }
         }

--- a/src/components/panels/classic-sheet/monster-card/monster-card.scss
+++ b/src/components/panels/classic-sheet/monster-card/monster-card.scss
@@ -45,11 +45,7 @@
         center center;
 }
 
-
-main#classic-sheet .encounter-sheet .monster,
-main#classic-sheet .hero-sheet .monster,
-main#classic-sheet .encounter-sheet .terrain.card,
-main#classic-sheet .library-item-sheet .terrain.card {
+main#classic-sheet :is(.encounter-sheet, .hero-sheet, .library-item-sheet) :is(.monster.card, .terrain.card) {
     padding: 10px;
     display: grid;
     justify-self: stretch;
@@ -80,9 +76,11 @@ main#classic-sheet .library-item-sheet .terrain.card {
             section.bordered {
                 column-count: 2;
                 column-gap: 25px;
+                padding-top: 10px;
 
                 .name-wrapper {
                     @include monster-header-gradient-half(common.$color-general-monster);
+                    margin-top: -8px;
                 }
             }
         }
@@ -296,6 +294,7 @@ main#classic-sheet .library-item-sheet .terrain.card {
         grid-template-columns: min-content 1fr;
         grid-template-rows: min-content 1fr;
         margin-top: 5px;
+        break-inside: avoid;
 
         .ability {
             margin-bottom: 10px;
@@ -338,8 +337,7 @@ main#classic-sheet .encounter-sheet .terrain.card {
     }
 }
 
-main#classic-sheet .color .monster.card,
-main#classic-sheet .color .terrain.card {
+main#classic-sheet .color :is(.monster.card, .terrain.card) {
     &.ambusher {
         section.bordered .name-wrapper {
             @include monster-header-gradient(common.$color-ambusher);

--- a/src/components/panels/classic-sheet/notes-card/notes-card.tsx
+++ b/src/components/panels/classic-sheet/notes-card/notes-card.tsx
@@ -2,11 +2,11 @@ import { Markdown } from '@/components/controls/markdown/markdown';
 
 import './notes-card.scss';
 
-interface Props {
+interface NotesProps {
 	notes: string;
 }
 
-export const NotesCard = (props: Props) => {
+export const NotesCard = (props: NotesProps) => {
 	const notes = props.notes;
 
 	return (
@@ -14,6 +14,22 @@ export const NotesCard = (props: Props) => {
 			<h2>Notes</h2>
 			<div className='content'>
 				<Markdown text={notes} />
+			</div>
+		</div>
+	);
+};
+
+interface GenericProps {
+	title: string;
+	content: string;
+}
+
+export const GenericCard = (props: GenericProps) => {
+	return (
+		<div className='card'>
+			<h2>{props.title}</h2>
+			<div className='content'>
+				<Markdown text={props.content} />
 			</div>
 		</div>
 	);

--- a/src/data/monsters/ajax.ts
+++ b/src/data/monsters/ajax.ts
@@ -205,7 +205,7 @@ Until the end of the round, Ajax chooses one of the following environments he ha
 						cost: 2,
 						keywords: [ AbilityKeyword.Area, AbilityKeyword.Magic, AbilityKeyword.Ranged ],
 						distance: [ FactoryLogic.distance.create({ type: AbilityDistanceType.Cube, value: 5, within: 20 }) ],
-						target: '',
+						target: 'Special',
 						sections: [
 							FactoryLogic.createAbilitySectionText('Ajax throws a glowing bead to a square within distance, which ignites at the start of Ajax’s next turn and creates an area around it that lasts until the start of Ajax’s following turn. Each enemy in the area when the bead ignites takes 20 fire damage, and if they have <code>A < 5</code>, they are dazed (save ends). Any enemy who starts their turn in the area takes 10 fire damage.')
 						]

--- a/src/data/terrain/fieldworks.ts
+++ b/src/data/terrain/fieldworks.ts
@@ -494,7 +494,7 @@ export const snareTrap: Terrain = {
 					id: 'effect',
 					name: 'Effect',
 					description:
-            'A triggering creature or object ends their movement and is targeted by the *Snare* ability.'
+            'A triggering creature or object ends their movement and is targeted by the **Snare** ability.'
 				})
 			]
 		},

--- a/src/logic/classic-sheet/classic-sheet-builder.ts
+++ b/src/logic/classic-sheet/classic-sheet-builder.ts
@@ -273,6 +273,9 @@ export class ClassicSheetBuilder {
 				sheet.abilityType = `${ability.cost} Malice`;
 			} else if (isMonster && creature.retainer?.level) {
 				sheet.abilityType = 'Encounter';
+			} else if (ability.type.usage === AbilityUsage.VillainAction) {
+				sheet.abilityType = `Villain Action ${ability.type.order}`;
+				sheet.actionType = '';
 			} else {
 				sheet.abilityType = '';
 			}

--- a/src/logic/classic-sheet/sheet-layout.tsx
+++ b/src/logic/classic-sheet/sheet-layout.tsx
@@ -1,7 +1,6 @@
 import { Fragment, JSX } from 'react';
 import { AbilityCard } from '@/components/panels/classic-sheet/ability-card/ability-card';
 import { AbilitySheet } from '@/models/classic-sheets/ability-sheet';
-import { EncounterSheet } from '@/models/classic-sheets/encounter-sheet';
 import { HeroSheet } from '@/models/classic-sheets/hero-sheet';
 import { Options } from '@/models/options';
 import { SheetFormatter } from '@/logic/classic-sheet/sheet-formatter';
@@ -55,12 +54,20 @@ export class SheetLayout {
 	};
 
 	static getFollowerCardsLayout = (options: Options, hasRetainers: boolean): CardPageLayout => {
+		// FORCE portrait if there are any retainers
+		const orientation = hasRetainers ? 'portrait' : options.pageOrientation;
+		return this.getCardsLayoutForOrientation(options, orientation);
+	};
+
+	static getMonsterCardsLayout = (options: Options): CardPageLayout => {
+		// FORCE portrait
+		return this.getCardsLayoutForOrientation(options, 'portrait');
+	};
+
+	static getCardsLayoutForOrientation = (options: Options, orientation: 'portrait' | 'landscape'): CardPageLayout => {
 		// Get root font size (1rem)
 		const rootFontSize = parseFloat(getComputedStyle(document.documentElement).fontSize);
 		const charWidth = rootFontSize * 0.553;
-
-		// FORCE portrait if there are any retainers
-		const orientation = hasRetainers ? 'portrait' : options.pageOrientation;
 
 		// gap between cards
 		const gapPx = 10; // px
@@ -435,7 +442,7 @@ export class SheetLayout {
 		return pages;
 	};
 
-	static getMonsterCardPages = (monsterCards: FillerCard[], encounter: EncounterSheet, layout: CardPageLayout, idPrefix = 'extra') => {
+	static getMonsterCardPages = (monsterCards: FillerCard[], layout: CardPageLayout, idPrefix = 'extra') => {
 		const pages: JSX.Element[] = [];
 		let i = 0;
 		const extraCards: ExtraCards = {
@@ -453,7 +460,7 @@ export class SheetLayout {
 			pages.push(
 				<Fragment key={`${idPrefix}-${++i}`}>
 					<hr className='dashed' />
-					<div className={pageClasses.join(' ')} id={SheetFormatter.getPageId('encounter', encounter.id, `${idPrefix}-${i}`)}>
+					<div className={pageClasses.join(' ')} id={`${idPrefix}-${i}`}>
 						{cards}
 					</div>
 				</Fragment>


### PR DESCRIPTION
# Overview

- Adds a Classic Sheet style view for Monsters and MonsterGRoups in Library view.
   - Can also be exported as PDF
   <img width="720" height="615" alt="lib" src="https://github.com/user-attachments/assets/2f888b66-3efb-4631-98e3-4d91e4758f9c" />

- Adds color hinting to Monster abilities in Classic view similar to Hero abilities
   <img width="616" height="1013" alt="image" src="https://github.com/user-attachments/assets/31de0ea3-1e66-474d-98aa-420e37a4d4c3" />

- Fixes the `target` field for one of Ajax's abilities
- Now properly displays the Villain action number (e.g. '**Villain Action 1**') for Villain Actions in classic view.
