### PR TITLE
Add hero show/hide toggle button for heroes

### DIFF
--- a/src/components/main/main.tsx
+++ b/src/components/main/main.tsx
@@ -1841,7 +1841,7 @@ export const Main = (props: Props) => {
 										addHero={newHero}
 										importHero={importHero}
 										showParty={onShowParty}
-										toggleHeroAvailability={persistHero}
+										onActiveChanged={persistHero}
 									/>
 								}
 							/>
@@ -1879,7 +1879,6 @@ export const Main = (props: Props) => {
 										onAddMonsterToSquad={addMonsterToSquad}
 										onSelectControlledMonster={selectControlledMonster}
 										onSelectControlledSquad={selectControlledSquad}
-										toggleHeroAvailability={persistHero}
 									/>
 								}
 							/>

--- a/src/components/main/main.tsx
+++ b/src/components/main/main.tsx
@@ -1743,7 +1743,7 @@ export const Main = (props: Props) => {
 	const onShowParty = (folder: string) => {
 		setDrawer(
 			<PartyModal
-				heroes={heroes.filter(h => h.folder === folder)}
+				heroes={HeroLogic.getPartyHeroes(heroes, folder)}
 				sourcebooks={SourcebookLogic.getSourcebooks(homebrewSourcebooks)}
 				onClose={() => setDrawer(null)}
 			/>
@@ -1841,6 +1841,7 @@ export const Main = (props: Props) => {
 										addHero={newHero}
 										importHero={importHero}
 										showParty={onShowParty}
+										toggleHeroAvailability={persistHero}
 									/>
 								}
 							/>
@@ -1878,6 +1879,7 @@ export const Main = (props: Props) => {
 										onAddMonsterToSquad={addMonsterToSquad}
 										onSelectControlledMonster={selectControlledMonster}
 										onSelectControlledSquad={selectControlledSquad}
+										toggleHeroAvailability={persistHero}
 									/>
 								}
 							/>

--- a/src/components/modals/select/hero-select/hero-select-modal.tsx
+++ b/src/components/modals/select/hero-select/hero-select-modal.tsx
@@ -26,7 +26,8 @@ interface Props {
 export const HeroSelectModal = (props: Props) => {
 	const [ mode, setMode ] = useState<string>('folder');
 	const [ heroName, setHeroName ] = useState<string>('');
-	const heroes = useHeroes();
+	const allHeroes = useHeroes();
+	const heroes = allHeroes.filter(HeroLogic.isActive);
 
 	const getContent = () => {
 		switch (mode) {
@@ -53,7 +54,7 @@ export const HeroSelectModal = (props: Props) => {
 							folders.map(f => (
 								<SelectablePanel
 									key={f}
-									onSelect={() => props.onSelect(heroes.filter(h => h.folder === f))}
+									onSelect={() => props.onSelect(HeroLogic.getPartyHeroes(allHeroes, f))}
 								>
 									<HeaderText level={1}>{f}</HeaderText>
 									<Space orientation='vertical' style={{ width: '100%' }}>

--- a/src/components/modals/select/hero-select/hero-select-modal.tsx
+++ b/src/components/modals/select/hero-select/hero-select-modal.tsx
@@ -27,7 +27,7 @@ export const HeroSelectModal = (props: Props) => {
 	const [ mode, setMode ] = useState<string>('folder');
 	const [ heroName, setHeroName ] = useState<string>('');
 	const allHeroes = useHeroes();
-	const heroes = allHeroes.filter(HeroLogic.isActive);
+	const heroes = allHeroes.filter(h => h.isActive);
 
 	const getContent = () => {
 		switch (mode) {

--- a/src/components/pages/heroes/hero-list/hero-list-page.tsx
+++ b/src/components/pages/heroes/hero-list/hero-list-page.tsx
@@ -32,6 +32,7 @@ interface Props {
 	addHero: (folder: string) => void;
 	importHero: (hero: Hero, folder: string) => void;
 	showParty: (folder: string) => void;
+	toggleHeroAvailability: (hero: Hero) => void;
 }
 
 export const HeroListPage = (props: Props) => {
@@ -80,11 +81,33 @@ export const HeroListPage = (props: Props) => {
 		return (
 			<div className='hero-section-row'>
 				{
-					list.map(hero => (
-						<SelectablePanel key={hero.id} watermark={hero.picture || undefined} onSelect={() => navigation.goToHeroView(hero.id)}>
-							<HeroOverviewPanel hero={hero} />
-						</SelectablePanel>
-					))
+					list.map(hero => {
+						const fullHero = fullHeroes.find(h => h.id === hero.id);
+
+						return (
+							<SelectablePanel
+								key={hero.id}
+								watermark={hero.picture || undefined}
+								onSelect={() => navigation.goToHeroView(hero.id)}
+							>
+								<HeroOverviewPanel
+									hero={hero}
+									visibility={
+										fullHero ?
+											{
+												visible: !hero.isDisabled,
+												onSetVisibility: visible => {
+													const copy = Utils.copy(fullHero);
+													copy.isDisabled = !visible;
+													props.toggleHeroAvailability(copy);
+												}
+											}
+											: undefined
+									}
+								/>
+							</SelectablePanel>
+						);
+					})
 				}
 			</div>
 		);

--- a/src/components/pages/heroes/hero-list/hero-list-page.tsx
+++ b/src/components/pages/heroes/hero-list/hero-list-page.tsx
@@ -32,7 +32,7 @@ interface Props {
 	addHero: (folder: string) => void;
 	importHero: (hero: Hero, folder: string) => void;
 	showParty: (folder: string) => void;
-	toggleHeroAvailability: (hero: Hero) => void;
+	onActiveChanged: (hero: Hero) => void;
 }
 
 export const HeroListPage = (props: Props) => {
@@ -95,11 +95,11 @@ export const HeroListPage = (props: Props) => {
 									visibility={
 										fullHero ?
 											{
-												visible: !hero.isDisabled,
+												visible: hero.isActive,
 												onSetVisibility: visible => {
 													const copy = Utils.copy(fullHero);
-													copy.isDisabled = !visible;
-													props.toggleHeroAvailability(copy);
+													copy.isActive = visible;
+													props.onActiveChanged(copy);
 												}
 											}
 											: undefined

--- a/src/components/pages/heroes/hero-view/hero-view-page.tsx
+++ b/src/components/pages/heroes/hero-view/hero-view-page.tsx
@@ -1,6 +1,6 @@
 import { Alert, Button, Divider } from 'antd';
 import { AppFooter, FooterParams } from '@/components/panels/app-footer/app-footer';
-import { CloseOutlined, CopyOutlined, DeleteOutlined, EditOutlined, EyeInvisibleOutlined, EyeOutlined, UploadOutlined } from '@ant-design/icons';
+import { CloseOutlined, CopyOutlined, DeleteOutlined, EditOutlined, UploadOutlined } from '@ant-design/icons';
 import { useMemo, useState } from 'react';
 import { Ability } from '@/models/ability';
 import { Ancestry } from '@/models/ancestry';
@@ -18,7 +18,6 @@ import { Fixture } from '@/models/fixture';
 import { Follower } from '@/models/follower';
 import { Hero } from '@/models/hero';
 import { HeroClass } from '@/models/class';
-import { HeroLogic } from '@/logic/hero-logic';
 import { HeroModalType } from '@/enums/hero-modal-type';
 import { HeroPanel } from '@/components/panels/hero/hero-panel';
 import { HeroSheetPage } from '@/components/pages/heroes/hero-sheet/hero-sheet-page';
@@ -31,7 +30,6 @@ import { Sourcebook } from '@/models/sourcebook';
 import { StandardAbilitiesPage } from '@/components/pages/heroes/hero-sheet/standard-abilities-page';
 import { SummoningInfo } from '@/models/summon';
 import { Title } from '@/models/title';
-import { Utils } from '@/utils/utils';
 import { ViewSelector } from '@/components/panels/view-selector/view-selector';
 import { useHeroes } from '@/contexts/data-context';
 import { useIsSmall } from '@/hooks/use-is-small';
@@ -72,7 +70,6 @@ interface Props {
 	onAddMonsterToSquad: (hero: Hero, slotID: string) => void;
 	onSelectControlledMonster: (hero: Hero, monster: Monster) => void;
 	onSelectControlledSquad: (hero: Hero, slot: EncounterSlot) => void;
-	toggleHeroAvailability: (hero: Hero) => void;
 }
 
 export const HeroViewPage = (props: Props) => {
@@ -108,8 +105,6 @@ export const HeroViewPage = (props: Props) => {
 			</div>
 		);
 	}
-
-	const isDisabled = HeroLogic.isDisabled(hero);
 
 	const getContent = () => {
 		switch (view) {
@@ -176,16 +171,6 @@ export const HeroViewPage = (props: Props) => {
 					<ButtonGroup
 						buttons={[
 							{ type: 'button', label: isSmall ? undefined : 'Edit', icon: <EditOutlined />, onClick: () => navigation.goToHeroEdit(heroID!, 'details') },
-							{
-								type: 'button',
-								label: isSmall ? undefined : (isDisabled ? 'Show' : 'Hide'),
-								icon: isDisabled ? <EyeOutlined /> : <EyeInvisibleOutlined />,
-								onClick: () => {
-									const copy = Utils.copy(hero);
-									copy.isDisabled = !copy.isDisabled;
-									props.toggleHeroAvailability(copy);
-								}
-							},
 							{ type: 'button', label: isSmall ? undefined : 'Copy', icon: <CopyOutlined />, onClick: () => props.copyHero(hero) },
 							{
 								type: 'dropdown',

--- a/src/components/pages/heroes/hero-view/hero-view-page.tsx
+++ b/src/components/pages/heroes/hero-view/hero-view-page.tsx
@@ -1,6 +1,6 @@
 import { Alert, Button, Divider } from 'antd';
 import { AppFooter, FooterParams } from '@/components/panels/app-footer/app-footer';
-import { CloseOutlined, CopyOutlined, DeleteOutlined, EditOutlined, UploadOutlined } from '@ant-design/icons';
+import { CloseOutlined, CopyOutlined, DeleteOutlined, EditOutlined, EyeInvisibleOutlined, EyeOutlined, UploadOutlined } from '@ant-design/icons';
 import { useMemo, useState } from 'react';
 import { Ability } from '@/models/ability';
 import { Ancestry } from '@/models/ancestry';
@@ -18,6 +18,7 @@ import { Fixture } from '@/models/fixture';
 import { Follower } from '@/models/follower';
 import { Hero } from '@/models/hero';
 import { HeroClass } from '@/models/class';
+import { HeroLogic } from '@/logic/hero-logic';
 import { HeroModalType } from '@/enums/hero-modal-type';
 import { HeroPanel } from '@/components/panels/hero/hero-panel';
 import { HeroSheetPage } from '@/components/pages/heroes/hero-sheet/hero-sheet-page';
@@ -30,6 +31,7 @@ import { Sourcebook } from '@/models/sourcebook';
 import { StandardAbilitiesPage } from '@/components/pages/heroes/hero-sheet/standard-abilities-page';
 import { SummoningInfo } from '@/models/summon';
 import { Title } from '@/models/title';
+import { Utils } from '@/utils/utils';
 import { ViewSelector } from '@/components/panels/view-selector/view-selector';
 import { useHeroes } from '@/contexts/data-context';
 import { useIsSmall } from '@/hooks/use-is-small';
@@ -70,6 +72,7 @@ interface Props {
 	onAddMonsterToSquad: (hero: Hero, slotID: string) => void;
 	onSelectControlledMonster: (hero: Hero, monster: Monster) => void;
 	onSelectControlledSquad: (hero: Hero, slot: EncounterSlot) => void;
+	toggleHeroAvailability: (hero: Hero) => void;
 }
 
 export const HeroViewPage = (props: Props) => {
@@ -105,6 +108,8 @@ export const HeroViewPage = (props: Props) => {
 			</div>
 		);
 	}
+
+	const isDisabled = HeroLogic.isDisabled(hero);
 
 	const getContent = () => {
 		switch (view) {
@@ -171,6 +176,16 @@ export const HeroViewPage = (props: Props) => {
 					<ButtonGroup
 						buttons={[
 							{ type: 'button', label: isSmall ? undefined : 'Edit', icon: <EditOutlined />, onClick: () => navigation.goToHeroEdit(heroID!, 'details') },
+							{
+								type: 'button',
+								label: isSmall ? undefined : (isDisabled ? 'Show' : 'Hide'),
+								icon: isDisabled ? <EyeOutlined /> : <EyeInvisibleOutlined />,
+								onClick: () => {
+									const copy = Utils.copy(hero);
+									copy.isDisabled = !copy.isDisabled;
+									props.toggleHeroAvailability(copy);
+								}
+							},
 							{ type: 'button', label: isSmall ? undefined : 'Copy', icon: <CopyOutlined />, onClick: () => props.copyHero(hero) },
 							{
 								type: 'dropdown',

--- a/src/components/panels/hero-overview/hero-overview-panel.scss
+++ b/src/components/panels/hero-overview/hero-overview-panel.scss
@@ -3,4 +3,8 @@
 	display: flex;
 	flex-direction: column;
 	margin-top: -10px;
+
+	&.disabled {
+		opacity: 0.55;
+	}
 }

--- a/src/components/panels/hero-overview/hero-overview-panel.tsx
+++ b/src/components/panels/hero-overview/hero-overview-panel.tsx
@@ -18,7 +18,7 @@ interface Props {
 }
 
 export const HeroOverviewPanel = (props: Props) => {
-	const className = props.hero.isDisabled ? 'hero-overview-panel disabled' : 'hero-overview-panel';
+	const className = props.hero.isActive ? 'hero-overview-panel' : 'hero-overview-panel disabled';
 
 	const getButtons = () => {
 		const buttons: ReactNode[] = [];

--- a/src/components/panels/hero-overview/hero-overview-panel.tsx
+++ b/src/components/panels/hero-overview/hero-overview-panel.tsx
@@ -1,21 +1,57 @@
+import { Button, Flex } from 'antd';
+import { EyeInvisibleOutlined, EyeOutlined } from '@ant-design/icons';
 import { Field } from '@/components/controls/field/field';
 import { HeaderText } from '@/components/controls/header-text/header-text';
 import { HeroOverview } from '@/models/hero';
 import { HeroOverviewToken } from '@/components/panels/token/token';
+import { ReactNode } from 'react';
 
 import './hero-overview-panel.scss';
 
 interface Props {
 	hero: HeroOverview;
+	extra?: ReactNode;
+	visibility?: {
+		visible: boolean;
+		onSetVisibility: (value: boolean) => void;
+	};
 }
 
 export const HeroOverviewPanel = (props: Props) => {
+	const className = props.hero.isDisabled ? 'hero-overview-panel disabled' : 'hero-overview-panel';
+
+	const getButtons = () => {
+		const buttons: ReactNode[] = [];
+
+		if (props.visibility) {
+			buttons.push(
+				<Button
+					key='show-hide'
+					type='text'
+					title='Show/Hide'
+					icon={props.visibility.visible ? <EyeOutlined /> : <EyeInvisibleOutlined />}
+					onClick={e => {
+						e.stopPropagation();
+						props.visibility!.onSetVisibility(!props.visibility!.visible);
+					}}
+				/>
+			);
+		}
+
+		if (props.extra) {
+			buttons.push(props.extra);
+		}
+
+		return buttons.length > 0 ? <Flex>{buttons}</Flex> : null;
+	};
+
 	return (
-		<div className='hero-overview-panel'>
+		<div className={className}>
 			<HeaderText
 				level={1}
 				ribbon={props.hero.picture ? <HeroOverviewToken hero={props.hero} size={34} /> : null}
 				tags={props.hero.folder ? [ props.hero.folder ] : []}
+				extra={getButtons()}
 			>
 				{props.hero.name || 'Unnamed Hero'}
 			</HeaderText>

--- a/src/logic/factory-logic.ts
+++ b/src/logic/factory-logic.ts
@@ -98,7 +98,8 @@ export class FactoryLogic {
 				})
 			],
 			state: FactoryLogic.createHeroState(),
-			abilityCustomizations: []
+			abilityCustomizations: [],
+			isDisabled: false
 		};
 	};
 

--- a/src/logic/factory-logic.ts
+++ b/src/logic/factory-logic.ts
@@ -99,7 +99,7 @@ export class FactoryLogic {
 			],
 			state: FactoryLogic.createHeroState(),
 			abilityCustomizations: [],
-			isDisabled: false
+			isActive: true
 		};
 	};
 

--- a/src/logic/hero-logic.ts
+++ b/src/logic/hero-logic.ts
@@ -38,6 +38,16 @@ import { TutorialMode } from '@/enums/tutorial-mode';
 import { Utils } from '@/utils/utils';
 
 export class HeroLogic {
+	static isDisabled = (hero: Hero) => {
+		const value = (hero as unknown as { isDisabled?: boolean | string }).isDisabled;
+		return (value === true) || (value === 'true');
+	};
+
+	static isActive = (hero: Hero) => !HeroLogic.isDisabled(hero);
+
+	static getPartyHeroes = (heroes: Hero[], party: string) =>
+		heroes.filter(h => h.folder === party).filter(HeroLogic.isActive);
+
 	static getHeroDescription = (hero: Hero) => {
 		if (!hero.class || !hero.ancestry) {
 			return 'Hero';
@@ -1517,7 +1527,8 @@ export class HeroLogic {
 			class: hero.class ? `${hero.class.name} (${[ `Level ${hero.class.level}`, ...HeroLogic.getClassSpecialization(hero) ].join(' ')})` : null,
 			complication: hero.complication ? hero.complication.name : null,
 			picture: hero.picture,
-			folder: hero.folder
+			folder: hero.folder,
+			isDisabled: HeroLogic.isDisabled(hero)
 		};
 
 		return overview;

--- a/src/logic/hero-logic.ts
+++ b/src/logic/hero-logic.ts
@@ -38,15 +38,8 @@ import { TutorialMode } from '@/enums/tutorial-mode';
 import { Utils } from '@/utils/utils';
 
 export class HeroLogic {
-	static isDisabled = (hero: Hero) => {
-		const value = (hero as unknown as { isDisabled?: boolean | string }).isDisabled;
-		return (value === true) || (value === 'true');
-	};
-
-	static isActive = (hero: Hero) => !HeroLogic.isDisabled(hero);
-
 	static getPartyHeroes = (heroes: Hero[], party: string) =>
-		heroes.filter(h => h.folder === party).filter(HeroLogic.isActive);
+		heroes.filter(h => h.folder === party).filter(h => h.isActive);
 
 	static getHeroDescription = (hero: Hero) => {
 		if (!hero.class || !hero.ancestry) {
@@ -1528,7 +1521,7 @@ export class HeroLogic {
 			complication: hero.complication ? hero.complication.name : null,
 			picture: hero.picture,
 			folder: hero.folder,
-			isDisabled: HeroLogic.isDisabled(hero)
+			isActive: hero.isActive
 		};
 
 		return overview;

--- a/src/logic/options-logic.test.ts
+++ b/src/logic/options-logic.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from 'vitest';
+import { FactoryLogic } from '@/logic/factory-logic';
+import { Hero } from '@/models/hero';
+import { HeroLogic } from '@/logic/hero-logic';
+import { Options } from '@/models/options';
+import { OptionsLogic } from '@/logic/options-logic';
+
+const createPartyHero = (folder: string, level = 1, victories = 0, isDisabled = false) => {
+	const hero = FactoryLogic.createHero();
+	hero.folder = folder;
+	hero.isDisabled = isDisabled;
+	hero.class = FactoryLogic.createClass();
+	hero.class.level = level;
+	hero.state.victories = victories;
+	return hero;
+};
+
+describe('getHeroCount', () => {
+	test('returns the correct hero count when defined in options', () => {
+		const options = {
+			heroCount: 4
+		} as Options;
+
+		expect(OptionsLogic.getHeroCount(options, [])).toBe(4);
+	});
+
+	test('returns the correct hero count when a party is defined', () => {
+		const heroes: Hero[] = [
+			createPartyHero('test'),
+			createPartyHero('test'),
+			createPartyHero('test'),
+			createPartyHero('test'),
+			createPartyHero('asdf')
+		];
+		const options = {
+			heroParty: 'test'
+		} as Options;
+
+		expect(OptionsLogic.getHeroCount(options, heroes)).toBe(4);
+	});
+
+	test('excludes disabled heroes when a party is defined', () => {
+		const heroes: Hero[] = [
+			createPartyHero('party'),
+			createPartyHero('party'),
+			createPartyHero('party', 1, 0, true)
+		];
+		const options = { heroParty: 'party' } as Options;
+
+		expect(OptionsLogic.getHeroCount(options, heroes)).toBe(2);
+	});
+
+	test('treats legacy string disabled values as disabled', () => {
+		const hero = createPartyHero('party');
+		(hero as unknown as { isDisabled: string }).isDisabled = 'true';
+		const options = { heroParty: 'party' } as Options;
+
+		expect(OptionsLogic.getHeroCount(options, [ hero ])).toBe(0);
+		expect(HeroLogic.isDisabled(hero)).toBe(true);
+	});
+});
+
+describe('getHeroLevel', () => {
+	test('excludes disabled heroes when a party is defined', () => {
+		const heroes: Hero[] = [
+			createPartyHero('party', 2),
+			createPartyHero('party', 4),
+			createPartyHero('party', 10, 0, true)
+		];
+		const options = { heroParty: 'party' } as Options;
+
+		expect(OptionsLogic.getHeroLevel(options, heroes)).toBe(3);
+	});
+});
+
+describe('getHeroVictories', () => {
+	test('excludes disabled heroes when a party is defined', () => {
+		const heroes: Hero[] = [
+			createPartyHero('party', 1, 2),
+			createPartyHero('party', 1, 4),
+			createPartyHero('party', 1, 10, true)
+		];
+		const options = { heroParty: 'party' } as Options;
+
+		expect(OptionsLogic.getHeroVictories(options, heroes)).toBe(3);
+	});
+});

--- a/src/logic/options-logic.test.ts
+++ b/src/logic/options-logic.test.ts
@@ -1,14 +1,13 @@
 import { describe, expect, test } from 'vitest';
 import { FactoryLogic } from '@/logic/factory-logic';
 import { Hero } from '@/models/hero';
-import { HeroLogic } from '@/logic/hero-logic';
 import { Options } from '@/models/options';
 import { OptionsLogic } from '@/logic/options-logic';
 
-const createPartyHero = (folder: string, level = 1, victories = 0, isDisabled = false) => {
+const createPartyHero = (folder: string, level = 1, victories = 0, isActive = true) => {
 	const hero = FactoryLogic.createHero();
 	hero.folder = folder;
-	hero.isDisabled = isDisabled;
+	hero.isActive = isActive;
 	hero.class = FactoryLogic.createClass();
 	hero.class.level = level;
 	hero.state.victories = victories;
@@ -39,33 +38,24 @@ describe('getHeroCount', () => {
 		expect(OptionsLogic.getHeroCount(options, heroes)).toBe(4);
 	});
 
-	test('excludes disabled heroes when a party is defined', () => {
+	test('excludes inactive heroes when a party is defined', () => {
 		const heroes: Hero[] = [
 			createPartyHero('party'),
 			createPartyHero('party'),
-			createPartyHero('party', 1, 0, true)
+			createPartyHero('party', 1, 0, false)
 		];
 		const options = { heroParty: 'party' } as Options;
 
 		expect(OptionsLogic.getHeroCount(options, heroes)).toBe(2);
 	});
-
-	test('treats legacy string disabled values as disabled', () => {
-		const hero = createPartyHero('party');
-		(hero as unknown as { isDisabled: string }).isDisabled = 'true';
-		const options = { heroParty: 'party' } as Options;
-
-		expect(OptionsLogic.getHeroCount(options, [ hero ])).toBe(0);
-		expect(HeroLogic.isDisabled(hero)).toBe(true);
-	});
 });
 
 describe('getHeroLevel', () => {
-	test('excludes disabled heroes when a party is defined', () => {
+	test('excludes inactive heroes when a party is defined', () => {
 		const heroes: Hero[] = [
 			createPartyHero('party', 2),
 			createPartyHero('party', 4),
-			createPartyHero('party', 10, 0, true)
+			createPartyHero('party', 10, 0, false)
 		];
 		const options = { heroParty: 'party' } as Options;
 
@@ -74,11 +64,11 @@ describe('getHeroLevel', () => {
 });
 
 describe('getHeroVictories', () => {
-	test('excludes disabled heroes when a party is defined', () => {
+	test('excludes inactive heroes when a party is defined', () => {
 		const heroes: Hero[] = [
 			createPartyHero('party', 1, 2),
 			createPartyHero('party', 1, 4),
-			createPartyHero('party', 1, 10, true)
+			createPartyHero('party', 1, 10, false)
 		];
 		const options = { heroParty: 'party' } as Options;
 

--- a/src/logic/options-logic.ts
+++ b/src/logic/options-logic.ts
@@ -22,7 +22,7 @@ export class OptionsLogic {
 	static getHeroCount = (options: Options, heroes: Hero[]) => {
 		let heroCount = options.heroCount;
 		if (options.heroParty) {
-			const party = heroes.filter(h => h.folder === options.heroParty);
+			const party = HeroLogic.getPartyHeroes(heroes, options.heroParty);
 			heroCount = party.length;
 			party.forEach(h => {
 				const retainers = HeroLogic.getRetainers(h);
@@ -37,7 +37,7 @@ export class OptionsLogic {
 	static getHeroLevel = (options: Options, heroes: Hero[]) => {
 		let heroLevel = options.heroLevel;
 		if (options.heroParty) {
-			const party = heroes.filter(h => h.folder === options.heroParty);
+			const party = HeroLogic.getPartyHeroes(heroes, options.heroParty);
 			heroLevel = Math.round(Collections.mean(party, h => h.class ? h.class.level : 1));
 		}
 		return heroLevel;
@@ -46,7 +46,7 @@ export class OptionsLogic {
 	static getHeroVictories = (options: Options, heroes: Hero[]) => {
 		let heroVictories = options.heroVictories;
 		if (options.heroParty) {
-			const party = heroes.filter(h => h.folder === options.heroParty);
+			const party = HeroLogic.getPartyHeroes(heroes, options.heroParty);
 			heroVictories = Math.round(Collections.mean(party, h => h.state.victories));
 		}
 		return heroVictories;

--- a/src/logic/session-logic.test.ts
+++ b/src/logic/session-logic.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'vitest';
+import { FactoryLogic } from '@/logic/factory-logic';
+import { Hero } from '@/models/hero';
+import { Options } from '@/models/options';
+import { SessionLogic } from '@/logic/session-logic';
+
+const createPartyHero = (folder: string, isDisabled = false) => {
+	const hero = FactoryLogic.createHero();
+	hero.folder = folder;
+	hero.isDisabled = isDisabled;
+	return hero;
+};
+
+describe('startEncounter', () => {
+	test('adds only active heroes when a party is configured', () => {
+		const heroes: Hero[] = [
+			createPartyHero('party'),
+			createPartyHero('party'),
+			createPartyHero('party', true)
+		];
+		const encounter = FactoryLogic.createEncounter();
+		const options = { party: 'party' } as Options;
+
+		const started = SessionLogic.startEncounter(encounter, [], heroes, options);
+
+		expect(started.heroes).toHaveLength(2);
+	});
+
+	test('skips group monster population when active party is below minHeroCount', () => {
+		const heroes: Hero[] = [
+			createPartyHero('party'),
+			createPartyHero('party', true),
+			createPartyHero('party', true)
+		];
+		const encounter = FactoryLogic.createEncounter();
+		encounter.groups.push(FactoryLogic.createEncounterGroup());
+		encounter.groups[0].minHeroCount = 2;
+		encounter.groups[0].slots.push(FactoryLogic.createEncounterSlot('test-monster'));
+		const options = { party: 'party' } as Options;
+
+		const started = SessionLogic.startEncounter(encounter, [], heroes, options);
+
+		expect(started.groups[0].slots[0].monsters).toHaveLength(0);
+		expect(started.heroes).toHaveLength(1);
+	});
+});
+
+describe('startEncounter without party', () => {
+	test('adds no heroes when party is not configured', () => {
+		const heroes: Hero[] = [ createPartyHero('party') ];
+		const encounter = FactoryLogic.createEncounter();
+		const options = { party: '' } as Options;
+
+		const started = SessionLogic.startEncounter(encounter, [], heroes, options);
+
+		expect(started.heroes).toHaveLength(0);
+	});
+});

--- a/src/logic/session-logic.test.ts
+++ b/src/logic/session-logic.test.ts
@@ -4,10 +4,10 @@ import { Hero } from '@/models/hero';
 import { Options } from '@/models/options';
 import { SessionLogic } from '@/logic/session-logic';
 
-const createPartyHero = (folder: string, isDisabled = false) => {
+const createPartyHero = (folder: string, isActive = true) => {
 	const hero = FactoryLogic.createHero();
 	hero.folder = folder;
-	hero.isDisabled = isDisabled;
+	hero.isActive = isActive;
 	return hero;
 };
 
@@ -16,7 +16,7 @@ describe('startEncounter', () => {
 		const heroes: Hero[] = [
 			createPartyHero('party'),
 			createPartyHero('party'),
-			createPartyHero('party', true)
+			createPartyHero('party', false)
 		];
 		const encounter = FactoryLogic.createEncounter();
 		const options = { party: 'party' } as Options;
@@ -29,8 +29,8 @@ describe('startEncounter', () => {
 	test('skips group monster population when active party is below minHeroCount', () => {
 		const heroes: Hero[] = [
 			createPartyHero('party'),
-			createPartyHero('party', true),
-			createPartyHero('party', true)
+			createPartyHero('party', false),
+			createPartyHero('party', false)
 		];
 		const encounter = FactoryLogic.createEncounter();
 		encounter.groups.push(FactoryLogic.createEncounterGroup());

--- a/src/logic/session-logic.ts
+++ b/src/logic/session-logic.ts
@@ -21,11 +21,16 @@ export class SessionLogic {
 		copy.id = Utils.guid();
 		copy.round = 0;
 
+		const activeEncounterHeroes = options.party !== ''
+			? HeroLogic.getPartyHeroes(heroes, options.party)
+			: heroes.filter(HeroLogic.isActive);
+		const activeHeroCount = activeEncounterHeroes.length;
+
 		const monsterInfo: { monsterID: string, monster: Monster, name: string, count: number, added: number }[] = [];
 		copy.groups
 			.filter(g => {
-				const minHeroes = g.minHeroCount || heroes.length;
-				return heroes.length >= minHeroes;
+				const minHeroes = g.minHeroCount || activeHeroCount;
+				return activeHeroCount >= minHeroes;
 			})
 			.flatMap(g => g.slots)
 			.forEach(slot => {
@@ -50,8 +55,8 @@ export class SessionLogic {
 
 		copy.groups
 			.filter(g => {
-				const minHeroes = g.minHeroCount || heroes.length;
-				return heroes.length >= minHeroes;
+				const minHeroes = g.minHeroCount || activeHeroCount;
+				return activeHeroCount >= minHeroes;
 			})
 			.flatMap(g => g.slots)
 			.forEach(slot => {
@@ -70,8 +75,8 @@ export class SessionLogic {
 
 		copy.groups
 			.filter(g => {
-				const minHeroes = g.minHeroCount || heroes.length;
-				return heroes.length >= minHeroes;
+				const minHeroes = g.minHeroCount || activeHeroCount;
+				return activeHeroCount >= minHeroes;
 			})
 			.forEach(g => {
 				const minions = g.slots.filter(s => {
@@ -88,8 +93,7 @@ export class SessionLogic {
 			});
 
 		if (options.party !== '') {
-			heroes
-				.filter(h => h.folder === options.party)
+			activeEncounterHeroes
 				.forEach(h => {
 					h.state.controlledSlots = [];
 					HeroLogic.getCompanions(h).forEach(monster => {

--- a/src/logic/session-logic.ts
+++ b/src/logic/session-logic.ts
@@ -23,7 +23,7 @@ export class SessionLogic {
 
 		const activeEncounterHeroes = options.party !== ''
 			? HeroLogic.getPartyHeroes(heroes, options.party)
-			: heroes.filter(HeroLogic.isActive);
+			: heroes.filter(h => h.isActive);
 		const activeHeroCount = activeEncounterHeroes.length;
 
 		const monsterInfo: { monsterID: string, monster: Monster, name: string, count: number, added: number }[] = [];

--- a/src/logic/update/hero-update-logic.ts
+++ b/src/logic/update/hero-update-logic.ts
@@ -30,12 +30,16 @@ export class HeroUpdateLogic {
 			hero.folder = '';
 		}
 
-		if (hero.isDisabled === undefined) {
-			hero.isDisabled = false;
-		} else if (hero.isDisabled === 'true' as unknown as boolean) {
-			hero.isDisabled = true;
-		} else if (hero.isDisabled !== true) {
-			hero.isDisabled = false;
+		if (hero.isActive === undefined) {
+			const legacy = (hero as unknown as { isDisabled?: boolean | string }).isDisabled;
+			if (legacy !== undefined) {
+				hero.isActive = !(legacy === true || legacy === 'true');
+				delete (hero as unknown as { isDisabled?: boolean | string }).isDisabled;
+			} else {
+				hero.isActive = true;
+			}
+		} else {
+			hero.isActive = hero.isActive === true;
 		}
 
 		if (hero.sourcebookIDs === undefined) {

--- a/src/logic/update/hero-update-logic.ts
+++ b/src/logic/update/hero-update-logic.ts
@@ -30,6 +30,14 @@ export class HeroUpdateLogic {
 			hero.folder = '';
 		}
 
+		if (hero.isDisabled === undefined) {
+			hero.isDisabled = false;
+		} else if (hero.isDisabled === 'true' as unknown as boolean) {
+			hero.isDisabled = true;
+		} else if (hero.isDisabled !== true) {
+			hero.isDisabled = false;
+		}
+
 		if (hero.sourcebookIDs === undefined) {
 			hero.sourcebookIDs = SourcebookLogic.getSourcebooks()
 				.filter(sb => sb.type === SourcebookType.Official)

--- a/src/models/hero.ts
+++ b/src/models/hero.ts
@@ -35,6 +35,7 @@ export interface Hero {
 	features: Feature[];
 	state: HeroState;
 	abilityCustomizations: AbilityCustomization[];
+	isDisabled: boolean;
 }
 
 export interface HeroOverview {
@@ -46,6 +47,7 @@ export interface HeroOverview {
 	complication: string | null;
 	picture: string | null;
 	folder: string;
+	isDisabled: boolean;
 }
 
 export type HeroEditTab = 'start' | 'ancestry' | 'culture' | 'career' | 'class' | 'complication' | 'details';

--- a/src/models/hero.ts
+++ b/src/models/hero.ts
@@ -35,7 +35,7 @@ export interface Hero {
 	features: Feature[];
 	state: HeroState;
 	abilityCustomizations: AbilityCustomization[];
-	isDisabled: boolean;
+	isActive: boolean;
 }
 
 export interface HeroOverview {
@@ -47,7 +47,7 @@ export interface HeroOverview {
 	complication: string | null;
 	picture: string | null;
 	folder: string;
-	isDisabled: boolean;
+	isActive: boolean;
 }
 
 export type HeroEditTab = 'start' | 'ancestry' | 'culture' | 'career' | 'class' | 'complication' | 'details';


### PR DESCRIPTION
Add hero enable/disable so directors can temporarily exclude heroes from active play without removing them from their party folder.
- **Show/Hide toggles** — eye button on hero list cards
- **Active-only party logic** — `HeroLogic.getPartyHeroes` / `isActive` used for difficulty stats, montage thresholds, encounter start, `minHeroCount`, hero select, and party modal
- **`EncounterRewardLogic`** — present vs entire-party reward targeting (present excludes disabled; party includes disabled)

Fixes #938 

Some screenshots: 

<img width="49%" alt="image" src="https://github.com/user-attachments/assets/a83f1ed6-117e-4bea-bc5a-bb65bd012799" />

<img width="49%" alt="image" src="https://github.com/user-attachments/assets/92f3bb59-68fe-4edd-ae34-5440f6d4e6c5" />


