### PR TITLE
Add visibility toggles for library item categories and library items

### DIFF
--- a/src/components/main/main.tsx
+++ b/src/components/main/main.tsx
@@ -90,6 +90,7 @@ import { Utils } from '@/utils/utils';
 import localforage from 'localforage';
 import { useErrorListener } from '@/hooks/use-error-listener';
 import { useNavigation } from '@/hooks/use-navigation';
+import { useVisibleSourcebooks } from '@/hooks/use-visible-sourcebooks';
 
 import './main.scss';
 
@@ -121,6 +122,8 @@ export const Main = (props: Props) => {
 	const heroes = useHeroes();
 	const homebrewSourcebooks = useHomebrewSourcebooks();
 	const dataManager = useDataManager();
+	const allSourcebooks = SourcebookLogic.getSourcebooks(homebrewSourcebooks);
+	const visibleSourcebooks = useVisibleSourcebooks(allSourcebooks);
 
 	const [ connectionSettings, setConnectionSettings ] = useState<ConnectionSettings>(props.connectionSettings);
 	const [ dataService, setDataService ] = useState<DataService>(props.dataService);
@@ -219,7 +222,7 @@ export const Main = (props: Props) => {
 		const hero = FactoryLogic.createHero();
 
 		hero.folder = folder;
-		hero.sourcebookIDs = SourcebookLogic.getSourcebooks(homebrewSourcebooks)
+		hero.sourcebookIDs = visibleSourcebooks
 			.filter(sb => sb.type === SourcebookType.Official)
 			.map(sb => sb.id);
 
@@ -1598,7 +1601,7 @@ export const Main = (props: Props) => {
 	};
 
 	const onSelectFeature = (feature: Feature, hero: Hero) => {
-		const sourcebooks = SourcebookLogic.getSourcebooks(homebrewSourcebooks)
+		const sourcebooks = visibleSourcebooks
 			.filter(sb => hero.sourcebookIDs.includes(sb.id));
 
 		setDrawer(
@@ -1624,7 +1627,7 @@ export const Main = (props: Props) => {
 	};
 
 	const onShowHeroState = (hero: Hero, type: HeroModalType) => {
-		const sourcebooks = SourcebookLogic.getSourcebooks(homebrewSourcebooks)
+		const sourcebooks = visibleSourcebooks
 			.filter(sb => hero.sourcebookIDs.includes(sb.id));
 
 		const takeRespite = (updatedHero: Hero) => {
@@ -1729,8 +1732,8 @@ export const Main = (props: Props) => {
 				setDrawer(
 					<HeroSettingsModal
 						hero={hero}
-						sourcebooks={sourcebooks}
-						allSourcebooks={SourcebookLogic.getSourcebooks(homebrewSourcebooks)}
+						sourcebooks={visibleSourcebooks}
+						allSourcebooks={allSourcebooks}
 						onClose={() => setDrawer(null)}
 						onImportSourcebook={persistHomebrewSourcebook}
 						onChange={persistHero}
@@ -1890,7 +1893,7 @@ export const Main = (props: Props) => {
 								path='edit/:heroID/:page'
 								element={
 									<HeroEditPage
-										sourcebooks={SourcebookLogic.getSourcebooks(homebrewSourcebooks)}
+										sourcebooks={visibleSourcebooks}
 										params={footerParams}
 										saveChanges={saveHero}
 										importSourcebook={persistHomebrewSourcebook}
@@ -1911,7 +1914,7 @@ export const Main = (props: Props) => {
 								path=':kind/:elementID?'
 								element={
 									<LibraryListPage
-										sourcebooks={SourcebookLogic.getSourcebooks(homebrewSourcebooks)}
+										sourcebooks={allSourcebooks}
 										params={footerParams}
 										showSourcebooks={showSourcebooks}
 										showMonster={monster => onSelectMonster(undefined, monster, undefined, undefined)}
@@ -1934,7 +1937,7 @@ export const Main = (props: Props) => {
 								path='edit/:kind/:sourcebookID/:elementID/:subElementID?'
 								element={
 									<LibraryEditPage
-										sourcebooks={SourcebookLogic.getSourcebooks(homebrewSourcebooks)}
+										sourcebooks={allSourcebooks}
 										params={footerParams}
 										showMonster={(monster, monsterGroup) => onSelectMonster(undefined, monster, monsterGroup, undefined)}
 										showTerrain={onSelectTerrain}
@@ -1946,7 +1949,7 @@ export const Main = (props: Props) => {
 								path='print/:kind/:sourcebookID/:elementID'
 								element={
 									<LibraryPrintPage
-										sourcebooks={SourcebookLogic.getSourcebooks(homebrewSourcebooks)}
+										sourcebooks={allSourcebooks}
 									/>
 								}
 							/>
@@ -1960,7 +1963,7 @@ export const Main = (props: Props) => {
 								path='director'
 								element={
 									<SessionDirectorPage
-										sourcebooks={SourcebookLogic.getSourcebooks(homebrewSourcebooks)}
+										sourcebooks={allSourcebooks}
 										params={footerParams}
 										showPlayerView={showPlayerView}
 										startEncounter={startEncounter}
@@ -1983,7 +1986,7 @@ export const Main = (props: Props) => {
 								path='player'
 								element={
 									<SessionPlayerPage
-										sourcebooks={SourcebookLogic.getSourcebooks(homebrewSourcebooks)}
+										sourcebooks={allSourcebooks}
 										params={footerParams}
 									/>
 								}

--- a/src/components/modals/settings/settings-modal.tsx
+++ b/src/components/modals/settings/settings-modal.tsx
@@ -96,6 +96,30 @@ export const SettingsModal = (props: Props) => {
 		);
 	};
 
+	const getLibrary = () => {
+		const setShowHiddenLibraryItems = (value: boolean) => {
+			const copy = Utils.copy(options);
+			copy.showHiddenLibraryItems = value;
+			setOptions(copy);
+			saveOptions(copy);
+		};
+
+		return (
+			<Expander title='Library'>
+				<Space orientation='vertical' style={{ width: '100%' }}>
+					<Toggle
+						label='Display all hidden library items'
+						value={options.showHiddenLibraryItems}
+						onChange={setShowHiddenLibraryItems}
+					/>
+					<div className='ds-text'>
+						Hidden library items can be shown again here, or by re-toggling their sourcebook visibility.
+					</div>
+				</Space>
+			</Expander>
+		);
+	};
+
 	const getHeroesGeneral = () => {
 		const setXPPerLevel = (value: number) => {
 			const copy = Utils.copy(options);
@@ -749,6 +773,7 @@ export const SettingsModal = (props: Props) => {
 						{getDifficulty()}
 						{getTacticalMaps()}
 						{getHomebrewing()}
+						{getLibrary()}
 						{getConnections()}
 					</Space>
 				);

--- a/src/components/modals/sourcebooks/sourcebooks-modal.tsx
+++ b/src/components/modals/sourcebooks/sourcebooks-modal.tsx
@@ -1,6 +1,6 @@
 import { Button, Drawer, Flex, Segmented, Space, Upload } from 'antd';
 import { DownloadOutlined, PlusOutlined } from '@ant-design/icons';
-import { useDataManager, useHiddenSourcebookIDs } from '@/contexts/data-context';
+import { useDataManager, useHiddenElementIDs, useHiddenSourcebookIDs } from '@/contexts/data-context';
 import { Collections } from '@/utils/collections';
 import { Empty } from '@/components/controls/empty/empty';
 import { FactoryLogic } from '@/logic/factory-logic';
@@ -15,6 +15,7 @@ import { SourcebookPanel } from '@/components/panels/elements/sourcebook-panel/s
 import { SourcebookType } from '@/enums/sourcebook-type';
 import { UpdateLogic } from '@/logic/update/update-logic';
 import { Utils } from '@/utils/utils';
+import { VisibilityLogic } from '@/logic/visibility-logic';
 import { useState } from 'react';
 
 import './sourcebooks-modal.scss';
@@ -32,10 +33,15 @@ export const SourcebooksModal = (props: Props) => {
 	const [ selectedSourcebook, setSelectedSourcebook ] = useState<Sourcebook | null>(null);
 	const [ homebrewSourcebooks, setHomebrewSourcebooks ] = useState<Sourcebook[]>(Utils.copy(props.homebrewSourcebooks));
 	const [ hiddenSourcebookIDs, setHiddenSourcebookIDs ] = useState<string[]>(Utils.copy(useHiddenSourcebookIDs()));
+	const [ hiddenElementIDs, setHiddenElementIDs ] = useState<string[]>(Utils.copy(useHiddenElementIDs()));
 
 	const dataManager = useDataManager();
 
 	const setVisibility = (sourcebook: Sourcebook, visible: boolean) => {
+		const clearedElementIDs = VisibilityLogic.clearHiddenForSourcebook(hiddenElementIDs, sourcebook);
+		setHiddenElementIDs(clearedElementIDs);
+		dataManager.saveHiddenElementIDs(clearedElementIDs);
+
 		if (visible) {
 			const copy = Utils.copy(hiddenSourcebookIDs.filter(id => id !== sourcebook.id));
 			setHiddenSourcebookIDs(copy);

--- a/src/components/pages/library/library-list/library-list-page.tsx
+++ b/src/components/pages/library/library-list/library-list-page.tsx
@@ -1,6 +1,6 @@
 import { Alert, Button, Divider, Flex, Segmented } from 'antd';
 import { AppFooter, FooterParams } from '@/components/panels/app-footer/app-footer';
-import { ArrowRightOutlined, CopyOutlined, DoubleLeftOutlined, DoubleRightOutlined, EditOutlined, FilterFilled, FilterOutlined, PlayCircleOutlined, UploadOutlined } from '@ant-design/icons';
+import { ArrowRightOutlined, CopyOutlined, DoubleLeftOutlined, DoubleRightOutlined, EditOutlined, EyeInvisibleOutlined, EyeOutlined, FilterFilled, FilterOutlined, PlayCircleOutlined, UploadOutlined } from '@ant-design/icons';
 import { ButtonConfig, ButtonGroup, DangerConfig, DropdownConfig } from '@/components/controls/button-group/button-group';
 import { ReactNode, useState } from 'react';
 import { Sourcebook, SourcebookElementKind } from '@/models/sourcebook';
@@ -72,9 +72,13 @@ import { Title } from '@/models/title';
 import { TitlePanel } from '@/components/panels/elements/title-panel/title-panel';
 import { Toggle } from '@/components/controls/toggle/toggle';
 import { ViewSelector } from '@/components/panels/view-selector/view-selector';
+import { VisibilityLogic } from '@/logic/visibility-logic';
+import { useDataManager } from '@/contexts/data-context';
+import { useHiddenElementIDs } from '@/contexts/data-context';
 import { useHiddenSourcebookIDs } from '@/contexts/data-context';
 import { useIsSmall } from '@/hooks/use-is-small';
 import { useNavigation } from '@/hooks/use-navigation';
+import { useOptions } from '@/contexts/data-context';
 import { useParams } from 'react-router';
 import { useTitle } from '@/hooks/use-title';
 
@@ -119,6 +123,57 @@ export const LibraryListPage = (props: Props) => {
 	const [ monsterFilter, setMonsterFilter ] = useState<MonsterFilter>(FactoryLogic.createMonsterFilter());
 	const [ sourcebookID, setSourcebookID ] = useState<string>(props.sourcebooks.filter(sb => sb.type === SourcebookType.Homebrew).length > 0 ? Collections.sort(props.sourcebooks, sb => sb.name).filter(sb => sb.type === SourcebookType.Homebrew)[0].id : '');
 	const hiddenSourcebookIDs = useHiddenSourcebookIDs();
+	const hiddenElementIDs = useHiddenElementIDs();
+	const dataManager = useDataManager();
+	const options = useOptions();
+	const visibleSourcebooks = VisibilityLogic.getVisibleSourcebooks(
+		props.sourcebooks,
+		hiddenSourcebookIDs,
+		options.showHiddenLibraryItems ? [] : hiddenElementIDs
+	);
+
+	const toggleElementVisibility = (elementID: string) => {
+		const copy = hiddenElementIDs.includes(elementID)
+			? VisibilityLogic.showElement(hiddenElementIDs, elementID)
+			: VisibilityLogic.hideElement(hiddenElementIDs, elementID);
+		dataManager.saveHiddenElementIDs(copy);
+	};
+
+	const toggleCategoryVisibility = (kind: SourcebookElementKind) => {
+		const activeSourcebooks = props.sourcebooks.filter(sb => !hiddenSourcebookIDs.includes(sb.id));
+		const copy = VisibilityLogic.toggleCategoryHidden(hiddenElementIDs, activeSourcebooks, kind, {
+			showMonsters,
+			includeCulturesFromAncestries: showCulturesFromAncestries,
+			includeSubclassesFromClasses: showSubclassesFromClasses,
+			includeProjectsFromImbuements: showProjectsFromImbuements,
+			includeProjectsFromItems: showProjectsFromItems
+		});
+		dataManager.saveHiddenElementIDs(copy);
+	};
+
+	const createVisibilityEye = (elementID: string | null, title: string, onClick: () => void) => {
+		const isHidden = !!elementID && hiddenElementIDs.includes(elementID);
+		return (
+			<span
+				title={title}
+				role='button'
+				tabIndex={0}
+				onClick={e => {
+					e.stopPropagation();
+					onClick();
+				}}
+				onKeyDown={e => {
+					if (e.key === 'Enter' || e.key === ' ') {
+						e.preventDefault();
+						e.stopPropagation();
+						onClick();
+					}
+				}}
+			>
+				{isHidden ? <EyeInvisibleOutlined /> : <EyeOutlined />}
+			</span>
+		);
+	};
 	useTitle('Library');
 
 	if (kind !== previousCategory) {
@@ -136,7 +191,7 @@ export const LibraryListPage = (props: Props) => {
 		let list: Element[] = [];
 
 		const getSourcebooks = () => {
-			return props.sourcebooks.filter(sb => !hiddenSourcebookIDs.includes(sb.id));
+			return visibleSourcebooks;
 		};
 
 		switch (type) {
@@ -411,12 +466,18 @@ export const LibraryListPage = (props: Props) => {
 				const items = getList(category).filter(item => LibraryLogic.getGroupHeader(item, category, props.sourcebooks) === header);
 
 				items.forEach(a => {
+					const isHidden = hiddenElementIDs.includes(a.id);
 					listItems.push(
 						<SelectorRow
 							key={a.id}
 							selected={selectedID === a.id}
-							content={(category === 'monster-group') && showMonsters ? <MonsterInfo monster={a as Monster} /> : a.name || `Unnamed ${Format.capitalize(category.split('-').join(' '))}`}
+							content={
+								<span style={isHidden && options.showHiddenLibraryItems ? { opacity: 0.5 } : undefined}>
+									{(category === 'monster-group') && showMonsters ? <MonsterInfo monster={a as Monster} /> : a.name || `Unnamed ${Format.capitalize(category.split('-').join(' '))}`}
+								</span>
+							}
 							info={LibraryLogic.getInfo(a, category, showMonsters)}
+							hoverInfo={createVisibilityEye(a.id, 'Show / hide this item only. Hidden items can be shown again via Settings › Library, or by re-toggling their source.', () => toggleElementVisibility(a.id))}
 							onSelect={() => {
 								if (isSmall) {
 									setShowSidebar(false);
@@ -545,9 +606,27 @@ export const LibraryListPage = (props: Props) => {
 						<div className='selection-content'>
 							<div className='selection-list'>
 								<HeaderText level={3}>For Players</HeaderText>
-								{playerCategories.map(c => <SelectorRow key={c.kind} selected={category === c.kind} content={c.label} info={getList(c.kind).length} onSelect={() => navigation.goToLibrary(c.kind)} />)}
+								{playerCategories.map(c => (
+									<SelectorRow
+										key={c.kind}
+										selected={category === c.kind}
+										content={c.label}
+										info={getList(c.kind).length}
+										hoverInfo={createVisibilityEye(null, 'Show / hide all items in this category for currently visible sources. Hidden items can be shown again via Settings › Library, or by re-toggling their source.', () => toggleCategoryVisibility(c.kind))}
+										onSelect={() => navigation.goToLibrary(c.kind)}
+									/>
+								))}
 								<HeaderText level={3}>For Directors</HeaderText>
-								{directorCategories.map(c => <SelectorRow key={c.kind} selected={category === c.kind} content={c.label} info={getList(c.kind).length} onSelect={() => navigation.goToLibrary(c.kind)} />)}
+								{directorCategories.map(c => (
+									<SelectorRow
+										key={c.kind}
+										selected={category === c.kind}
+										content={c.label}
+										info={getList(c.kind).length}
+										hoverInfo={createVisibilityEye(null, 'Show / hide all items in this category for currently visible sources. Hidden items can be shown again via Settings › Library, or by re-toggling their source.', () => toggleCategoryVisibility(c.kind))}
+										onSelect={() => navigation.goToLibrary(c.kind)}
+									/>
+								))}
 							</div>
 							<div className='selection-list'>
 								{getElementListHeader()}

--- a/src/components/panels/data-loader/data-loader.tsx
+++ b/src/components/panels/data-loader/data-loader.tsx
@@ -30,6 +30,7 @@ export interface LoadedData {
 	heroes: Hero[];
 	homebrewSourcebooks: Sourcebook[];
 	hiddenSourcebookIDs: string[];
+	hiddenElementIDs: string[];
 	session: Session;
 	options: Options;
 };
@@ -48,6 +49,7 @@ export const DataLoader = (props: Props) => {
 	const [ optionsState, setOptionsState ] = useState<LoadingStatus>(undefined);
 	const [ sessionState, setSessionState ] = useState<LoadingStatus>(undefined);
 	const [ hiddenSourcebookIDsState, setHiddenSourcebookIDsState ] = useState<LoadingStatus>(undefined);
+	const [ hiddenElementIDsState, setHiddenElementIDsState ] = useState<LoadingStatus>(undefined);
 	const [ overallLoadState, setOverallLoadState ] = useState<LoadingStatus>('pending');
 	const [ connectionSettings, setConnectionSettings ] = useState<ConnectionSettings | null>(null);
 	const [ dataSource, setDataSource ] = useState<FSDataSource>(undefined);
@@ -167,6 +169,7 @@ export const DataLoader = (props: Props) => {
 		setSessionState(undefined);
 		setOptionsState(undefined);
 		setHiddenSourcebookIDsState(undefined);
+		setHiddenElementIDsState(undefined);
 
 		initializeConnectionSettings().then(settings => {
 			setConnectionSettings(settings);
@@ -178,6 +181,7 @@ export const DataLoader = (props: Props) => {
 				setSessionState('pending');
 				setOptionsState('pending');
 				setHiddenSourcebookIDsState('pending');
+				setHiddenElementIDsState('pending');
 
 				const promises = [
 					updateLoadingStatus(
@@ -187,6 +191,7 @@ export const DataLoader = (props: Props) => {
 					),
 					updateLoadingStatus(getHeroes(dataService, settings.dataSource), setHeroesState),
 					updateLoadingStatus(dataService.getHiddenSourcebookIDs(), setHiddenSourcebookIDsState),
+					updateLoadingStatus(dataService.getHiddenElementIDs(), setHiddenElementIDsState),
 					updateLoadingStatus(dataService.getSession(), setSessionState),
 					updateLoadingStatus(dataService.getOptions(), setOptionsState)
 				];
@@ -211,11 +216,12 @@ export const DataLoader = (props: Props) => {
 					});
 
 					const hiddenSourcebookIDs = results[2] as string[];
+					const hiddenElementIDs = results[3] as string[];
 
-					const session = results[3] as Session;
+					const session = results[4] as Session;
 					UpdateLogic.updateSession(session);
 
-					const options = results[4] as Options;
+					const options = results[5] as Options;
 					UpdateLogic.updateOptions(options);
 					if (isSmall) {
 						options.compactView = true;
@@ -229,6 +235,7 @@ export const DataLoader = (props: Props) => {
 						heroes: heroes,
 						homebrewSourcebooks: sourcebooks,
 						hiddenSourcebookIDs: hiddenSourcebookIDs,
+						hiddenElementIDs: hiddenElementIDs,
 						session: session,
 						options: options
 					});
@@ -278,6 +285,7 @@ export const DataLoader = (props: Props) => {
 						<CheckLabel state={sessionState}>Session</CheckLabel>
 						<CheckLabel state={optionsState}>Options</CheckLabel>
 						<CheckLabel state={hiddenSourcebookIDsState}>Manifold</CheckLabel>
+						<CheckLabel state={hiddenElementIDsState}>Hidden Items</CheckLabel>
 					</Flex>
 					{
 						error ?

--- a/src/components/panels/edit/encounter-edit/encounter-edit-panel.tsx
+++ b/src/components/panels/edit/encounter-edit/encounter-edit-panel.tsx
@@ -44,6 +44,7 @@ import { TerrainLogic } from '@/logic/terrain-logic';
 import { TextInput } from '@/components/controls/text-input/text-input';
 import { Toggle } from '@/components/controls/toggle/toggle';
 import { Utils } from '@/utils/utils';
+import { useVisibleSourcebooks } from '@/hooks/use-visible-sourcebooks';
 
 import './encounter-edit-panel.scss';
 
@@ -66,6 +67,7 @@ export const EncounterEditPanel = (props: Props) => {
 	const [ draggedTerrain, setDraggedTerrain ] = useState<Terrain | null>(null);
 	const options = useOptions();
 	const heroes = useHeroes();
+	const pickerSourcebooks = useVisibleSourcebooks(props.sourcebooks);
 
 	const switchLeftTab = (key: string) => {
 		setActiveLeftTabKey(key);
@@ -573,7 +575,7 @@ ${value.victories}`
 	};
 
 	const getMonsterListSection = () => {
-		const groups = Collections.sort(props.sourcebooks.flatMap(sb => sb.monsterGroups).filter(g => g.monsters.some(m => (m.role.organization !== MonsterOrganizationType.Retainer) && MonsterLogic.matches(m, monsterFilter))), g => g.name);
+		const groups = Collections.sort(pickerSourcebooks.flatMap(sb => sb.monsterGroups).filter(g => g.monsters.some(m => (m.role.organization !== MonsterOrganizationType.Retainer) && MonsterLogic.matches(m, monsterFilter))), g => g.name);
 
 		return (
 			<Space orientation='vertical' style={{ width: '100%', padding: '5px' }}>
@@ -582,7 +584,7 @@ ${value.victories}`
 						<>
 							<MonsterFilterPanel
 								monsterFilter={monsterFilter}
-								monsters={props.sourcebooks.flatMap(sb => sb.monsterGroups).flatMap(g => g.monsters)}
+								monsters={pickerSourcebooks.flatMap(sb => sb.monsterGroups).flatMap(g => g.monsters)}
 								includeNameFilter={true}
 								includeOrgFilter={true}
 								includeEVFilter={true}
@@ -601,7 +603,7 @@ ${value.victories}`
 										<MonsterListItem
 											key={m.id}
 											monster={m}
-											monsterGroup={SourcebookLogic.getMonsterGroup(props.sourcebooks, m.id) as MonsterGroup}
+											monsterGroup={SourcebookLogic.getMonsterGroup(pickerSourcebooks, m.id) as MonsterGroup}
 											encounter={encounter}
 											addMonster={addMonster}
 											showMonster={props.showMonster}
@@ -622,7 +624,7 @@ ${value.victories}`
 	};
 
 	const getTerrainListSection = () => {
-		const allTerrains = SourcebookLogic.getTerrains(props.sourcebooks);
+		const allTerrains = SourcebookLogic.getTerrains(pickerSourcebooks);
 		const terrains = Collections.sort(allTerrains.filter(m => TerrainLogic.matches(m, terrainFilter)), t => t.name);
 
 		return (

--- a/src/components/panels/elements/sourcebook-panel/sourcebook-panel.tsx
+++ b/src/components/panels/elements/sourcebook-panel/sourcebook-panel.tsx
@@ -364,7 +364,7 @@ export const SourcebookPanel = (props: Props) => {
 				<Button
 					key='show-hide'
 					type='text'
-					title='Show / Hide'
+					title='Show / hide this sourcebook. Toggling also resets its library items so their visibility matches the source.'
 					icon={props.visibility.visible ? <EyeOutlined /> : <EyeInvisibleOutlined />}
 					onClick={e => {
 						e.stopPropagation();

--- a/src/components/panels/selector-row/selector-row.scss
+++ b/src/components/panels/selector-row/selector-row.scss
@@ -6,9 +6,26 @@
 	border-radius: 5px;
 	padding: 4px 8px;
 	cursor: pointer;
+	position: relative;
 
 	&:hover {
 		background-color: rgba(5, 5, 5, 0.06);
+
+		.info.has-hover-info.has-default-info {
+			.info-default {
+				display: none;
+			}
+
+			.info-hover {
+				display: flex;
+			}
+		}
+
+		.info.has-hover-info.hover-only {
+			.info-hover {
+				display: flex;
+			}
+		}
 	}
 
 	&.selected {
@@ -22,7 +39,39 @@
 	.info {
 		text-align: right;
 		font-size: 12px;
-		opacity: 0.5;
+		display: flex;
+		align-items: center;
+		justify-content: flex-end;
+
+		.info-default {
+			opacity: 0.5;
+		}
+
+		.info-hover {
+			display: none;
+			align-items: center;
+			justify-content: center;
+			color: rgba(0, 0, 0, 0.65);
+			font-size: 12px;
+			line-height: 1;
+			cursor: pointer;
+
+			.anticon {
+				font-size: 12px;
+			}
+		}
+
+		&.hover-only {
+			position: absolute;
+			right: 8px;
+			top: 50%;
+			transform: translateY(-50%);
+			pointer-events: none;
+
+			.info-hover {
+				pointer-events: auto;
+			}
+		}
 	}
 }
 
@@ -32,6 +81,10 @@ html[data-theme="dark"] {
 
 		&.selected {
 			background-color: rgb(55, 55, 55);
+		}
+
+		.info .info-hover {
+			color: rgba(255, 255, 255, 0.85);
 		}
 	}
 }

--- a/src/components/panels/selector-row/selector-row.tsx
+++ b/src/components/panels/selector-row/selector-row.tsx
@@ -6,16 +6,32 @@ import './selector-row.scss';
 interface Props {
 	content: ReactNode;
 	info?: ReactNode;
+	hoverInfo?: ReactNode;
 	selected: boolean;
 	onSelect: () => void;
 }
 
 export const SelectorRow = (props: Props) => {
+	const hasHoverInfo = !!props.hoverInfo;
+	const hasInfo = props.info !== undefined && props.info !== null && props.info !== '';
+
 	return (
 		<div className={props.selected ? 'selector-row selected' : 'selector-row'} onClick={() => props.onSelect()}>
 			<Flex align='center' justify='space-between' gap={5}>
 				<div className='content'>{props.content}</div>
-				{props.info ? <div className='info'>{props.info}</div> : null}
+				{
+					hasInfo || hasHoverInfo ?
+						<div className={[
+							'info',
+							hasHoverInfo ? 'has-hover-info' : '',
+							hasInfo ? 'has-default-info' : 'hover-only'
+						].filter(Boolean).join(' ')}
+						>
+							{hasInfo ? <div className='info-default'>{props.info}</div> : null}
+							{hasHoverInfo ? <div className='info-hover'>{props.hoverInfo}</div> : null}
+						</div>
+						: null
+				}
 			</Flex>
 		</div>
 	);

--- a/src/contexts/data-context.tsx
+++ b/src/contexts/data-context.tsx
@@ -12,6 +12,7 @@ interface DataManagerDispatchers {
 	options: ActionDispatch<[ReducerAction<Options>]>;
 	session: ActionDispatch<[ReducerAction<Session>]>;
 	hiddenSourcebooks: ActionDispatch<[ReducerAction<string[]>]>;
+	hiddenElements: ActionDispatch<[ReducerAction<string[]>]>;
 	hero: ActionDispatch<[ReducerAction<Hero>]>;
 	sourcebooks: ActionDispatch<[ReducerAction<Sourcebook>]>;
 }
@@ -21,6 +22,7 @@ export class DataManager {
 	private readonly optionsDispatch: ActionDispatch<[ReducerAction<Options>]>;
 	private readonly sessionDispatch: ActionDispatch<[ReducerAction<Session>]>;
 	private readonly hiddenSourcebooksDispatch:	ActionDispatch<[ReducerAction<string[]>]>;
+	private readonly hiddenElementsDispatch: ActionDispatch<[ReducerAction<string[]>]>;
 	private readonly heroDispatch: ActionDispatch<[ReducerAction<Hero>]>;
 	private readonly sourcebookDispatch: ActionDispatch<[ReducerAction<Sourcebook>]>;
 
@@ -29,6 +31,7 @@ export class DataManager {
 		this.optionsDispatch = dispatchers.options;
 		this.sessionDispatch = dispatchers.session;
 		this.hiddenSourcebooksDispatch = dispatchers.hiddenSourcebooks;
+		this.hiddenElementsDispatch = dispatchers.hiddenElements;
 		this.heroDispatch = dispatchers.hero;
 		this.sourcebookDispatch = dispatchers.sourcebooks;
 	};
@@ -57,6 +60,16 @@ export class DataManager {
 		return this.dataService.saveHiddenSourcebookIDs(hiddenSourcebookIDs)
 			.then(ids => {
 				this.hiddenSourcebooksDispatch({
+					type: ReducerActionKind.UPDATE,
+					payload: ids
+				});
+			});
+	}
+
+	async saveHiddenElementIDs(hiddenElementIDs: string[]) {
+		return this.dataService.saveHiddenElementIDs(hiddenElementIDs)
+			.then(ids => {
+				this.hiddenElementsDispatch({
 					type: ReducerActionKind.UPDATE,
 					payload: ids
 				});
@@ -119,12 +132,14 @@ interface DataManagerProps {
 	initialOptions: Options;
 	initialSession: Session;
 	initialHiddenSourcebookIDs: string[];
+	initialHiddenElementIDs: string[];
 	initialHeroes: Hero[];
 	initialHomebrewSourcebooks: Sourcebook[];
 }
 
 export const OptionsContext = createContext<Options | null>(null);
 export const HiddenSourcebookIDsContext = createContext<string[] | null>(null);
+export const HiddenElementIDsContext = createContext<string[] | null>(null);
 export const SessionContext = createContext<Session | null>(null);
 export const HeroesContext = createContext<Hero[] | null>(null);
 export const HomebrewSourcebooksContext = createContext<Sourcebook[] | null>(null);
@@ -135,6 +150,7 @@ export function DataManagerProvider(props: PropsWithChildren<DataManagerProps>) 
 	const [ options, optionsDispatch ] = useReducer(UpdateOnlyReducer<Options>, props.initialOptions);
 	const [ session, sessionDispatch ] = useReducer(UpdateOnlyReducer<Session>, props.initialSession);
 	const [ hiddenSourcebookIDs, hiddenSourcebookIDsDispatch ] = useReducer(UpdateOnlyReducer<string[]>, props.initialHiddenSourcebookIDs);
+	const [ hiddenElementIDs, hiddenElementIDsDispatch ] = useReducer(UpdateOnlyReducer<string[]>, props.initialHiddenElementIDs);
 	const [ heroes, heroDispatch ] = useReducer(HeroesReducer, props.initialHeroes);
 	const [ sourcebooks, sourcebookDispatch ] = useReducer(SourcebooksReducer, props.initialHomebrewSourcebooks);
 
@@ -142,6 +158,7 @@ export function DataManagerProvider(props: PropsWithChildren<DataManagerProps>) 
 		options: optionsDispatch,
 		session: sessionDispatch,
 		hiddenSourcebooks: hiddenSourcebookIDsDispatch,
+		hiddenElements: hiddenElementIDsDispatch,
 		hero: heroDispatch,
 		sourcebooks: sourcebookDispatch
 	});
@@ -220,11 +237,13 @@ export function DataManagerProvider(props: PropsWithChildren<DataManagerProps>) 
 			<OptionsContext value={options}>
 				<SessionContext value={session}>
 					<HiddenSourcebookIDsContext value={hiddenSourcebookIDs}>
-						<HomebrewSourcebooksContext value={sourcebooks}>
-							<HeroesContext value={heroes}>
-								{props.children}
-							</HeroesContext>
-						</HomebrewSourcebooksContext>
+						<HiddenElementIDsContext value={hiddenElementIDs}>
+							<HomebrewSourcebooksContext value={sourcebooks}>
+								<HeroesContext value={heroes}>
+									{props.children}
+								</HeroesContext>
+							</HomebrewSourcebooksContext>
+						</HiddenElementIDsContext>
 					</HiddenSourcebookIDsContext>
 				</SessionContext>
 			</OptionsContext>
@@ -262,6 +281,14 @@ export function useHiddenSourcebookIDs() {
 	const context = useContext(HiddenSourcebookIDsContext);
 	if (!context) {
 		throw new Error('useHiddenSourcebookIDs may only be used within <HiddenSourcebookIDsContext>');
+	}
+	return context;
+}
+
+export function useHiddenElementIDs() {
+	const context = useContext(HiddenElementIDsContext);
+	if (!context) {
+		throw new Error('useHiddenElementIDs may only be used within <HiddenElementIDsContext>');
 	}
 	return context;
 }

--- a/src/hooks/use-visible-sourcebooks.ts
+++ b/src/hooks/use-visible-sourcebooks.ts
@@ -1,0 +1,13 @@
+import { useHiddenElementIDs, useHiddenSourcebookIDs, useHomebrewSourcebooks } from '@/contexts/data-context';
+import { Sourcebook } from '@/models/sourcebook';
+import { SourcebookLogic } from '@/logic/sourcebook-logic';
+import { VisibilityLogic } from '@/logic/visibility-logic';
+
+export const useVisibleSourcebooks = (sourcebooks?: Sourcebook[]) => {
+	const homebrewSourcebooks = useHomebrewSourcebooks();
+	const hiddenSourcebookIDs = useHiddenSourcebookIDs();
+	const hiddenElementIDs = useHiddenElementIDs();
+	const allSourcebooks = sourcebooks ?? SourcebookLogic.getSourcebooks(homebrewSourcebooks);
+
+	return VisibilityLogic.getVisibleSourcebooks(allSourcebooks, hiddenSourcebookIDs, hiddenElementIDs);
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -36,6 +36,7 @@ root.render(
 										initialHeroes={data.heroes}
 										initialHomebrewSourcebooks={data.homebrewSourcebooks}
 										initialHiddenSourcebookIDs={data.hiddenSourcebookIDs}
+										initialHiddenElementIDs={data.hiddenElementIDs}
 									>
 										<Main
 											connectionSettings={data.connectionSettings}

--- a/src/logic/factory-logic.ts
+++ b/src/logic/factory-logic.ts
@@ -1048,6 +1048,7 @@ export class FactoryLogic {
 			// App
 			cookieConsent: false,
 			showDataSource: false,
+			showHiddenLibraryItems: false,
 			// Hero
 			shownStandardAbilities: [],
 			xpPerLevel: 16,

--- a/src/logic/update/update-logic.ts
+++ b/src/logic/update/update-logic.ts
@@ -647,6 +647,10 @@ ${encounter.objective.victories}`
 			options.showDataSource = false;
 		}
 
+		if (options.showHiddenLibraryItems === undefined) {
+			options.showHiddenLibraryItems = false;
+		}
+
 		if (options.xpPerLevel === undefined) {
 			options.xpPerLevel = 16;
 		}

--- a/src/logic/visibility-logic.test.ts
+++ b/src/logic/visibility-logic.test.ts
@@ -1,0 +1,348 @@
+import { describe, expect, test } from 'vitest';
+import { FactoryLogic } from '@/logic/factory-logic';
+import { MonsterOrganizationType } from '@/enums/monster-organization-type';
+import { MonsterRoleType } from '@/enums/monster-role-type';
+import { Sourcebook } from '@/models/sourcebook';
+import { VisibilityLogic } from '@/logic/visibility-logic';
+
+const createTestMonster = (id: string, name: string) => {
+	return FactoryLogic.createMonster({
+		id,
+		name,
+		level: 1,
+		role: FactoryLogic.createMonsterRole(MonsterOrganizationType.Platoon, MonsterRoleType.Ambusher),
+		keywords: [],
+		encounterValue: 1,
+		size: FactoryLogic.createSize(1),
+		speed: FactoryLogic.createSpeed(5),
+		stamina: 10,
+		stability: 0,
+		freeStrikeDamage: 1,
+		characteristics: FactoryLogic.createCharacteristics(0, 0, 0, 0, 0),
+		features: []
+	});
+};
+
+const createAncestry = (id: string, name: string) => {
+	const ancestry = FactoryLogic.createAncestry();
+	ancestry.id = id;
+	ancestry.name = name;
+	return ancestry;
+};
+
+const createSourcebookWithAncestries = (id: string, ancestries: { id: string, name: string }[]): Sourcebook => {
+	const sourcebook = FactoryLogic.createSourcebook();
+	sourcebook.id = id;
+	sourcebook.name = id;
+	sourcebook.ancestries = ancestries.map(a => createAncestry(a.id, a.name));
+	return sourcebook;
+};
+
+describe('VisibilityLogic', () => {
+	describe('single item hide / show', () => {
+		test('hideElement adds an id once', () => {
+			expect(VisibilityLogic.hideElement([], 'devil')).toEqual([ 'devil' ]);
+			expect(VisibilityLogic.hideElement([ 'devil' ], 'devil')).toEqual([ 'devil' ]);
+			expect(VisibilityLogic.hideElement([ 'other' ], 'devil').sort()).toEqual([ 'devil', 'other' ]);
+		});
+
+		test('showElement removes only that id', () => {
+			expect(VisibilityLogic.showElement([ 'devil', 'human' ], 'devil')).toEqual([ 'human' ]);
+			expect(VisibilityLogic.showElement([ 'human' ], 'devil')).toEqual([ 'human' ]);
+		});
+
+		test('isElementHidden reports membership', () => {
+			expect(VisibilityLogic.isElementHidden('devil', [ 'devil' ])).toBe(true);
+			expect(VisibilityLogic.isElementHidden('devil', [ 'human' ])).toBe(false);
+		});
+
+		test('getVisibleSourcebooks omits a single hidden item', () => {
+			const core = createSourcebookWithAncestries('core', [
+				{ id: 'devil', name: 'Devil' },
+				{ id: 'human', name: 'Human' }
+			]);
+
+			const result = VisibilityLogic.getVisibleSourcebooks([ core ], [], [ 'devil' ]);
+
+			expect(result[0].ancestries.map(a => a.id)).toEqual([ 'human' ]);
+		});
+
+		test('showing a hidden item restores it in getVisibleSourcebooks', () => {
+			const core = createSourcebookWithAncestries('core', [
+				{ id: 'devil', name: 'Devil' },
+				{ id: 'human', name: 'Human' }
+			]);
+
+			const hidden = VisibilityLogic.hideElement([], 'devil');
+			const shown = VisibilityLogic.showElement(hidden, 'devil');
+			const result = VisibilityLogic.getVisibleSourcebooks([ core ], [], shown);
+
+			expect(result[0].ancestries.map(a => a.id).sort()).toEqual([ 'devil', 'human' ]);
+		});
+	});
+
+	describe('category hide / show', () => {
+		test('toggleCategoryHidden hides all items of that kind in the given sourcebooks', () => {
+			const core = createSourcebookWithAncestries('core', [
+				{ id: 'a1', name: 'A1' },
+				{ id: 'a2', name: 'A2' }
+			]);
+
+			const hidden = VisibilityLogic.toggleCategoryHidden([], [ core ], 'ancestry');
+
+			expect(hidden.sort()).toEqual([ 'a1', 'a2' ]);
+		});
+
+		test('toggleCategoryHidden shows all when every category item is already hidden', () => {
+			const core = createSourcebookWithAncestries('core', [
+				{ id: 'a1', name: 'A1' },
+				{ id: 'a2', name: 'A2' }
+			]);
+
+			const shown = VisibilityLogic.toggleCategoryHidden([ 'a1', 'a2', 'unrelated' ], [ core ], 'ancestry');
+
+			expect(shown).toEqual([ 'unrelated' ]);
+		});
+
+		test('toggleCategoryHidden with partial hides finishes hiding the rest', () => {
+			const core = createSourcebookWithAncestries('core', [
+				{ id: 'a1', name: 'A1' },
+				{ id: 'a2', name: 'A2' },
+				{ id: 'a3', name: 'A3' }
+			]);
+
+			const hidden = VisibilityLogic.toggleCategoryHidden([ 'a1' ], [ core ], 'ancestry');
+
+			expect(hidden.sort()).toEqual([ 'a1', 'a2', 'a3' ]);
+		});
+
+		test('toggleCategoryHidden only affects currently provided (visible) sources', () => {
+			const core = createSourcebookWithAncestries('core', [
+				{ id: 'core-devil', name: 'Devil' }
+			]);
+			const extras = createSourcebookWithAncestries('extras', [
+				{ id: 'extras-elf', name: 'Elf' }
+			]);
+
+			// Library passes only active/visible sourcebooks into category toggle
+			const hidden = VisibilityLogic.toggleCategoryHidden([], [ core ], 'ancestry');
+
+			expect(hidden).toEqual([ 'core-devil' ]);
+			expect(hidden).not.toContain('extras-elf');
+
+			const visible = VisibilityLogic.getVisibleSourcebooks([ core, extras ], [], hidden);
+			expect(visible.find(sb => sb.id === 'core')!.ancestries).toHaveLength(0);
+			expect(visible.find(sb => sb.id === 'extras')!.ancestries.map(a => a.id)).toEqual([ 'extras-elf' ]);
+		});
+
+		test('getVisibleSourcebooks reflects a fully hidden category', () => {
+			const core = createSourcebookWithAncestries('core', [
+				{ id: 'a1', name: 'A1' },
+				{ id: 'a2', name: 'A2' }
+			]);
+			const hidden = VisibilityLogic.toggleCategoryHidden([], [ core ], 'ancestry');
+			const result = VisibilityLogic.getVisibleSourcebooks([ core ], [], hidden);
+
+			expect(result[0].ancestries).toHaveLength(0);
+		});
+
+		test('toggleCategoryHidden for monster-group uses groups or monsters based on options', () => {
+			const group = FactoryLogic.createMonsterGroup();
+			group.id = 'group-1';
+			group.monsters = [
+				createTestMonster('m1', 'M1'),
+				createTestMonster('m2', 'M2')
+			];
+			const sourcebook = FactoryLogic.createSourcebook();
+			sourcebook.id = 'sb';
+			sourcebook.monsterGroups = [ group ];
+
+			const hiddenGroups = VisibilityLogic.toggleCategoryHidden([], [ sourcebook ], 'monster-group', { showMonsters: false });
+			expect(hiddenGroups).toEqual([ 'group-1' ]);
+
+			const hiddenMonsters = VisibilityLogic.toggleCategoryHidden([], [ sourcebook ], 'monster-group', { showMonsters: true });
+			expect(hiddenMonsters.sort()).toEqual([ 'm1', 'm2' ]);
+		});
+	});
+
+	describe('sourcebook toggle resets item visibility', () => {
+		test('clearHiddenForSourcebook removes single-item hides for that source only', () => {
+			const core = createSourcebookWithAncestries('core', [
+				{ id: 'devil', name: 'Devil' },
+				{ id: 'human', name: 'Human' }
+			]);
+			const extras = createSourcebookWithAncestries('extras', [
+				{ id: 'elf', name: 'Elf' }
+			]);
+
+			const hidden = [ 'devil', 'elf' ];
+			const afterCoreToggle = VisibilityLogic.clearHiddenForSourcebook(hidden, core);
+
+			expect(afterCoreToggle).toEqual([ 'elf' ]);
+			expect(VisibilityLogic.clearHiddenForSourcebook(afterCoreToggle, extras)).toEqual([]);
+		});
+
+		test('clearHiddenForSourcebook removes category hides for that source', () => {
+			const core = createSourcebookWithAncestries('core', [
+				{ id: 'a1', name: 'A1' },
+				{ id: 'a2', name: 'A2' }
+			]);
+
+			const hidden = VisibilityLogic.toggleCategoryHidden([], [ core ], 'ancestry');
+			expect(hidden.sort()).toEqual([ 'a1', 'a2' ]);
+
+			const cleared = VisibilityLogic.clearHiddenForSourcebook(hidden, core);
+			expect(cleared).toEqual([]);
+		});
+
+		test('hide then show source restores previously hidden single items', () => {
+			const core = createSourcebookWithAncestries('core', [
+				{ id: 'devil', name: 'Devil' },
+				{ id: 'human', name: 'Human' }
+			]);
+
+			let hiddenElementIDs = VisibilityLogic.hideElement([], 'devil');
+			let visible = VisibilityLogic.getVisibleSourcebooks([ core ], [], hiddenElementIDs);
+			expect(visible[0].ancestries.map(a => a.id)).toEqual([ 'human' ]);
+
+			// Source hide/show cycle clears per-item overrides for that source
+			hiddenElementIDs = VisibilityLogic.clearHiddenForSourcebook(hiddenElementIDs, core);
+			visible = VisibilityLogic.getVisibleSourcebooks([ core ], [], hiddenElementIDs);
+
+			expect(visible[0].ancestries.map(a => a.id).sort()).toEqual([ 'devil', 'human' ]);
+		});
+
+		test('hide then show source restores previously hidden category items', () => {
+			const core = createSourcebookWithAncestries('core', [
+				{ id: 'a1', name: 'A1' },
+				{ id: 'a2', name: 'A2' }
+			]);
+
+			let hiddenElementIDs = VisibilityLogic.toggleCategoryHidden([], [ core ], 'ancestry');
+			expect(VisibilityLogic.getVisibleSourcebooks([ core ], [], hiddenElementIDs)[0].ancestries).toHaveLength(0);
+
+			hiddenElementIDs = VisibilityLogic.clearHiddenForSourcebook(hiddenElementIDs, core);
+			const visible = VisibilityLogic.getVisibleSourcebooks([ core ], [], hiddenElementIDs);
+
+			expect(visible[0].ancestries.map(a => a.id).sort()).toEqual([ 'a1', 'a2' ]);
+		});
+
+		test('toggling one source does not restore hidden items from another source', () => {
+			const core = createSourcebookWithAncestries('core', [ { id: 'devil', name: 'Devil' } ]);
+			const extras = createSourcebookWithAncestries('extras', [ { id: 'elf', name: 'Elf' } ]);
+
+			let hiddenElementIDs = VisibilityLogic.hideElement([], 'devil');
+			hiddenElementIDs = VisibilityLogic.hideElement(hiddenElementIDs, 'elf');
+
+			hiddenElementIDs = VisibilityLogic.clearHiddenForSourcebook(hiddenElementIDs, core);
+
+			expect(hiddenElementIDs).toEqual([ 'elf' ]);
+			const visible = VisibilityLogic.getVisibleSourcebooks([ core, extras ], [], hiddenElementIDs);
+			expect(visible.find(sb => sb.id === 'core')!.ancestries.map(a => a.id)).toEqual([ 'devil' ]);
+			expect(visible.find(sb => sb.id === 'extras')!.ancestries).toHaveLength(0);
+		});
+
+		test('clearHiddenForSourcebook also clears nested monster and subclass ids', () => {
+			const monster = createTestMonster('imp', 'Imp');
+			const group = FactoryLogic.createMonsterGroup();
+			group.id = 'devils';
+			group.monsters = [ monster ];
+
+			const subclass = FactoryLogic.createSubclass();
+			subclass.id = 'shadow';
+			const heroClass = FactoryLogic.createClass();
+			heroClass.id = 'class-1';
+			heroClass.subclasses = [ subclass ];
+
+			const sourcebook = FactoryLogic.createSourcebook();
+			sourcebook.id = 'core';
+			sourcebook.monsterGroups = [ group ];
+			sourcebook.classes = [ heroClass ];
+
+			const cleared = VisibilityLogic.clearHiddenForSourcebook([ 'imp', 'shadow', 'other' ], sourcebook);
+			expect(cleared).toEqual([ 'other' ]);
+		});
+	});
+
+	describe('display all hidden library items', () => {
+		test('passing empty hiddenElementIDs shows individually hidden items (setting on)', () => {
+			const core = createSourcebookWithAncestries('core', [
+				{ id: 'devil', name: 'Devil' },
+				{ id: 'human', name: 'Human' }
+			]);
+			const hiddenElementIDs = [ 'devil' ];
+
+			// Library uses [] for hiddenElementIDs when showHiddenLibraryItems is true
+			const whenShowingHidden = VisibilityLogic.getVisibleSourcebooks([ core ], [], []);
+			expect(whenShowingHidden[0].ancestries.map(a => a.id).sort()).toEqual([ 'devil', 'human' ]);
+
+			const whenHiding = VisibilityLogic.getVisibleSourcebooks([ core ], [], hiddenElementIDs);
+			expect(whenHiding[0].ancestries.map(a => a.id)).toEqual([ 'human' ]);
+		});
+
+		test('display-all-hidden still respects hidden sourcebooks', () => {
+			const core = createSourcebookWithAncestries('core', [ { id: 'devil', name: 'Devil' } ]);
+			const extras = createSourcebookWithAncestries('extras', [ { id: 'elf', name: 'Elf' } ]);
+
+			const result = VisibilityLogic.getVisibleSourcebooks(
+				[ core, extras ],
+				[ 'extras' ],
+				[] // showHiddenLibraryItems: true
+			);
+
+			expect(result.map(sb => sb.id)).toEqual([ 'core' ]);
+			expect(result[0].ancestries.map(a => a.id)).toEqual([ 'devil' ]);
+		});
+
+		test('display-all-hidden reveals category-hidden items without clearing stored hides', () => {
+			const core = createSourcebookWithAncestries('core', [
+				{ id: 'a1', name: 'A1' },
+				{ id: 'a2', name: 'A2' }
+			]);
+			const hiddenElementIDs = VisibilityLogic.toggleCategoryHidden([], [ core ], 'ancestry');
+
+			const displayed = VisibilityLogic.getVisibleSourcebooks([ core ], [], []);
+			expect(displayed[0].ancestries).toHaveLength(2);
+
+			const storedStillHidden = VisibilityLogic.getVisibleSourcebooks([ core ], [], hiddenElementIDs);
+			expect(storedStillHidden[0].ancestries).toHaveLength(0);
+			expect(hiddenElementIDs.sort()).toEqual([ 'a1', 'a2' ]);
+		});
+	});
+
+	describe('getVisibleSourcebooks nesting', () => {
+		test('strips nested monsters and subclasses', () => {
+			const monsterKeep = createTestMonster('monster-keep', 'Keep');
+			const monsterHide = createTestMonster('monster-hide', 'Hide');
+			const group = FactoryLogic.createMonsterGroup();
+			group.id = 'group-1';
+			group.monsters = [ monsterKeep, monsterHide ];
+
+			const subclassKeep = FactoryLogic.createSubclass();
+			subclassKeep.id = 'subclass-keep';
+			const subclassHide = FactoryLogic.createSubclass();
+			subclassHide.id = 'subclass-hide';
+			const heroClass = FactoryLogic.createClass();
+			heroClass.id = 'class-1';
+			heroClass.subclasses = [ subclassKeep, subclassHide ];
+
+			const sourcebook = FactoryLogic.createSourcebook();
+			sourcebook.id = 'sb-1';
+			sourcebook.monsterGroups = [ group ];
+			sourcebook.classes = [ heroClass ];
+
+			const result = VisibilityLogic.getVisibleSourcebooks([ sourcebook ], [], [ 'monster-hide', 'subclass-hide' ]);
+
+			expect(result[0].monsterGroups[0].monsters.map(m => m.id)).toEqual([ 'monster-keep' ]);
+			expect(result[0].classes[0].subclasses.map(s => s.id)).toEqual([ 'subclass-keep' ]);
+		});
+
+		test('drops entire hidden sourcebooks', () => {
+			const core = createSourcebookWithAncestries('core', [ { id: 'a1', name: 'A1' } ]);
+			const extras = createSourcebookWithAncestries('extras', [ { id: 'a2', name: 'A2' } ]);
+
+			const result = VisibilityLogic.getVisibleSourcebooks([ core, extras ], [ 'extras' ], []);
+			expect(result.map(sb => sb.id)).toEqual([ 'core' ]);
+		});
+	});
+});

--- a/src/logic/visibility-logic.ts
+++ b/src/logic/visibility-logic.ts
@@ -1,0 +1,224 @@
+import { Sourcebook, SourcebookElementKind } from '@/models/sourcebook';
+import { Collections } from '@/utils/collections';
+import { Element } from '@/models/element';
+import { SourcebookLogic } from '@/logic/sourcebook-logic';
+import { Utils } from '@/utils/utils';
+
+export interface VisibilityKindOptions {
+	showMonsters?: boolean;
+	includeCulturesFromAncestries?: boolean;
+	includeSubclassesFromClasses?: boolean;
+	includeProjectsFromImbuements?: boolean;
+	includeProjectsFromItems?: boolean;
+}
+
+export class VisibilityLogic {
+	static isElementHidden = (elementID: string, hiddenElementIDs: string[]) => {
+		return hiddenElementIDs.includes(elementID);
+	};
+
+	static getElementIDsForSourcebook = (sourcebook: Sourcebook): string[] => {
+		const ids = SourcebookLogic.getElements(sourcebook).map(x => x.element.id);
+		sourcebook.monsterGroups.forEach(group => {
+			group.monsters.forEach(monster => ids.push(monster.id));
+		});
+		sourcebook.classes.forEach(heroClass => {
+			heroClass.subclasses.forEach(subclass => ids.push(subclass.id));
+		});
+		return Collections.distinct(ids, id => id);
+	};
+
+	static clearHiddenForSourcebook = (hiddenElementIDs: string[], sourcebook: Sourcebook): string[] => {
+		const sourceElementIDs = new Set(VisibilityLogic.getElementIDsForSourcebook(sourcebook));
+		return hiddenElementIDs.filter(id => !sourceElementIDs.has(id));
+	};
+
+	static getElementIDsForKind = (sourcebooks: Sourcebook[], kind: SourcebookElementKind, options: VisibilityKindOptions = {}): string[] => {
+		const showMonsters = options.showMonsters ?? false;
+		const includeCulturesFromAncestries = options.includeCulturesFromAncestries ?? false;
+		const includeSubclassesFromClasses = options.includeSubclassesFromClasses ?? false;
+		const includeProjectsFromImbuements = options.includeProjectsFromImbuements ?? false;
+		const includeProjectsFromItems = options.includeProjectsFromItems ?? false;
+
+		let elements: Element[] = [];
+		switch (kind) {
+			case 'adventure':
+				elements = SourcebookLogic.getAdventures(sourcebooks);
+				break;
+			case 'ancestry':
+				elements = SourcebookLogic.getAncestries(sourcebooks);
+				break;
+			case 'career':
+				elements = SourcebookLogic.getCareers(sourcebooks);
+				break;
+			case 'class':
+				elements = SourcebookLogic.getClasses(sourcebooks);
+				break;
+			case 'complication':
+				elements = SourcebookLogic.getComplications(sourcebooks);
+				break;
+			case 'culture':
+				elements = SourcebookLogic.getCultures(sourcebooks, includeCulturesFromAncestries);
+				break;
+			case 'domain':
+				elements = SourcebookLogic.getDomains(sourcebooks);
+				break;
+			case 'encounter':
+				elements = SourcebookLogic.getEncounters(sourcebooks);
+				break;
+			case 'imbuement':
+				elements = SourcebookLogic.getImbuements(sourcebooks);
+				break;
+			case 'item':
+				elements = SourcebookLogic.getItems(sourcebooks);
+				break;
+			case 'kit':
+				elements = SourcebookLogic.getKits(sourcebooks);
+				break;
+			case 'monster-group':
+				elements = showMonsters ?
+					SourcebookLogic.getMonsters(sourcebooks) :
+					SourcebookLogic.getMonsterGroups(sourcebooks);
+				break;
+			case 'montage':
+				elements = SourcebookLogic.getMontages(sourcebooks);
+				break;
+			case 'negotiation':
+				elements = SourcebookLogic.getNegotiations(sourcebooks);
+				break;
+			case 'perk':
+				elements = SourcebookLogic.getPerks(sourcebooks);
+				break;
+			case 'project':
+				elements = SourcebookLogic.getProjects(sourcebooks, includeProjectsFromImbuements, includeProjectsFromItems);
+				break;
+			case 'subclass':
+				elements = SourcebookLogic.getSubclasses(sourcebooks, includeSubclassesFromClasses);
+				break;
+			case 'tactical-map':
+				elements = SourcebookLogic.getTacticalMaps(sourcebooks);
+				break;
+			case 'terrain':
+				elements = SourcebookLogic.getTerrains(sourcebooks);
+				break;
+			case 'title':
+				elements = SourcebookLogic.getTitles(sourcebooks);
+				break;
+		}
+
+		return Collections.distinct(elements.map(e => e.id), id => id);
+	};
+
+	static toggleCategoryHidden = (
+		hiddenElementIDs: string[],
+		sourcebooks: Sourcebook[],
+		kind: SourcebookElementKind,
+		options: VisibilityKindOptions = {}
+	): string[] => {
+		const categoryIDs = VisibilityLogic.getElementIDsForKind(sourcebooks, kind, options);
+		if (categoryIDs.length === 0) {
+			return hiddenElementIDs;
+		}
+
+		const allHidden = categoryIDs.every(id => hiddenElementIDs.includes(id));
+		if (allHidden) {
+			const categorySet = new Set(categoryIDs);
+			return hiddenElementIDs.filter(id => !categorySet.has(id));
+		}
+
+		const copy = Utils.copy(hiddenElementIDs);
+		categoryIDs.forEach(id => {
+			if (!copy.includes(id)) {
+				copy.push(id);
+			}
+		});
+		return copy;
+	};
+
+	static hideElement = (hiddenElementIDs: string[], elementID: string): string[] => {
+		if (hiddenElementIDs.includes(elementID)) {
+			return hiddenElementIDs;
+		}
+		const copy = Utils.copy(hiddenElementIDs);
+		copy.push(elementID);
+		return copy;
+	};
+
+	static showElement = (hiddenElementIDs: string[], elementID: string): string[] => {
+		return hiddenElementIDs.filter(id => id !== elementID);
+	};
+
+	static getHiddenElementsForSourcebook = (sourcebook: Sourcebook, hiddenElementIDs: string[]): { element: Element, type: SourcebookElementKind | 'monster' }[] => {
+		const hiddenSet = new Set(hiddenElementIDs);
+		const results: { element: Element, type: SourcebookElementKind | 'monster' }[] = [];
+
+		SourcebookLogic.getElements(sourcebook).forEach(entry => {
+			if (hiddenSet.has(entry.element.id)) {
+				results.push(entry);
+			}
+		});
+
+		sourcebook.monsterGroups.forEach(group => {
+			group.monsters.forEach(monster => {
+				if (hiddenSet.has(monster.id)) {
+					results.push({ element: monster, type: 'monster' });
+				}
+			});
+		});
+
+		sourcebook.classes.forEach(heroClass => {
+			heroClass.subclasses.forEach(subclass => {
+				if (hiddenSet.has(subclass.id) && !results.some(r => r.element.id === subclass.id)) {
+					results.push({ element: subclass, type: 'subclass' });
+				}
+			});
+		});
+
+		return Collections.sort(results, r => r.element.name);
+	};
+
+	static getVisibleSourcebooks = (
+		sourcebooks: Sourcebook[],
+		hiddenSourcebookIDs: string[],
+		hiddenElementIDs: string[]
+	): Sourcebook[] => {
+		const hiddenElementSet = new Set(hiddenElementIDs);
+
+		return sourcebooks
+			.filter(sb => !hiddenSourcebookIDs.includes(sb.id))
+			.map(sb => {
+				const copy = Utils.copy(sb);
+				copy.adventures = copy.adventures.filter(x => !hiddenElementSet.has(x.id));
+				copy.ancestries = copy.ancestries.filter(x => !hiddenElementSet.has(x.id));
+				copy.careers = copy.careers.filter(x => !hiddenElementSet.has(x.id));
+				copy.classes = copy.classes
+					.filter(x => !hiddenElementSet.has(x.id))
+					.map(heroClass => {
+						heroClass.subclasses = heroClass.subclasses.filter(sc => !hiddenElementSet.has(sc.id));
+						return heroClass;
+					});
+				copy.complications = copy.complications.filter(x => !hiddenElementSet.has(x.id));
+				copy.cultures = copy.cultures.filter(x => !hiddenElementSet.has(x.id));
+				copy.domains = copy.domains.filter(x => !hiddenElementSet.has(x.id));
+				copy.encounters = copy.encounters.filter(x => !hiddenElementSet.has(x.id));
+				copy.imbuements = copy.imbuements.filter(x => !hiddenElementSet.has(x.id));
+				copy.items = copy.items.filter(x => !hiddenElementSet.has(x.id));
+				copy.kits = copy.kits.filter(x => !hiddenElementSet.has(x.id));
+				copy.monsterGroups = copy.monsterGroups
+					.filter(x => !hiddenElementSet.has(x.id))
+					.map(group => {
+						group.monsters = group.monsters.filter(m => !hiddenElementSet.has(m.id));
+						return group;
+					});
+				copy.montages = copy.montages.filter(x => !hiddenElementSet.has(x.id));
+				copy.negotiations = copy.negotiations.filter(x => !hiddenElementSet.has(x.id));
+				copy.perks = copy.perks.filter(x => !hiddenElementSet.has(x.id));
+				copy.projects = copy.projects.filter(x => !hiddenElementSet.has(x.id));
+				copy.subclasses = copy.subclasses.filter(x => !hiddenElementSet.has(x.id));
+				copy.tacticalMaps = copy.tacticalMaps.filter(x => !hiddenElementSet.has(x.id));
+				copy.terrain = copy.terrain.filter(x => !hiddenElementSet.has(x.id));
+				copy.titles = copy.titles.filter(x => !hiddenElementSet.has(x.id));
+				return copy;
+			});
+	};
+}

--- a/src/models/options.ts
+++ b/src/models/options.ts
@@ -5,6 +5,7 @@ export interface Options {
 	// App
 	cookieConsent: boolean;
 	showDataSource: boolean;
+	showHiddenLibraryItems: boolean;
 	// Hero
 	shownStandardAbilities: string[];
 	xpPerLevel: number;

--- a/src/services/data-service.test.ts
+++ b/src/services/data-service.test.ts
@@ -162,4 +162,53 @@ describe('DataService', () => {
 		});
 	});
 	// #endregion HiddenSettingIds
+
+	// #region HiddenElementIds
+	const mockHiddenElementIds = [ 'elem-one', 'elem-two' ];
+
+	describe('getHiddenElementIDs', () => {
+		test('forwards to the storage service', async () => {
+			const ds = new DataService(mockStorage);
+
+			mockStorage.getHiddenElementIDs = vi.fn().mockImplementation(() => Promise.resolve(mockHiddenElementIds));
+
+			await ds.getHiddenElementIDs()
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(mockStorage.getHiddenElementIDs).toHaveBeenCalled();
+			expect(thenFn).toHaveBeenCalledWith(mockHiddenElementIds);
+			expect(catchFn).not.toHaveBeenCalled();
+		});
+
+		test('returns empty array when storage returns null', async () => {
+			const ds = new DataService(mockStorage);
+
+			mockStorage.getHiddenElementIDs = vi.fn().mockImplementation(() => Promise.resolve(null));
+
+			await ds.getHiddenElementIDs()
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(thenFn).toHaveBeenCalledWith([]);
+			expect(catchFn).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('saveHiddenElementIDs', () => {
+		test('forwards to the storage service', async () => {
+			const ds = new DataService(mockStorage);
+
+			mockStorage.putHiddenElementIDs = vi.fn().mockImplementation(() => Promise.resolve(mockHiddenElementIds));
+
+			await ds.saveHiddenElementIDs(mockHiddenElementIds)
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(mockStorage.putHiddenElementIDs).toHaveBeenCalledWith(mockHiddenElementIds);
+			expect(thenFn).toHaveBeenCalledWith(mockHiddenElementIds);
+			expect(catchFn).not.toHaveBeenCalled();
+		});
+	});
+	// #endregion HiddenElementIds
 });

--- a/src/services/data-service.ts
+++ b/src/services/data-service.ts
@@ -100,4 +100,17 @@ export class DataService {
 	}
 
 	// #endregion
+
+	// #region Hidden element IDs
+
+	async getHiddenElementIDs(): Promise<string[]> {
+		const result = await this.storageService.getHiddenElementIDs();
+		return result ?? [];
+	}
+
+	async saveHiddenElementIDs(ids: string[]): Promise<string[]> {
+		return this.storageService.putHiddenElementIDs(ids);
+	}
+
+	// #endregion
 };

--- a/src/services/storage/local-service.test.ts
+++ b/src/services/storage/local-service.test.ts
@@ -480,4 +480,33 @@ describe('LocalService', () => {
 			expect(catchFn).not.toHaveBeenCalled();
 		});
 	});
+
+	const testElementIDs = [ 'test-element-x', 'test-element-y' ];
+	describe('getHiddenElementIDs', () => {
+		test('retrieves ids stored at correct key', async () => {
+			localforage.getItem = vi.fn().mockImplementation(() => Promise.resolve(testElementIDs));
+
+			await service.getHiddenElementIDs()
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(localforage.getItem).toHaveBeenCalledWith(DataStorageKeys.HiddenElementIDs);
+			expect(thenFn).toHaveBeenCalledWith(testElementIDs);
+			expect(catchFn).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('putHiddenElementIDs', () => {
+		test('sets ids at correct key', async () => {
+			localforage.setItem = vi.fn().mockImplementation(() => Promise.resolve(testElementIDs));
+
+			await service.putHiddenElementIDs(testElementIDs)
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(localforage.setItem).toHaveBeenCalledWith(DataStorageKeys.HiddenElementIDs, testElementIDs);
+			expect(thenFn).toHaveBeenCalledWith(testElementIDs);
+			expect(catchFn).not.toHaveBeenCalled();
+		});
+	});
 });

--- a/src/services/storage/local-service.ts
+++ b/src/services/storage/local-service.ts
@@ -9,7 +9,8 @@ export enum DataStorageKeys {
 	Heroes = 'forgesteel-heroes',
 	Sourcebooks = 'forgesteel-homebrew-settings',
 	Session = 'forgesteel-session',
-	HiddenSourcebookIDs = 'forgesteel-hidden-setting-ids'
+	HiddenSourcebookIDs = 'forgesteel-hidden-setting-ids',
+	HiddenElementIDs = 'forgesteel-hidden-element-ids'
 };
 
 export class LocalService implements StorageService {
@@ -135,5 +136,18 @@ export class LocalService implements StorageService {
 
 	putHiddenSourcebookIDs(ids: string[]): Promise<string[]> {
 		return localforage.setItem<string[]>(DataStorageKeys.HiddenSourcebookIDs, ids);
+	}
+
+	getHiddenElementIDs(): Promise<string[] | null> {
+		try {
+			return localforage.getItem<string[]>(DataStorageKeys.HiddenElementIDs);
+		} catch (error) {
+			console.error('Error getting hidden element ids', error);
+			return Promise.resolve(null);
+		}
+	}
+
+	putHiddenElementIDs(ids: string[]): Promise<string[]> {
+		return localforage.setItem<string[]>(DataStorageKeys.HiddenElementIDs, ids);
 	}
 };

--- a/src/services/storage/storage-service.ts
+++ b/src/services/storage/storage-service.ts
@@ -39,4 +39,8 @@ export interface StorageService {
 	// Hidden sourcebook IDs
 	getHiddenSourcebookIDs(): Promise<string[] | null>;
 	putHiddenSourcebookIDs(ids: string[]): Promise<string[]>;
+
+	// Hidden library element IDs
+	getHiddenElementIDs(): Promise<string[] | null>;
+	putHiddenElementIDs(ids: string[]): Promise<string[]>;
 };

--- a/src/services/storage/warehouse-service.test.ts
+++ b/src/services/storage/warehouse-service.test.ts
@@ -700,4 +700,48 @@ describe('WarehouseService', () => {
 		});
 	});
 	// #endregion
+
+	// #region Hidden Element IDs
+	const testElementIDs = [ 'test-element-x', 'test-element-y' ];
+	describe('getHiddenElementIDs', () => {
+		test('calls the correct api endpoint with the correct authorization', async () => {
+			mockAdapter.onGet('data/forgesteel-hidden-element-ids').reply(config => {
+				expect(config.headers?.Authorization).toBe('Bearer fake_token');
+				return [ 200, { data: testElementIDs } ];
+			});
+
+			const service = new WarehouseService(defaultSettings);
+			const connected = await service.initialize();
+			expect(connected).toBe(true);
+
+			await service.getHiddenElementIDs()
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(catchFn).not.toHaveBeenCalled();
+			expect(thenFn).toHaveBeenCalledWith(testElementIDs);
+		});
+	});
+
+	describe('putHiddenElementIDs', () => {
+		test('calls the correct api endpoint with the correct authorization', async () => {
+			mockAdapter.onPut('data/forgesteel-hidden-element-ids').reply(config => {
+				expect(config.headers?.Authorization).toBe('Bearer fake_token');
+				expect(config.data).toBe(testElementIDs);
+				return [ 204 ];
+			});
+
+			const service = new WarehouseService(defaultSettings);
+			const connected = await service.initialize();
+			expect(connected).toBe(true);
+
+			await service.putHiddenElementIDs(testElementIDs)
+				.then(thenFn)
+				.catch(catchFn);
+
+			expect(catchFn).not.toHaveBeenCalled();
+			expect(thenFn).toHaveBeenCalledWith(testElementIDs);
+		});
+	});
+	// #endregion
 });

--- a/src/services/storage/warehouse-service.ts
+++ b/src/services/storage/warehouse-service.ts
@@ -281,4 +281,24 @@ export class WarehouseService implements StorageService {
 			throw new Error(this.getErrorMessage(error), { cause: error });
 		}
 	}
+
+	async getHiddenElementIDs(): Promise<string[] | null> {
+		try {
+			const response = await this.api.get('data/forgesteel-hidden-element-ids');
+			return response.data.data;
+		} catch (error) {
+			console.error('Error communicating with FS Warehouse', error);
+			throw new Error(this.getErrorMessage(error), { cause: error });
+		}
+	}
+
+	async putHiddenElementIDs(value: string[]): Promise<string[]> {
+		try {
+			await this.api.put('data/forgesteel-hidden-element-ids', value);
+			return value;
+		} catch (error) {
+			console.error('Error communicating with FS Warehouse', error);
+			throw new Error(this.getErrorMessage(error), { cause: error });
+		}
+	}
 };


### PR DESCRIPTION
- Added Setting category "Library" which contains library related settings. 
- Added "Show all hidden library items" toggle to display all hidden library items.
- Updated "Show/Hide" toggle description, to include explanation of the effect it will trigger.
- Added functionality to hide or show single library item
- Added functionality to hide or show all items in library category.
   - This functionality only hides or shows all items depending on what current sourcebooks are selected. 
- Sourcebook visibility toggle now resets visibility of each of sourcebook items if any were set.

Fixes #445 

<img width="49%" alt="image" src="https://github.com/user-attachments/assets/6cfea81c-f468-4e71-9d5d-9b8fcd82a313" />

<img width="49%" alt="image" src="https://github.com/user-attachments/assets/9137618f-b600-49c9-8ab8-092a55011058" />

<img width="49%" alt="image" src="https://github.com/user-attachments/assets/0f2d489f-4e74-4cfe-978d-8813e884b9d1" />

<img width="49%" alt="image" src="https://github.com/user-attachments/assets/ae46c58a-b33b-424e-bc0d-c050416b629a" />

<img width="49%" alt="image" src="https://github.com/user-attachments/assets/f28d9edb-4825-4dee-98e5-242d4d99ae72" />