### PR TITLE
Debounce and coalesce hero saves in persistHero

### DIFF
--- a/src/components/main/main.tsx
+++ b/src/components/main/main.tsx
@@ -1,7 +1,7 @@
 import { Encounter, EncounterSlot } from '@/models/encounter';
 import { Feature, FeatureCompanion, FeatureRetainer, FeatureSummon, FeatureSummonChoice } from '@/models/feature';
 import { Navigate, Route, Routes } from 'react-router';
-import { ReactNode, Suspense, lazy, useState } from 'react';
+import { ReactNode, Suspense, lazy, useEffect, useRef, useState } from 'react';
 import { Sourcebook, SourcebookElementKind } from '@/models/sourcebook';
 import { Spin, notification } from 'antd';
 import { useDataManager, useHeroes, useHomebrewSourcebooks, useOptions, useSession } from '@/contexts/data-context';
@@ -134,9 +134,27 @@ export const Main = (props: Props) => {
 
 	// #region Persistence
 
-	const persistHero = (hero: Hero) => {
-		return dataManager
-			.saveHero(hero)
+	const HERO_SAVE_DEBOUNCE_MS = 400;
+
+	interface PendingHeroSave {
+		hero: Hero;
+		timer: ReturnType<typeof setTimeout>;
+		resolvers: (() => void)[];
+	}
+
+	const pendingHeroSavesRef = useRef<Map<string, PendingHeroSave>>(new Map());
+
+	const flushHeroSave = (heroId: string) => {
+		const pending = pendingHeroSavesRef.current.get(heroId);
+		if (!pending) {
+			return;
+		}
+
+		pendingHeroSavesRef.current.delete(heroId);
+		clearTimeout(pending.timer);
+
+		dataManager
+			.saveHero(pending.hero)
 			.catch(err => {
 				console.error(err);
 				notify.error({
@@ -144,7 +162,39 @@ export const Main = (props: Props) => {
 					description: Utils.getErrorMessage(err),
 					placement: 'top'
 				});
+			})
+			.then(() => {
+				pending.resolvers.forEach(resolve => resolve());
 			});
+	};
+
+	// Keep a stable indirection to the latest closure so the unmount effect
+	// below (which must only run once) always flushes with fresh dataManager / notify.
+	const flushHeroSaveRef = useRef(flushHeroSave);
+	flushHeroSaveRef.current = flushHeroSave;
+
+	useEffect(() => {
+		return () => {
+			// Flush any hero saves still debouncing so a last-second edit isn't lost on unmount.
+			pendingHeroSavesRef.current.forEach((_, heroId) => flushHeroSaveRef.current(heroId));
+		};
+	}, []);
+
+	const persistHero = (hero: Hero) => {
+		// UI / local state is already updated synchronously by callers before this is invoked;
+		// only the network PUT is delayed and coalesced here, per hero.id.
+		return new Promise<void>(resolve => {
+			const existing = pendingHeroSavesRef.current.get(hero.id);
+			if (existing) {
+				clearTimeout(existing.timer);
+				existing.hero = hero;
+				existing.resolvers.push(resolve);
+				existing.timer = setTimeout(() => flushHeroSave(hero.id), HERO_SAVE_DEBOUNCE_MS);
+			} else {
+				const timer = setTimeout(() => flushHeroSave(hero.id), HERO_SAVE_DEBOUNCE_MS);
+				pendingHeroSavesRef.current.set(hero.id, { hero, timer, resolvers: [ resolve ] });
+			}
+		});
 	};
 
 	const persistSession = (session: Session) => {


### PR DESCRIPTION
Rapid successive edits (e.g. quick +/- clicks on stamina/resources) could fire an immediate, un-debounced PUT per call, so an older save could land after a newer one and clobber it. persistHero now debounces the network save per hero.id (400ms trailing edge), keeping local UI updates instant while coalescing rapid calls into a single save of the latest snapshot.