### PR TITLE
Add heroic resource and recoveries tracking to Party modal

### DIFF
--- a/src/components/modals/party/party-modal.scss
+++ b/src/components/modals/party/party-modal.scss
@@ -22,4 +22,9 @@
 			margin-top: 5px;
 		}
 	}
+
+	.resource-name {
+		font-size: 11px;
+		opacity: 0.7;
+	}
 }

--- a/src/components/modals/party/party-modal.tsx
+++ b/src/components/modals/party/party-modal.tsx
@@ -32,7 +32,7 @@ export const PartyModal = (props: Props) => {
 		<Modal
 			content={
 				<div className='party-modal'>
-					<HeaderText>Stamina</HeaderText>
+					<HeaderText>Resources</HeaderText>
 					<table>
 						<thead>
 							<tr>
@@ -58,6 +58,43 @@ export const PartyModal = (props: Props) => {
 															<Tag color={state === 'winded' ? 'orange' : 'red'} variant='outlined'>{Format.capitalize(state)}</Tag>
 														</div>
 														: null
+												}
+											</td>
+										);
+									})
+								}
+							</tr>
+							<tr>
+								<td className='row-label'>Recoveries</td>
+								{
+									props.heroes.map(h => {
+										const max = HeroLogic.getRecoveries(h);
+										const current = max - h.state.recoveriesUsed;
+
+										return (
+											<td key={h.id} className='row-cell'>
+												{max > 0 ? `${current} / ${max}` : '-'}
+											</td>
+										);
+									})
+								}
+							</tr>
+							<tr>
+								<td className='row-label'>Heroic Resource</td>
+								{
+									props.heroes.map(h => {
+										const resources = HeroLogic.getHeroicResources(h);
+										return (
+											<td key={h.id} className='row-cell'>
+												{
+													resources.length > 0 ?
+														resources.map(hr => (
+															<div key={hr.id}>
+																<div>{hr.value}</div>
+																<div className='resource-name'>{hr.name}</div>
+															</div>
+														))
+														: '-'
 												}
 											</td>
 										);


### PR DESCRIPTION
Adds a Recoveries row to the Stamina box, and a new Heroic Resource section, so the GM can see the whole party's resource state at a glance.

<img width="980" height="716" alt="1" src="https://github.com/user-attachments/assets/1eed26a6-5688-4fb5-8258-d81da6a35433" />
<img width="964" height="728" alt="2" src="https://github.com/user-attachments/assets/2e84c732-fd5f-4f32-81b7-b5ada474d6d5" />
