### PR TITLE
Show a message when a viewed hero cannot be found

### DIFF
--- a/src/components/pages/heroes/hero-view/hero-view-page.tsx
+++ b/src/components/pages/heroes/hero-view/hero-view-page.tsx
@@ -78,10 +78,31 @@ export const HeroViewPage = (props: Props) => {
 	const [ view, setView ] = useState<string>('modern');
 	const heroes = useHeroes();
 	const hero = useMemo(
-		() => heroes.find(h => h.id === heroID)!,
+		() => heroes.find(h => h.id === heroID),
 		[ heroID, heroes ]
 	);
-	useTitle(hero.name || 'Unnamed Hero');
+	useTitle(hero?.name || 'Unnamed Hero');
+
+	if (!hero) {
+		return (
+			<div className='hero-view-page'>
+				<AppHeader subheader='Hero' />
+				<ErrorBoundary>
+					<div className={isSmall ? 'hero-view-page-content compact' : 'hero-view-page-content'}>
+						<Alert
+							type='warning'
+							showIcon={true}
+							title='This hero could not be found. It may have been deleted, or the link points to a hero that only exists on another device.'
+						/>
+					</div>
+				</ErrorBoundary>
+				<AppFooter
+					page='heroes'
+					params={props.params}
+				/>
+			</div>
+		);
+	}
 
 	const getContent = () => {
 		switch (view) {


### PR DESCRIPTION
Opening a hero view link for a hero that is not in local storage (for example a shared link to someone else's sheet) crashes with `Cannot read properties of undefined (reading 'name')`. `heroes.find(...)!` returns `undefined` when there is no match, and `useTitle(hero.name ...)` then dereferences it.

This drops the non-null assertion and shows a warning when the hero cannot be found instead of crashing to a blank page.

Fixes #946.