### PR TITLE
Fix Warehouse save reliability: silent failures, CSRF 401s, JWT truncation, and rapid-edit clobbering

### DIFF
--- a/src/components/main/main.tsx
+++ b/src/components/main/main.tsx
@@ -255,7 +255,13 @@ export const Main = (props: Props) => {
 			).then(() => {
 				const storage = StorageServiceFactory.fromConnectionSettings(connectionSettings);
 				const ds = new DataService(storage);
-				ds.initialize();
+				ds.initialize().catch(err => {
+					notify.error({
+						title: 'Couldn\'t connect to Warehouse with the new settings',
+						description: Utils.getErrorMessage(err),
+						placement: 'top'
+					});
+				});
 				setDataService(ds);
 			});
 	};

--- a/src/components/main/main.tsx
+++ b/src/components/main/main.tsx
@@ -1,7 +1,7 @@
 import { Encounter, EncounterSlot } from '@/models/encounter';
 import { Feature, FeatureCompanion, FeatureRetainer, FeatureSummon, FeatureSummonChoice } from '@/models/feature';
 import { Navigate, Route, Routes } from 'react-router';
-import { ReactNode, Suspense, lazy, useState } from 'react';
+import { ReactNode, Suspense, lazy, useEffect, useRef, useState } from 'react';
 import { Sourcebook, SourcebookElementKind } from '@/models/sourcebook';
 import { Spin, notification } from 'antd';
 import { useDataManager, useHeroes, useHomebrewSourcebooks, useOptions, useSession } from '@/contexts/data-context';
@@ -133,9 +133,27 @@ export const Main = (props: Props) => {
 
 	// #region Persistence
 
-	const persistHero = (hero: Hero) => {
-		return dataManager
-			.saveHero(hero)
+	const HERO_SAVE_DEBOUNCE_MS = 400;
+
+	interface PendingHeroSave {
+		hero: Hero;
+		timer: ReturnType<typeof setTimeout>;
+		resolvers: (() => void)[];
+	}
+
+	const pendingHeroSavesRef = useRef<Map<string, PendingHeroSave>>(new Map());
+
+	const flushHeroSave = (heroId: string) => {
+		const pending = pendingHeroSavesRef.current.get(heroId);
+		if (!pending) {
+			return;
+		}
+
+		pendingHeroSavesRef.current.delete(heroId);
+		clearTimeout(pending.timer);
+
+		dataManager
+			.saveHero(pending.hero)
 			.catch(err => {
 				console.error(err);
 				notify.error({
@@ -143,7 +161,39 @@ export const Main = (props: Props) => {
 					description: Utils.getErrorMessage(err),
 					placement: 'top'
 				});
+			})
+			.then(() => {
+				pending.resolvers.forEach(resolve => resolve());
 			});
+	};
+
+	// Keep a stable indirection to the latest closure so the unmount effect
+	// below (which must only run once) always flushes with fresh dataManager / notify.
+	const flushHeroSaveRef = useRef(flushHeroSave);
+	flushHeroSaveRef.current = flushHeroSave;
+
+	useEffect(() => {
+		return () => {
+			// Flush any hero saves still debouncing so a last-second edit isn't lost on unmount.
+			pendingHeroSavesRef.current.forEach((_, heroId) => flushHeroSaveRef.current(heroId));
+		};
+	}, []);
+
+	const persistHero = (hero: Hero) => {
+		// UI / local state is already updated synchronously by callers before this is invoked;
+		// only the network PUT is delayed and coalesced here, per hero.id.
+		return new Promise<void>(resolve => {
+			const existing = pendingHeroSavesRef.current.get(hero.id);
+			if (existing) {
+				clearTimeout(existing.timer);
+				existing.hero = hero;
+				existing.resolvers.push(resolve);
+				existing.timer = setTimeout(() => flushHeroSave(hero.id), HERO_SAVE_DEBOUNCE_MS);
+			} else {
+				const timer = setTimeout(() => flushHeroSave(hero.id), HERO_SAVE_DEBOUNCE_MS);
+				pendingHeroSavesRef.current.set(hero.id, { hero, timer, resolvers: [ resolve ] });
+			}
+		});
 	};
 
 	const persistSession = (session: Session) => {

--- a/src/components/pages/transfer/transfer-page.tsx
+++ b/src/components/pages/transfer/transfer-page.tsx
@@ -1,4 +1,4 @@
-import { Alert, Button, Flex, Popconfirm, Segmented, Space, Spin, Tabs } from 'antd';
+import { Alert, Button, Flex, Popconfirm, Segmented, Space, Spin, Tabs, notification } from 'antd';
 import { useEffect, useMemo, useState } from 'react';
 import { Collections } from '@/utils/collections';
 import { ConnectionSettings } from '@/models/connection-settings';
@@ -28,6 +28,8 @@ interface Props {
 };
 
 export const TransferPage = (props: Props) => {
+	const [ notify, notifyContext ] = notification.useNotification();
+
 	const [ mergeBehavior, setMergeBehavior ] = useState<MergeDuplicateBehavior>(MergeDuplicateBehavior.Skip);
 	const [ copyLocalOpen, setCopyLocalOpen ] = useState<boolean>(false);
 
@@ -42,13 +44,25 @@ export const TransferPage = (props: Props) => {
 
 	const localDs = useMemo(() => {
 		const ds = new DataService(new LocalService());
-		ds.initialize();
+		ds.initialize().catch(err => {
+			notify.error({
+				title: 'Error initializing local storage',
+				description: Utils.getErrorMessage(err),
+				placement: 'top'
+			});
+		});
 		return ds;
 	}, []);
 	const warehouseDs = useMemo(() => {
 		const storage = StorageServiceFactory.fromConnectionSettings(props.connectionSettings);
 		const ds = new DataService(storage);
-		ds.initialize();
+		ds.initialize().catch(err => {
+			notify.error({
+				title: 'Error connecting to Warehouse',
+				description: Utils.getErrorMessage(err),
+				placement: 'top'
+			});
+		});
 		return ds;
 	}, [ props.connectionSettings ]);
 
@@ -339,6 +353,7 @@ export const TransferPage = (props: Props) => {
 					}
 					{getTransferContent()}
 				</div>
+				{notifyContext}
 			</div>
 		</ErrorBoundary>
 	);

--- a/src/services/patreon-service.ts
+++ b/src/services/patreon-service.ts
@@ -40,6 +40,8 @@ export class PatreonService {
 
 				return this.api(error.config);
 			}
+
+			return Promise.reject(error);
 		});
 	};
 

--- a/src/services/storage/warehouse-service.ts
+++ b/src/services/storage/warehouse-service.ts
@@ -102,6 +102,8 @@ export class WarehouseService implements StorageService {
 
 				return this.api(error.config);
 			}
+
+			return Promise.reject(error);
 		});
 
 		const connected = await this.ensureAuth();

--- a/src/services/storage/warehouse-service.ts
+++ b/src/services/storage/warehouse-service.ts
@@ -33,8 +33,8 @@ export class WarehouseService implements StorageService {
 
 		this.api = axios.create({
 			baseURL: this.host,
-			withCredentials: true,
-			withXSRFToken: true,
+			withCredentials: this.useNewAuth,
+			withXSRFToken: this.useNewAuth,
 			xsrfCookieName: 'csrf_access_token',
 			xsrfHeaderName: 'X-CSRF-TOKEN'
 		});
@@ -60,8 +60,8 @@ export class WarehouseService implements StorageService {
 		try {
 			const refreshConfig = {
 				headers: {},
-				withCredentials: true,
-				withXSRFToken: true,
+				withCredentials: this.useNewAuth,
+				withXSRFToken: this.useNewAuth,
 				xsrfCookieName: 'csrf_refresh_token',
 				xsrfHeaderName: 'X-CSRF-TOKEN'
 			};

--- a/src/services/storage/warehouse-service.ts
+++ b/src/services/storage/warehouse-service.ts
@@ -40,6 +40,22 @@ export class WarehouseService implements StorageService {
 		});
 	};
 
+	private isJwtExpired = (token: string): boolean => {
+		try {
+			const payload = token.split('.')[1];
+			const base64 = payload.replace(/-/g, '+').replace(/_/g, '/');
+			const decoded = JSON.parse(atob(base64));
+			if (typeof decoded.exp !== 'number') {
+				return false;
+			}
+
+			const bufferSeconds = 5;
+			return (decoded.exp - bufferSeconds) * 1000 <= Date.now();
+		} catch {
+			return false;
+		}
+	};
+
 	private isExpiredTokenError = (err: unknown): boolean => {
 		if ((err as AxiosError).isAxiosError) {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -81,6 +97,12 @@ export class WarehouseService implements StorageService {
 			if (!this.useNewAuth) {
 				if (this.jwt === null) {
 					await this.ensureAuth();
+				} else if (this.isJwtExpired(this.jwt)) {
+					// Refresh before sending rather than after a failed round-trip: a large save
+					// (the full hero payload) that gets rejected can have its response body
+					// truncated by the proxy, which is otherwise indistinguishable from a network error.
+					this.jwt = null;
+					await this.refreshJwt();
 				}
 				config.headers.Authorization = `Bearer ${this.jwt}`;
 			}

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -86,8 +86,7 @@ export class Utils {
 					const offsetX = (maxSize - scaledWidth) / 2;
 					const offsetY = (maxSize - scaledHeight) / 2;
 					ctx.drawImage(img, offsetX, offsetY, scaledWidth, scaledHeight);
-					const mime = data.match(/^data:([^;,]+)[;,]/)?.[1] || 'image/png';
-					resolve(canvas.toDataURL(mime));
+					resolve(canvas.toDataURL('image/webp', 0.85));
 				} else {
 					resolve(data);
 				}


### PR DESCRIPTION
### **Fix Warehouse save reliability: silent failures, CSRF 401s, JWT truncation, and rapid-edit clobbering**

This PR bundles six fixes uncovered while diagnosing why hero saves to Warehouse were intermittently failing or silently "succeeding" without actually persisting. They were found and fixed in the order below, each building on what the previous one revealed.

### 1. Fix silently swallowed non-expiry errors in axios response interceptors (7295ecda)

warehouse-service.ts and patreon-service.ts both had response interceptors that handled 401/token-expiry inside an if block but had no fallthrough reject. An async interceptor callback that falls through without an explicit return/throw resolves to undefined, which axios treats as "handled" — so the outer request promise resolved instead of rejecting, even on genuine failures (timeouts, dropped connections). This caused persistHero's .catch() to never fire, so failed hero saves silently looked like they'd succeeded.

### 2. Gate Warehouse CSRF cookie settings behind useNewAuth (df1b67e0)

WarehouseService supports two auth methods distinguished by useNewAuth: a manually-generated API token (Bearer header, fully self-contained) and Patreon-based cookie sessions (which need CSRF protection). withCredentials/withXSRFToken were applied unconditionally to both, even though the API-token flow never needed cookies at all.

For API-token users whose Warehouse is on a different subdomain than their client, cross-site cookie partitioning can leave the JWT cookie attached while the paired CSRF cookie isn't reliably readable, so the server's CSRF check fails with an empty-message 401 on state-changing requests even though the Bearer header was valid. Reads are unaffected since JWT_CSRF_METHODS excludes GET, matching the observed pattern of only saves failing. Gating both settings behind useNewAuth removes cookies from the API-token flow entirely and leaves the Patreon flow unchanged.

### 3. Catch DataService.initialize() rejections at all call sites (3cc08fe6)

ensureJwt() (via ensureAuth → WarehouseService.initialize) still throws on connection failure, but three call sites invoked initialize() without awaiting or catching the result, producing an unhandled promise rejection whenever the initial connect failed: main.tsx's persistConnectionSettings, and both the localDs/warehouseDs useMemo initializers on the transfer page. The response-interceptor fallthrough fix (#1) doesn't cover this — that only runs after a request round-trips, while this failure happens in the initial /connect call before any response interceptor logic runs.

Added .catch() at each site using the app's existing notify.error convention, with a title specific to what failed rather than a generic message. transfer-page.tsx had no notification handling at all previously, so this also wires up notification.useNotification().

### 4. Proactively refresh expired JWT before sending, not after (d4d922f3)

Root cause found for a persistent, hard-to-reproduce save failure: the reverse proxy in front of Warehouse truncates the response body when a large request (the full hero payload, ~500KB+) gets rejected quickly with a 401. Confirmed independent of the app entirely — replicated with curl directly against Warehouse using a captured expired token: headers arrive (Content-Length: 28) but the body never does ("end of response with 28 bytes missing"), even though the same expired token against a small GET request returns the correct body every time. That truncated body meant the existing reactive 401-refresh-and-retry logic couldn't even parse the error to know a retry was needed.

Since the client controls when it sends the large payload, checking the token's own exp claim before attaching it to a request (and refreshing first if already expired, with a 5s buffer) means the large PUT essentially never goes out with a stale token in normal use — sidestepping the truncation bug rather than depending on recognizing it after the fact. The reactive 401-triggered refresh path stays in place as a fallback.

### 5. Debounce and coalesce hero saves in persistHero (207529a7)

Rapid successive edits (e.g. quick +/- clicks on stamina/resources) could fire an immediate, un-debounced PUT per call, so an older save could land after a newer one and clobber it. persistHero now debounces the network save per hero.id (400ms trailing edge), keeping local UI updates instant while coalescing rapid calls into a single save of the latest snapshot.

### 6. Encode resized hero pictures as WebP instead of preserving upload format (41d64d77)

getResizedImage() already caps uploaded pictures to 500x500, but was re-encoding using whatever format was uploaded — a PNG stayed a PNG. PNG is lossless and compresses painterly/photographic portraits poorly regardless of resolution, so a typical hero picture ends up several hundred KB, re-sent in full on every hero save since the Warehouse save API has no partial-update support (relevant given the payload-size-triggered JWT truncation bug in #4).

WebP supports both real lossy compression and transparency in one format, so this doesn't drop transparency support the way switching to JPEG would. Canvas.toDataURL falls back to PNG automatically if a browser doesn't support WebP encoding, so this is a safe no-op change on any environment that doesn't support it. Only affects newly-uploaded pictures going forward; existing stored pictures are untouched until re-uploaded.

### Testing
All six fixes were developed and verified against a live dev Warehouse instance with real heroes, including reproducing the CSRF 401 and JWT-truncation failures directly with curl before and after the fix. tsc --noEmit and eslint pass clean.

### Files changed
src/components/main/main.tsx
src/components/pages/transfer/transfer-page.tsx
src/services/patreon-service.ts
src/services/storage/warehouse-service.ts
src/utils/utils.ts