### PR TITLE
Fixes an incorrect War Dog Arachnite ability and some incorrect area abilities

### DIFF
--- a/src/data/monsters/rival.ts
+++ b/src/data/monsters/rival.ts
@@ -677,7 +677,7 @@ Rivals are NPCs built around the mechanics of seven of the classes in Draw Steel
 						name: 'The Depths Hunger',
 						type: FactoryLogic.type.createMain(),
 						keywords: [ AbilityKeyword.Area, AbilityKeyword.Green, AbilityKeyword.Magic, AbilityKeyword.Ranged ],
-						distance: [ FactoryLogic.distance.create({ type: AbilityDistanceType.Cube, value: 4, value2: 10 }) ],
+						distance: [ FactoryLogic.distance.create({ type: AbilityDistanceType.Cube, value: 4, within: 10 }) ],
 						target: 'Each enemy in the area',
 						cost: 4,
 						sections: [
@@ -1156,7 +1156,7 @@ Rivals are NPCs built around the mechanics of seven of the classes in Draw Steel
 						name: 'The Chasm Engulfs',
 						type: FactoryLogic.type.createMain(),
 						keywords: [ AbilityKeyword.Area, AbilityKeyword.Green, AbilityKeyword.Magic, AbilityKeyword.Ranged ],
-						distance: [ FactoryLogic.distance.create({ type: AbilityDistanceType.Cube, value: 5, value2: 10 }) ],
+						distance: [ FactoryLogic.distance.create({ type: AbilityDistanceType.Cube, value: 5, within: 10 }) ],
 						target: 'Each enemy in the area',
 						cost: 4,
 						sections: [
@@ -1644,7 +1644,7 @@ Rivals are NPCs built around the mechanics of seven of the classes in Draw Steel
 						name: 'The World Consumes',
 						type: FactoryLogic.type.createMain(),
 						keywords: [ AbilityKeyword.Area, AbilityKeyword.Green, AbilityKeyword.Magic, AbilityKeyword.Ranged ],
-						distance: [ FactoryLogic.distance.create({ type: AbilityDistanceType.Cube, value: 3, value2: 10 }) ],
+						distance: [ FactoryLogic.distance.create({ type: AbilityDistanceType.Cube, value: 3, within: 10 }) ],
 						target: 'Each enemy in the area',
 						cost: 5,
 						sections: [
@@ -1908,7 +1908,7 @@ Rivals are NPCs built around the mechanics of seven of the classes in Draw Steel
 						name: 'Guardian From Afar',
 						type: FactoryLogic.type.createMain(),
 						keywords: [ AbilityKeyword.Ranged, AbilityKeyword.Strike, AbilityKeyword.Weapon ],
-						distance: [ FactoryLogic.distance.create({ type: AbilityDistanceType.Cube, value: 3, value2: 10 }) ],
+						distance: [ FactoryLogic.distance.create({ type: AbilityDistanceType.Cube, value: 3, within: 10 }) ],
 						target: 'One creature in the area',
 						cost: 3,
 						sections: [

--- a/src/data/monsters/valok.ts
+++ b/src/data/monsters/valok.ts
@@ -311,7 +311,7 @@ One of the most advanced multivoks, a chief directs and coordinates other valok 
 						type: FactoryLogic.type.createMain(),
 						cost: 'signature',
 						keywords: [ AbilityKeyword.Area, AbilityKeyword.Ranged, AbilityKeyword.Weapon ],
-						distance: [ FactoryLogic.distance.create({ type: AbilityDistanceType.Cube, value: 3, value2: 5 }) ],
+						distance: [ FactoryLogic.distance.create({ type: AbilityDistanceType.Cube, value: 3, within: 5 }) ],
 						target: 'Each enemy and the object in the area',
 						sections: [
 							FactoryLogic.createAbilitySectionText('Each target must make either an **Agility test** or an **Intuition test**.'),
@@ -373,7 +373,7 @@ One of the most advanced multivoks, a chief directs and coordinates other valok 
 						name: 'Build Wall',
 						type: FactoryLogic.type.createManeuver(),
 						keywords: [ AbilityKeyword.Area, AbilityKeyword.Ranged ],
-						distance: [ FactoryLogic.distance.create({ type: AbilityDistanceType.Wall, value: 6, value2: 3 }) ],
+						distance: [ FactoryLogic.distance.create({ type: AbilityDistanceType.Wall, value: 6, within: 3 }) ],
 						target: 'Special',
 						sections: [
 							FactoryLogic.createAbilitySectionText('The builder creates a concrete wall. They can also remove any unoccupied squares of wet concrete within 3 squares of them, creating two additional squares of wall for each square of concrete removed.')
@@ -461,7 +461,7 @@ One of the most advanced multivoks, a chief directs and coordinates other valok 
 						type: FactoryLogic.type.createMain(),
 						cost: 3,
 						keywords: [ AbilityKeyword.Area ],
-						distance: [ FactoryLogic.distance.create({ type: AbilityDistanceType.Cube, value: 4, value2: 1 }) ],
+						distance: [ FactoryLogic.distance.create({ type: AbilityDistanceType.Cube, value: 4, within: 1 }) ],
 						target: 'Each enemy and the object in the area',
 						sections: [
 							FactoryLogic.createAbilitySectionText('Each target makes an **Agility test**.'),

--- a/src/data/monsters/wardog.ts
+++ b/src/data/monsters/wardog.ts
@@ -2269,7 +2269,7 @@ These monstrous war dogs are developed to fulfill specific roles and combat nich
 						name: 'Siegeworks',
 						type: FactoryLogic.type.createManeuver(),
 						keywords: [ AbilityKeyword.Area, AbilityKeyword.Magic, AbilityKeyword.Ranged ],
-						distance: [ FactoryLogic.distance.create({ type: AbilityDistanceType.Wall, value: 10 }) ],
+						distance: [ FactoryLogic.distance.create({ type: AbilityDistanceType.Wall, value: 5, within: 10 }) ],
 						target: 'Special',
 						sections: [
 							FactoryLogic.createAbilitySectionText('The geomancer raises a wall of stone set with viewing gaps. Creatures have line of effect through the wall while adjacent to it.')

--- a/src/data/monsters/wardog.ts
+++ b/src/data/monsters/wardog.ts
@@ -1179,9 +1179,9 @@ These monstrous war dogs are developed to fulfill specific roles and combat nich
 						sections: [
 							FactoryLogic.createAbilitySectionRoll(FactoryLogic.createPowerRoll({
 								bonus: 3,
-								tier1: '2 damage',
-								tier2: '4 damage; push 1',
-								tier3: '6 damage; push 3'
+								tier1: '7 damage',
+								tier2: '9 damage',
+								tier3: '11 damage; A<3 bleeding (save ends)'
 							})),
 							FactoryLogic.createAbilitySectionText('This ability ignores cover and concealment. The arachnite chooses one of the following damage types when making the strike: acid, cold, fire, lightning, poison, psychic, or sonic.'),
 							FactoryLogic.createAbilitySectionSpend({
@@ -1197,7 +1197,7 @@ These monstrous war dogs are developed to fulfill specific roles and combat nich
 						name: 'Web Vial',
 						type: FactoryLogic.type.createManeuver(),
 						keywords: [ AbilityKeyword.Area, AbilityKeyword.Ranged ],
-						distance: [ FactoryLogic.distance.create({ type: AbilityDistanceType.Cube, value: 2, value2: 10 }) ],
+						distance: [ FactoryLogic.distance.create({ type: AbilityDistanceType.Cube, value: 2, within: 10 }) ],
 						target: 'Special',
 						sections: [
 							FactoryLogic.createAbilitySectionText('The area is difficult terrain until the end of the encounter.')
@@ -1956,7 +1956,7 @@ These monstrous war dogs are developed to fulfill specific roles and combat nich
 						type: FactoryLogic.type.createManeuver(),
 						cost: 2,
 						keywords: [ AbilityKeyword.Area, AbilityKeyword.Magic, AbilityKeyword.Ranged ],
-						distance: [ FactoryLogic.distance.create({ type: AbilityDistanceType.Cube, value: 5 }) ],
+						distance: [ FactoryLogic.distance.create({ type: AbilityDistanceType.Cube, value: 3, within: 5 }) ],
 						target: 'Each creature or object in the area',
 						sections: [
 							FactoryLogic.createAbilitySectionRoll(FactoryLogic.createPowerRoll({
@@ -2022,7 +2022,7 @@ These monstrous war dogs are developed to fulfill specific roles and combat nich
 						type: FactoryLogic.type.createManeuver(),
 						cost: 3,
 						keywords: [ AbilityKeyword.Area, AbilityKeyword.Magic, AbilityKeyword.Ranged ],
-						distance: [ FactoryLogic.distance.create({ type: AbilityDistanceType.Cube, value: 3, value2: 12 }) ],
+						distance: [ FactoryLogic.distance.create({ type: AbilityDistanceType.Cube, value: 3, within: 12 }) ],
 						target: 'Special',
 						sections: [
 							FactoryLogic.createAbilitySectionText('Until the start of the ballistite’s next turn, the area is difficult terrain, and any ranged ability targeting an enemy in the area deals an extra 8 damage.')
@@ -2182,7 +2182,7 @@ These monstrous war dogs are developed to fulfill specific roles and combat nich
 						type: FactoryLogic.type.createMain(),
 						cost: 'signature',
 						keywords: [ AbilityKeyword.Area, AbilityKeyword.Weapon ],
-						distance: [ FactoryLogic.distance.create({ type: AbilityDistanceType.Line, value: 1, value2: 1 }) ],
+						distance: [ FactoryLogic.distance.create({ type: AbilityDistanceType.Line, value: 1, value2: 1, within: 1 }) ],
 						target: 'Each creature and object in the area',
 						sections: [
 							FactoryLogic.createAbilitySectionRoll(FactoryLogic.createPowerRoll({
@@ -2384,7 +2384,7 @@ These monstrous war dogs are developed to fulfill specific roles and combat nich
 						name: 'Hard Light Field',
 						type: FactoryLogic.type.createManeuver(),
 						keywords: [ AbilityKeyword.Area, AbilityKeyword.Psionic, AbilityKeyword.Ranged ],
-						distance: [ FactoryLogic.distance.create({ type: AbilityDistanceType.Cube, value: 4, value2: 10 }) ],
+						distance: [ FactoryLogic.distance.create({ type: AbilityDistanceType.Cube, value: 4, within: 10 }) ],
 						target: 'Each ally in the area',
 						sections: [
 							FactoryLogic.createAbilitySectionText('Until the start of the prismite’s next turn, each target has cover and gains a +2 bonus to stability.')
@@ -2457,7 +2457,7 @@ These monstrous war dogs are developed to fulfill specific roles and combat nich
 						type: FactoryLogic.type.createManeuver(),
 						cost: 2,
 						keywords: [ AbilityKeyword.Area, AbilityKeyword.Magic, AbilityKeyword.Ranged ],
-						distance: [ FactoryLogic.distance.create({ type: AbilityDistanceType.Cube, value: 4, value2: 10 }) ],
+						distance: [ FactoryLogic.distance.create({ type: AbilityDistanceType.Cube, value: 4, within: 10 }) ],
 						target: 'Each war dog in the area',
 						sections: [
 							FactoryLogic.createAbilitySectionText('Each target shifts up to their speed and can make a free strike that deals an extra 5 lightning damage.')
@@ -2905,7 +2905,7 @@ These monstrous war dogs are developed to fulfill specific roles and combat nich
 						type: FactoryLogic.type.createMain(),
 						cost: 3,
 						keywords: [ AbilityKeyword.Area, AbilityKeyword.Magic, AbilityKeyword.Ranged ],
-						distance: [ FactoryLogic.distance.create({ type: AbilityDistanceType.Cube, value: 3, value2: 15 }) ],
+						distance: [ FactoryLogic.distance.create({ type: AbilityDistanceType.Cube, value: 3, within: 15 }) ],
 						target: 'Each creature and object in the area',
 						sections: [
 							FactoryLogic.createAbilitySectionRoll(FactoryLogic.createPowerRoll({
@@ -2924,7 +2924,7 @@ These monstrous war dogs are developed to fulfill specific roles and combat nich
 						name: 'Portal to the Void',
 						type: FactoryLogic.type.createManeuver(),
 						keywords: [ AbilityKeyword.Area, AbilityKeyword.Magic, AbilityKeyword.Ranged ],
-						distance: [ FactoryLogic.distance.create({ type: AbilityDistanceType.Cube, value: 5, value2: 15 }) ],
+						distance: [ FactoryLogic.distance.create({ type: AbilityDistanceType.Cube, value: 5, within: 15 }) ],
 						target: 'Each creature and object in the area',
 						sections: [
 							FactoryLogic.createAbilitySectionRoll(FactoryLogic.createPowerRoll({
@@ -3006,7 +3006,7 @@ These monstrous war dogs are developed to fulfill specific roles and combat nich
 						type: FactoryLogic.type.createMain(),
 						cost: 2,
 						keywords: [ AbilityKeyword.Area, AbilityKeyword.Magic, AbilityKeyword.Ranged ],
-						distance: [ FactoryLogic.distance.create({ type: AbilityDistanceType.Cube, value: 3, value2: 10 }) ],
+						distance: [ FactoryLogic.distance.create({ type: AbilityDistanceType.Cube, value: 3, within: 10 }) ],
 						target: 'Each enemy in the area',
 						sections: [
 							FactoryLogic.createAbilitySectionRoll(FactoryLogic.createPowerRoll({


### PR DESCRIPTION
1. The War Dog Arachnite signature ability power roll tiers are incorrect (they were copied from War Dog Sweeper and never changed)
2. A bunch cube and wall area abilities are incorrectly entered with 'value1' and 'value2' when they should be entered as 'value1' and 'within'. Using value2 prevents the within value from showing.
3. Some area abilities are missing 'within' attributes or are just generally entered incorrectly.