### PR TITLE
Classic Sheet Fixes

### DIFF
--- a/src/components/pages/classic-sheet/common.scss
+++ b/src/components/pages/classic-sheet/common.scss
@@ -263,7 +263,7 @@ main#classic-sheet {
             }
             .power  {
                 font-weight: 600;
-                margin: 0 10px 5px;
+                margin: 0 10px 5px 0;
                 .symbol-text {
                     display: inline-block;
                     font-size: round(1.2rem, 1px);
@@ -502,6 +502,28 @@ main#classic-sheet {
                     @include color-ability-card($move);
                     h2 {
                         @include dividers.fancy-3($move);
+                    }
+                }
+            }
+
+            &.hero-sheet .follower .ability {
+                &.main-action {
+                    .action-type {
+                        color: $main-action;
+                    }
+                }
+
+                &.maneuver,
+                &.free-maneuver {
+                    .action-type {
+                        color: $maneuver;
+                    }
+                }
+
+                &.triggered-action,
+                &.free-triggered-action {
+                    .action-type {
+                        color: $triggered-action;
                     }
                 }
             }

--- a/src/components/panels/classic-sheet/ability-card/ability-card.scss
+++ b/src/components/panels/classic-sheet/ability-card/ability-card.scss
@@ -134,16 +134,17 @@
     .power-roll {
         display: grid;
         grid-template-rows: min-content 1fr;
+        margin: 5px 0 0;
 
         font-size: 15px;
 
         .roll-tiers {
             display: grid;
             grid-template-rows: min-content min-content min-content;
-            margin: 0 10px;
+            margin-left: -7px;
 
             .tier {
-                margin: 0 0 3px;
+                margin: 0;
             }
 
         }
@@ -159,8 +160,8 @@
 
     .trigger {
         font-size: 15px;
-        label {
-            font-weight: 450;
+        p {
+            margin: 0;
         }
     }
     .effect {
@@ -175,6 +176,11 @@
 
         ul {
             margin-left: 10px;
+        }
+
+        blockquote {
+            font-style: italic;
+            margin: 15px 15px 15px 40px;
         }
 
         .potency {

--- a/src/components/panels/classic-sheet/ability-card/ability-card.tsx
+++ b/src/components/panels/classic-sheet/ability-card/ability-card.tsx
@@ -1,4 +1,4 @@
-import { AbilitySheet } from '@/models/classic-sheets/ability-sheet';
+import { AbilitySheet, PowerRollSection } from '@/models/classic-sheets/ability-sheet';
 import { Collections } from '@/utils/collections';
 import { DrawSteelSymbolText } from '@/components/panels/classic-sheet/components/ds-symbol-text-component';
 import { Markdown } from '@/components/controls/markdown/markdown';
@@ -51,71 +51,82 @@ export const AbilityCard = (props: Props) => {
 		);
 	};
 
-	const getPowerRollSection = () => {
-		if (ability.hasPowerRoll) {
-			return (
-				<div className='power-roll'>
-					<div className='power'>Power Roll + <DrawSteelSymbolText content={ability.rollPower} lookFor='characteristics' /></div>
-					<div className='roll-tiers'>
-						<div className='tier t1'>
-							<img src={rollT1} alt='≤ 11' className='range' />
-							<div className='effect'>
-								<DrawSteelSymbolText content={ability.rollT1Effect} lookFor='potencies' />
-							</div>
-						</div>
-						<div className='tier t2'>
-							<img src={rollT2} alt='12 - 16' className='range' />
-							<div className='effect'>
-								<DrawSteelSymbolText content={ability.rollT2Effect} lookFor='potencies' />
-							</div>
-						</div>
-						<div className='tier t3'>
-							<img src={rollT3} alt='17 +' className='range' />
-							<div className='effect'>
-								<DrawSteelSymbolText content={ability.rollT3Effect} lookFor='potencies' />
-							</div>
-						</div>
-					</div>
-					{
-						ability.rollBonuses ?
-							<div className='roll-bonuses'>
-								{ability.rollBonuses.map(bonus => (
-									<p key={bonus.name}>
-										<strong>{bonus.name}</strong>: {bonus.tier1} | {bonus.tier2} | {bonus.tier3} {bonus.type} damage
-									</p>
-								))}
-							</div>
-							: null
-					}
-				</div>
-			);
-		}
-	};
-
 	const getTriggerSection = () => {
 		if (ability.trigger) {
 			return (
-				<p className='trigger'><label>Trigger: </label><Markdown useSpan={true} text={ability.trigger} /></p>
+				<Markdown
+					text={'**Trigger:** ' + ability.trigger}
+					className='trigger'
+				/>
 			);
 		}
 	};
 
-	const getEffectSection = () => {
-		if (ability.effect) {
-			return (
-				<div className='effect'>
-					{
-						!(ability.effect.startsWith('##') || ability.isNotTrueAbility) ?
-							<h4>Effect:</h4>
-							: null
-					}
-					<Markdown
-						text={ability.effect}
-						className='ability-effect'
-					/>
+	const getSections = () => {
+		let isFirstText = true;
+		return ability.sections.map(s => {
+			if (typeof s === 'string') {
+				const result = getEffectSection(s, isFirstText);
+				isFirstText = false;
+				return result;
+			} else {
+				return getPowerRollSection(s);
+			}
+		});
+	};
+
+	const getPowerRollSection = (section: PowerRollSection) => {
+		return (
+			<div className='power-roll'>
+				<div className='power'>Power Roll + <DrawSteelSymbolText content={section.rollPower} lookFor='characteristics' /></div>
+				<div className='roll-tiers'>
+					<div className='tier t1'>
+						<img src={rollT1} alt='≤ 11' className='range' />
+						<div className='effect'>
+							<DrawSteelSymbolText content={section.rollT1Effect} lookFor='potencies' />
+						</div>
+					</div>
+					<div className='tier t2'>
+						<img src={rollT2} alt='12 - 16' className='range' />
+						<div className='effect'>
+							<DrawSteelSymbolText content={section.rollT2Effect} lookFor='potencies' />
+						</div>
+					</div>
+					<div className='tier t3'>
+						<img src={rollT3} alt='17 +' className='range' />
+						<div className='effect'>
+							<DrawSteelSymbolText content={section.rollT3Effect} lookFor='potencies' />
+						</div>
+					</div>
 				</div>
-			);
+				{
+					section.rollBonuses ?
+						<div className='roll-bonuses'>
+							{section.rollBonuses.map(bonus => (
+								<p key={bonus.name}>
+									<strong>{bonus.name}</strong>: {bonus.tier1} | {bonus.tier2} | {bonus.tier3} {bonus.type} damage
+								</p>
+							))}
+						</div>
+						: null
+				}
+			</div>
+		);
+	};
+
+	const getEffectSection = (section: string, isFirstText: boolean) => {
+		let text = section;
+		if (isFirstText && !(section.startsWith('##') || ability.isNotTrueAbility)) {
+			text = '**Effect:** ' + section;
 		}
+		return (
+			<div className='effect'>
+				<Markdown
+					text={text}
+					className='ability-effect'
+				/>
+			</div>
+		);
 	};
 
 	const getCardClasses = (ability: AbilitySheet) => {
@@ -141,9 +152,8 @@ export const AbilityCard = (props: Props) => {
 				{ability.qualifiers?.map((q, i) => {
 					return (<div className='action-qualifier' key={`qualifier-${i}`}>{q}</div>);
 				})}
-				{getPowerRollSection()}
 				{getTriggerSection()}
-				{getEffectSection()}
+				{getSections()}
 			</section>
 		</div>
 	);

--- a/src/components/panels/classic-sheet/components/ability-component.scss
+++ b/src/components/panels/classic-sheet/components/ability-component.scss
@@ -88,7 +88,7 @@
         }
     }
 
-    p.trigger,
+    .trigger p,
     .effect p {
         font-size: 15px;
         margin-left: 0;

--- a/src/components/panels/classic-sheet/components/ability-component.tsx
+++ b/src/components/panels/classic-sheet/components/ability-component.tsx
@@ -1,4 +1,4 @@
-import { AbilitySheet } from '@/models/classic-sheets/ability-sheet';
+import { AbilitySheet, PowerRollSection } from '@/models/classic-sheets/ability-sheet';
 import { Collections } from '@/utils/collections';
 import { DrawSteelSymbolText } from '@/components/panels/classic-sheet/components/ds-symbol-text-component';
 import { Markdown } from '@/components/controls/markdown/markdown';
@@ -22,65 +22,138 @@ export const AbilityComponent = (props: Props) => {
 	const ability = useMemo(() => props.ability, [ props.ability ]);
 	const includeIcon = props.includeIcon || false;
 
-	const getPowerRollSection = () => {
-		if (ability.hasPowerRoll) {
-			return (
-				<div className='power-roll'>
-					<div className='roll-tiers'>
-						<div className='tier t1'>
-							<img src={rollT1} alt='≤ 11' className='range' />
-							<span className='effect'>
-								<DrawSteelSymbolText content={ability.rollT1Effect} lookFor='potencies' />
-							</span>
-						</div>
-						<div className='tier t2'>
-							<img src={rollT2} alt='12 - 16' className='range' />
-							<span className='effect'>
-								<DrawSteelSymbolText content={ability.rollT2Effect} lookFor='potencies' />
-							</span>
-						</div>
-						<div className='tier t3'>
-							<img src={rollT3} alt='17 +' className='range' />
-							<span className='effect'>
-								<DrawSteelSymbolText content={ability.rollT3Effect} lookFor='potencies' />
-							</span>
-						</div>
-					</div>
-				</div>
-			);
-		}
-	};
-
 	const getTriggerSection = () => {
 		if (ability.trigger) {
 			return (
-				<p className='trigger'><label>Trigger: </label><Markdown useSpan={true} text={ability.trigger} /></p>
+				<Markdown
+					text={'**Trigger:** ' + ability.trigger}
+					className='trigger'
+				/>
 			);
 		}
 	};
 
-	const getEffectSection = () => {
-		if (ability.effect) {
-			// A small number of ability effects start with a 'Special' section, so we want to make sure we don't prepend 'Effect' to that
-			let addedLabel = false;
-			const effectText = ability.effect.split('\n').map(l => {
-				let newLine = l;
-				if (!addedLabel && !(l.startsWith('**') || l.startsWith('#'))) {
-					addedLabel = true;
-					newLine = '**Effect**: ' + l;
-				}
-				return newLine;
-			}).join('\n');
-			return (
-				<div className='effect'>
-					<Markdown
-						text={effectText}
-						className='ability-effect'
-					/>
-				</div>
-			);
-		}
+	const getSections = () => {
+		let isFirstText = true;
+		return ability.sections.map(s => {
+			if (typeof s === 'string') {
+				const result = getEffectSection(s, isFirstText);
+				isFirstText = false;
+				return result;
+			} else {
+				return getPowerRollSection(s);
+			}
+		});
 	};
+
+	const firstPowerRoll = ability.sections.find(s => typeof s !== 'string');
+	const hasPowerRoll = firstPowerRoll !== undefined;
+	const rollPower = firstPowerRoll?.rollPower;
+
+	const getPowerRollSection = (section: PowerRollSection) => {
+		return (
+			<div className='power-roll'>
+				<div className='roll-tiers'>
+					<div className='tier t1'>
+						<img src={rollT1} alt='≤ 11' className='range' />
+						<div className='effect'>
+							<DrawSteelSymbolText content={section.rollT1Effect} lookFor='potencies' />
+						</div>
+					</div>
+					<div className='tier t2'>
+						<img src={rollT2} alt='12 - 16' className='range' />
+						<div className='effect'>
+							<DrawSteelSymbolText content={section.rollT2Effect} lookFor='potencies' />
+						</div>
+					</div>
+					<div className='tier t3'>
+						<img src={rollT3} alt='17 +' className='range' />
+						<div className='effect'>
+							<DrawSteelSymbolText content={section.rollT3Effect} lookFor='potencies' />
+						</div>
+					</div>
+				</div>
+				{
+					section.rollBonuses ?
+						<div className='roll-bonuses'>
+							{section.rollBonuses.map(bonus => (
+								<p key={bonus.name}>
+									<strong>{bonus.name}</strong>: {bonus.tier1} | {bonus.tier2} | {bonus.tier3} {bonus.type} damage
+								</p>
+							))}
+						</div>
+						: null
+				}
+			</div>
+		);
+	};
+
+	// const getPowerRollSection = () => {
+	// 	if (ability.hasPowerRoll) {
+	// 		return (
+	// 			<div className='power-roll'>
+	// 				<div className='roll-tiers'>
+	// 					<div className='tier t1'>
+	// 						<img src={rollT1} alt='≤ 11' className='range' />
+	// 						<span className='effect'>
+	// 							<DrawSteelSymbolText content={ability.rollT1Effect} lookFor='potencies' />
+	// 						</span>
+	// 					</div>
+	// 					<div className='tier t2'>
+	// 						<img src={rollT2} alt='12 - 16' className='range' />
+	// 						<span className='effect'>
+	// 							<DrawSteelSymbolText content={ability.rollT2Effect} lookFor='potencies' />
+	// 						</span>
+	// 					</div>
+	// 					<div className='tier t3'>
+	// 						<img src={rollT3} alt='17 +' className='range' />
+	// 						<span className='effect'>
+	// 							<DrawSteelSymbolText content={ability.rollT3Effect} lookFor='potencies' />
+	// 						</span>
+	// 					</div>
+	// 				</div>
+	// 			</div>
+	// 		);
+	// 	}
+	// };
+
+	const getEffectSection = (section: string, isFirstText: boolean) => {
+		let text = section;
+		if (isFirstText && !(section.startsWith('##') || ability.isNotTrueAbility)) {
+			text = '**Effect:** ' + section;
+		}
+		return (
+			<div className='effect'>
+				<Markdown
+					text={text}
+					className='ability-effect'
+				/>
+			</div>
+		);
+	};
+
+	// const getEffectSection = () => {
+	// 	if (ability.effect) {
+	// 		// A small number of ability effects start with a 'Special' section, so we want to make sure we don't prepend 'Effect' to that
+	// 		let addedLabel = false;
+	// 		const effectText = ability.effect.split('\n').map(l => {
+	// 			let newLine = l;
+	// 			if (!addedLabel && !(l.startsWith('**') || l.startsWith('#'))) {
+	// 				addedLabel = true;
+	// 				newLine = '**Effect**: ' + l;
+	// 			}
+	// 			return newLine;
+	// 		}).join('\n');
+	// 		return (
+	// 			<div className='effect'>
+	// 				<Markdown
+	// 					text={effectText}
+	// 					className='ability-effect'
+	// 				/>
+	// 			</div>
+	// 		);
+	// 	}
+	// };
 
 	let icon = null;
 	if (includeIcon) {
@@ -103,8 +176,8 @@ export const AbilityComponent = (props: Props) => {
 		<div className={getClasses(ability)}>
 			<div className='header'>
 				<div className='name'>{ability.name}</div>
-				{ability.hasPowerRoll ?
-					<div className='power-roll'>2d10 + {ability.rollPower}</div>
+				{hasPowerRoll ?
+					<div className='power-roll'>2d10 + {rollPower}</div>
 					: undefined}
 				<div className='ability-type'>
 					{ability.abilityType}
@@ -130,8 +203,7 @@ export const AbilityComponent = (props: Props) => {
 				</div>
 			</div>
 			{getTriggerSection()}
-			{getPowerRollSection()}
-			{getEffectSection()}
+			{getSections()}
 		</div>
 	);
 };

--- a/src/components/panels/classic-sheet/follower-card/companion-card.tsx
+++ b/src/components/panels/classic-sheet/follower-card/companion-card.tsx
@@ -103,42 +103,44 @@ export const CompanionCard = (props: Props) => {
 		);
 	};
 
-	const getAdvancement = () => {
-		return (
-			<div className='advancement-abilities'>
-				{companion.advancement?.map(a =>
-					<div className='advancement' key={`${companion.id}-advancement-${a.level}`}>
-						{
-							a.ability ?
-								<>
-									<h4>Level {a.level} Retainer Advancement Ability</h4>
-									{getAbilityIcon(a.ability)}
-									<AbilityComponent
-										ability={a.ability}
-									/>
-								</>
-								: null
-						}
-						{
-							a.features ?
-								<>
-									<h4>Level {a.level} {companion.name} Advancement Feature</h4>
-									<img src={starIcon} className='icon' />
-									{
-										a.features.map(f => {
-											return (
-												<FeatureComponent feature={f} key={`${companion.id}-advancement-${f.id}`} />
-											);
-										})
-									}
-								</>
-								: null
-						}
-					</div>
-				)}
-			</div>
-		);
-	};
+	// const getAdvancement = () => {
+	// 	if (false) { // future options.showRetainerAdvancement ?
+	// 		return (
+	// 			<div className='advancement-abilities'>
+	// 				{companion.advancement?.map(a =>
+	// 					<div className='advancement' key={`${companion.id}-advancement-${a.level}`}>
+	// 						{
+	// 							a.ability ?
+	// 								<>
+	// 									<h4>Level {a.level} Retainer Advancement Ability</h4>
+	// 									{getAbilityIcon(a.ability)}
+	// 									<AbilityComponent
+	// 										ability={a.ability}
+	// 									/>
+	// 								</>
+	// 								: null
+	// 						}
+	// 						{
+	// 							a.features ?
+	// 								<>
+	// 									<h4>Level {a.level} {companion.name} Advancement Feature</h4>
+	// 									<img src={starIcon} className='icon' />
+	// 									{
+	// 										a.features.map(f => {
+	// 											return (
+	// 												<FeatureComponent feature={f} key={`${companion.id}-advancement-${f.id}`} />
+	// 											);
+	// 										})
+	// 									}
+	// 								</>
+	// 								: null
+	// 						}
+	// 					</div>
+	// 				)}
+	// 			</div>
+	// 		);
+	// 	}
+	// };
 
 	const getAbilityIcon = (ability: AbilitySheet) => {
 		const icon = SheetFormatter.getAbilityIcon(ability);
@@ -193,7 +195,7 @@ export const CompanionCard = (props: Props) => {
 					{getAbilities()}
 					{getFeatures()}
 				</div>
-				{getAdvancement()}
+				{/* {getAdvancement()} */}
 			</section>
 		</div>
 	);

--- a/src/components/panels/classic-sheet/monster-card/monster-card.scss
+++ b/src/components/panels/classic-sheet/monster-card/monster-card.scss
@@ -286,9 +286,13 @@ main#classic-sheet :is(.encounter-sheet, .hero-sheet, .library-item-sheet) :is(.
     .feature .feature-description p {
         margin-left: 0;
         margin-right: 0;
+
+        em {
+            display: inline;
+        }
     }
 
-    .wrapper {
+    .wrapper, .advancement {
         display: grid;
         grid-template-columns: min-content 1fr;
         grid-template-rows: min-content 1fr;
@@ -298,9 +302,26 @@ main#classic-sheet :is(.encounter-sheet, .hero-sheet, .library-item-sheet) :is(.
         .ability {
             margin-bottom: 10px;
         }
+    }
 
-        &:not(:last-of-type) {
-            @include common.divider-plain(common.$color-medium, 1px);
+    .wrapper:not(:last-of-type):not(:has(+ .advancement-abilities)) {
+        @include common.divider-plain(common.$color-medium, 1px);
+    }
+    
+    .advancement-abilities {
+        display: flex;
+        flex-direction: column;
+
+        .advancement h4 {
+            grid-column-end: span 2;
+            color: #000;
+            background-color: common.$color-general-monster;
+            border-radius: 8px 8px 0 0;
+            border-bottom: 1px solid common.$color-medium;
+        }
+
+        &:last-child .ability {
+            margin-bottom: 0;
         }
     }
 }
@@ -344,6 +365,9 @@ main#classic-sheet .color :is(.monster.card, .terrain.card) {
         &.wide section.bordered .name-wrapper {
             @include monster-header-gradient-half(common.$color-ambusher);
         }
+        .advancement h4 {
+            background-color: common.$color-ambusher;
+        }
     }
     &.artillery {
         section.bordered .name-wrapper {
@@ -351,6 +375,9 @@ main#classic-sheet .color :is(.monster.card, .terrain.card) {
         }
         &.wide section.bordered .name-wrapper {
             @include monster-header-gradient-half(common.$color-artillery);
+        }
+        .advancement h4 {
+            background-color: common.$color-artillery;
         }
     }
     &.brute {
@@ -360,6 +387,9 @@ main#classic-sheet .color :is(.monster.card, .terrain.card) {
         &.wide section.bordered .name-wrapper {
             @include monster-header-gradient-half(common.$color-brute);
         }
+        .advancement h4 {
+            background-color: common.$color-brute;
+        }
     }
     &.controller {
         section.bordered .name-wrapper {
@@ -367,6 +397,9 @@ main#classic-sheet .color :is(.monster.card, .terrain.card) {
         }
         &.wide section.bordered .name-wrapper {
             @include monster-header-gradient-half(common.$color-controller);
+        }
+        .advancement h4 {
+            background-color: common.$color-controller;
         }
     }
     &.defender {
@@ -376,6 +409,9 @@ main#classic-sheet .color :is(.monster.card, .terrain.card) {
         &.wide section.bordered .name-wrapper {
             @include monster-header-gradient-half(common.$color-defender);
         }
+        .advancement h4 {
+            background-color: common.$color-defender;
+        }
     }
     &.harrier {
         section.bordered .name-wrapper {
@@ -383,6 +419,9 @@ main#classic-sheet .color :is(.monster.card, .terrain.card) {
         }
         &.wide section.bordered .name-wrapper {
             @include monster-header-gradient-half(common.$color-harrier);
+        }
+        .advancement h4 {
+            background-color: common.$color-harrier;
         }
     }
     &.hexer {
@@ -392,6 +431,9 @@ main#classic-sheet .color :is(.monster.card, .terrain.card) {
         &.wide section.bordered .name-wrapper {
             @include monster-header-gradient-half(common.$color-hexer);
         }
+        .advancement h4 {
+            background-color: common.$color-hexer;
+        }
     }
     &.mount {
         section.bordered .name-wrapper {
@@ -400,6 +442,9 @@ main#classic-sheet .color :is(.monster.card, .terrain.card) {
         &.wide section.bordered .name-wrapper {
             @include monster-header-gradient-half(common.$color-mount);
         }
+        .advancement h4 {
+            background-color: common.$color-mount;
+        }
     }
     &.support {
         section.bordered .name-wrapper {
@@ -407,6 +452,9 @@ main#classic-sheet .color :is(.monster.card, .terrain.card) {
         }
         &.wide section.bordered .name-wrapper {
             @include monster-header-gradient-half(common.$color-support);
+        }
+        .advancement h4 {
+            background-color: common.$color-support;
         }
     }
 }

--- a/src/components/panels/classic-sheet/monster-card/monster-card.tsx
+++ b/src/components/panels/classic-sheet/monster-card/monster-card.tsx
@@ -123,6 +123,45 @@ export const MonsterCard = (props: Props) => {
 		);
 	};
 
+	const getAdvancement = () => {
+		if (monster.advancement?.length) {
+			return (
+				<div className='advancement-abilities'>
+					{monster.advancement?.map(a =>
+						<div className='advancement' key={`${monster.id}-advancement-${a.level}`}>
+							{
+								a.ability ?
+									<>
+										<h4>Level {a.level} Retainer Advancement Ability</h4>
+										{getAbilityIcon(a.ability)}
+										<AbilityComponent
+											ability={a.ability}
+										/>
+									</>
+									: null
+							}
+							{
+								a.features ?
+									<>
+										<h4>Level {a.level} {monster.name} Advancement Feature</h4>
+										<img src={starIcon} className='icon' />
+										{
+											a.features.map(f => {
+												return (
+													<FeatureComponent feature={f} key={`${monster.id}-advancement-${f.id}`} />
+												);
+											})
+										}
+									</>
+									: null
+							}
+						</div>
+					)}
+				</div>
+			);
+		}
+	};
+
 	const cardClasses = [ 'monster', 'card' ];
 	if (columns > 1) {
 		cardClasses.push('wide');
@@ -148,6 +187,7 @@ export const MonsterCard = (props: Props) => {
 				<CharacteristicsComponent characteristics={monster.characteristics} />
 				{getAbilities()}
 				{getFeatures()}
+				{getAdvancement()}
 			</section>
 		</div>
 	);

--- a/src/data/monsters/retainer.ts
+++ b/src/data/monsters/retainer.ts
@@ -1134,6 +1134,7 @@ export const retainer: MonsterGroup = {
 						id: 'retainer-12-retainer-4',
 						name: '‘Scuse Me, Boss',
 						type: FactoryLogic.type.createTrigger('The warrior’s mentor is targeted by a strike while within distance.', { qualifiers: [ 'Encounter' ] }),
+						keywords: [ AbilityKeyword.Melee ],
 						distance: [ FactoryLogic.distance.createMelee(1) ],
 						target: 'The warrior’s mentor',
 						sections: [

--- a/src/logic/classic-sheet/classic-sheet-builder.test.ts
+++ b/src/logic/classic-sheet/classic-sheet-builder.test.ts
@@ -7,9 +7,12 @@ import { ArtifactData } from '@/data/items/artifact-data';
 import { Characteristic } from '@/enums/characteristic';
 import { ClassicSheetBuilder } from '@/logic/classic-sheet/classic-sheet-builder';
 import { FactoryLogic } from '@/logic/factory-logic';
+import { FeatureAbility } from '@/models/feature';
 import { HeroLogic } from '@/logic/hero-logic';
 import { Options } from '@/models/options';
+import { PowerRollSection } from '@/models/classic-sheets/ability-sheet';
 import { ajax } from '@/data/monsters/ajax';
+import { creation } from '@/data/domains/creation';
 import { goblin } from '@/data/monsters/goblin';
 
 describe('buildCharacteristicsSheet', () => {
@@ -60,7 +63,8 @@ describe('buildAbilitySheet', () => {
 		} as Options;
 
 		const result = ClassicSheetBuilder.buildAbilitySheet(ability, hero, undefined, options);
-		expect(result.rollPower).toBe('M or A');
+		const powerRoll = result.sections[1] as PowerRollSection;
+		expect(powerRoll.rollPower).toBe('M or A');
 	});
 
 	test('when showPowerRollCalc is true, calculates value', () => {
@@ -73,11 +77,13 @@ describe('buildAbilitySheet', () => {
 		} as Options;
 
 		const result = ClassicSheetBuilder.buildAbilitySheet(ability, hero, undefined, options);
-		expect(result.rollPower).toBe('4');
+		const powerRoll = result.sections[1] as PowerRollSection;
+		expect(powerRoll.rollPower).toBe('4');
 	});
 
 	test.each([
 		[ AbilityData.advance, true ],
+		[ AbilityData.freeStrikeMelee, false ],
 		[ AbilityData.escapeGrab, false ]
 	])('properly sets isNotTrueAbility for non-ability abilities', (ability: Ability, expected: boolean) => {
 		const hero = FactoryLogic.createHero();
@@ -99,7 +105,8 @@ describe('buildAbilitySheet', () => {
 		} as Options;
 
 		const result = ClassicSheetBuilder.buildAbilitySheet(ability, hero, undefined, options);
-		expect(result.rollPower).toBe('R or P');
+		const powerRoll = result.sections[1] as PowerRollSection;
+		expect(powerRoll.rollPower).toBe('R or P');
 	});
 
 	test('if a power roll can use any characteristic, clean up the text', () => {
@@ -117,7 +124,8 @@ describe('buildAbilitySheet', () => {
 		} as Options;
 
 		const result = ClassicSheetBuilder.buildAbilitySheet(ability, hero, undefined, options);
-		expect(result.rollPower).toBe('Highest Characteristic');
+		const powerRoll = result.sections[1] as PowerRollSection;
+		expect(powerRoll.rollPower).toBe('Highest Characteristic');
 	});
 
 	test('if a Hero does NOT has multiple kits that apply, rollBonuses is empty', () => {
@@ -125,7 +133,8 @@ describe('buildAbilitySheet', () => {
 		const options = {} as Options;
 
 		const result = ClassicSheetBuilder.buildAbilitySheet(AbilityData.escapeGrab, hero, undefined, options);
-		expect(result.rollBonuses).toBeNullable();
+		const powerRoll = result.sections[1] as PowerRollSection;
+		expect(powerRoll.rollBonuses).toBeNullable();
 	});
 
 	test('if a Hero has multiple kits that apply, rollBonuses gets populated', () => {
@@ -138,7 +147,8 @@ describe('buildAbilitySheet', () => {
 		]);
 
 		const result = ClassicSheetBuilder.buildAbilitySheet(AbilityData.freeStrikeMelee, hero, undefined, options);
-		expect(result.rollBonuses?.length).toBe(2);
+		const powerRoll = result.sections[0] as PowerRollSection;
+		expect(powerRoll.rollBonuses?.length).toBe(2);
 	});
 
 	test('if a Hero has multiple kits that apply, rollBonuses gets populated', () => {
@@ -152,7 +162,8 @@ describe('buildAbilitySheet', () => {
 		]);
 
 		const result = ClassicSheetBuilder.buildAbilitySheet(AbilityData.freeStrikeRanged, hero, undefined, options);
-		expect(result.rollBonuses?.length).toBe(2);
+		const powerRoll = result.sections[0] as PowerRollSection;
+		expect(powerRoll.rollBonuses?.length).toBe(2);
 	});
 
 	test('if a Hero has multiple kits but one is always worse, rollBonuses stays empty', () => {
@@ -165,8 +176,26 @@ describe('buildAbilitySheet', () => {
 		]);
 
 		const result = ClassicSheetBuilder.buildAbilitySheet(AbilityData.freeStrikeMelee, hero, undefined, options);
-		expect(result.rollBonuses).toBeNullable();
+		const powerRoll = result.sections[0] as PowerRollSection;
+		expect(powerRoll.rollBonuses).toBeNullable();
 	});
+
+	test('Ability sections are displayed in the same order as in the data', () => {
+		const divineDragon = creation.featuresByLevel
+			.find(lvlFeatures => lvlFeatures.level === 9)?.features
+			.find(feature => feature.name === 'Divine Dragon') as FeatureAbility;
+
+		const hero = FactoryLogic.createHero();
+		const options = {} as Options;
+
+		vi.spyOn(HeroLogic, 'getKitDamageBonuses').mockReturnValue([
+			{ name: 'Melee 1', type: 'melee', tier1: 1, tier2: 1, tier3: 1 }
+		]);
+		const result = ClassicSheetBuilder.buildAbilitySheet(divineDragon.data.ability, hero, undefined, options);
+		expect(result).not.toBe(undefined);
+	});
+
+	// test('Grab and Knockback mention Intuition instead of Might for Null')
 });
 
 describe('buildMonsterSheet', () => {

--- a/src/logic/classic-sheet/classic-sheet-builder.ts
+++ b/src/logic/classic-sheet/classic-sheet-builder.ts
@@ -1,7 +1,7 @@
+import { AbilitySheet, PowerRollSection } from '@/models/classic-sheets/ability-sheet';
 import { Ability } from '@/models/ability';
 import { AbilityKeyword } from '@/enums/ability-keyword';
 import { AbilityLogic } from '@/logic/ability-logic';
-import { AbilitySheet } from '@/models/classic-sheets/ability-sheet';
 import { AbilityUsage } from '@/enums/ability-usage';
 import { Characteristic } from '@/enums/characteristic';
 import { CharacteristicsSheet } from '@/models/classic-sheets/classic-sheets';
@@ -111,6 +111,29 @@ export class ClassicSheetBuilder {
 			.filter(f => f.type === FeatureType.Ability)
 			.map(f => f.data.ability);
 		sheet.abilities = abilities.map(a => ClassicSheetBuilder.buildAbilitySheet(a, monster));
+
+		if (monster.retainer) {
+			const advancement = [];
+			if (monster.retainer.level4?.type === FeatureType.Ability) {
+				advancement.push({
+					level: 4,
+					ability: ClassicSheetBuilder.buildAbilitySheet(monster.retainer.level4.data.ability, monster)
+				});
+			}
+			if (monster.retainer.level7?.type === FeatureType.Ability) {
+				advancement.push({
+					level: 7,
+					ability: ClassicSheetBuilder.buildAbilitySheet(monster.retainer.level7.data.ability, monster)
+				});
+			}
+			if (monster.retainer.level10?.type === FeatureType.Ability) {
+				advancement.push({
+					level: 10,
+					ability: ClassicSheetBuilder.buildAbilitySheet(monster.retainer.level10.data.ability, monster)
+				});
+			}
+			sheet.advancement = advancement;
+		}
 
 		return sheet;
 	};
@@ -272,7 +295,7 @@ export class ClassicSheetBuilder {
 			keywords: keywords.join(', '),
 			target: ability.target,
 			trigger: ability.type.trigger,
-			hasPowerRoll: false
+			sections: []
 		};
 
 		sheet.name = sheet.name.replace(/\s*Benefit and Drawback\s*/, '').trim();
@@ -346,98 +369,107 @@ export class ClassicSheetBuilder {
 			sheet.distance = ability.distance.map(d => AbilityLogic.getDistanceCreature(d, ability, refCreature)).join(', ');
 		}
 
-		const effectSections = ability.sections.filter(s => s.type !== 'roll');
-		let effectText = SheetFormatter.abilitySections(effectSections, refCreature).trim();
+		const sections = ability.sections.map(s => {
+			if (s.type === 'roll') {
+				const rollSection = {
+					rollPower: '',
+					rollT1Effect: '',
+					rollT2Effect: '',
+					rollT3Effect: '',
+					rollBonuses: undefined
+				} as PowerRollSection;
 
-		// Kind of hacky, but this is a one-off at the moment
-		if (CreatureLogic.isHero(creature)
-				&& ([ 'grab', 'knockback' ].includes(ability.id))
-				&& HeroLogic.getFeatures(creature as Hero).find(f => f.feature.id === 'null-1-8')) { // Psionic Martial Arts id
-			effectText = effectText.replace(/your Might/g, 'your Intuition');
-		}
-		sheet.effect = effectText;
+				const rollAutoCalc = options?.showPowerRollCalculation ?? true;
 
-		const rollSections = ability.sections.filter(s => s.type === 'roll');
-		if (rollSections.length) {
-			sheet.hasPowerRoll = true;
-			const rollSection = rollSections[0];
-			const rollAutoCalc = options?.showPowerRollCalculation ?? true;
-
-			if (rollAutoCalc) {
-				if (isSummon) {
-					sheet.rollPower = AbilityLogic.getPowerRollBonusValue(ability, summoner).toString();
+				if (rollAutoCalc) {
+					if (isSummon) {
+						rollSection.rollPower = AbilityLogic.getPowerRollBonusValue(ability, summoner).toString();
+					} else {
+						rollSection.rollPower = AbilityLogic.getPowerRollBonusValue(ability, refCreature).toString();
+					}
 				} else {
-					sheet.rollPower = AbilityLogic.getPowerRollBonusValue(ability, refCreature).toString();
+					const characteristics = AbilityLogic.getPowerRollCharacteristics(ability, undefined).sort(SheetFormatter.sortCharacteristics);
+					const allCharacteristics = Object.values(Characteristic).sort(SheetFormatter.sortCharacteristics);
+					const isAllCharacteristics = allCharacteristics.every((c, i) => characteristics[i] === c);
+					if (isAllCharacteristics) {
+						rollSection.rollPower = 'Highest Characteristic';
+					} else {
+						rollSection.rollPower = SheetFormatter.joinCommasOr(characteristics.map(c => c.toString().slice(0, 1)));
+					}
 				}
+
+				rollSection.rollT1Effect = SheetFormatter.formatAbilityTier(s.roll.tier1, 1, ability, refCreature);
+				rollSection.rollT2Effect = SheetFormatter.formatAbilityTier(s.roll.tier2, 2, ability, refCreature);
+				rollSection.rollT3Effect = SheetFormatter.formatAbilityTier(s.roll.tier3, 3, ability, refCreature);
+
+				if (CreatureLogic.isHero(creature)) {
+					const isMelee = keywords.includes(AbilityKeyword.Melee) && keywords.includes(AbilityKeyword.Weapon);
+					const isRanged = keywords.includes(AbilityKeyword.Ranged) && keywords.includes(AbilityKeyword.Weapon);
+
+					const meleeKits = HeroLogic
+						.getKitDamageBonuses(creature)
+						.filter(dmg => dmg.type === 'melee');
+
+					const rangedKits = HeroLogic
+						.getKitDamageBonuses(creature)
+						.filter(dmg => dmg.type === 'ranged');
+
+					if (isMelee && meleeKits.length > 1) {
+						const bestT1 = Math.max(...meleeKits.map(k => k.tier1));
+						const bestT2 = Math.max(...meleeKits.map(k => k.tier2));
+						const bestT3 = Math.max(...meleeKits.map(k => k.tier3));
+
+						const meleeBonuses = meleeKits
+							.filter(k => k.tier1 >= bestT1 || k.tier2 >= bestT2 || k.tier3 >= bestT3)
+							.map(k => {
+								return {
+									name: k.name,
+									type: k.type,
+									tier1: SheetFormatter.addSign(k.tier1) || '',
+									tier2: SheetFormatter.addSign(k.tier2) || '',
+									tier3: SheetFormatter.addSign(k.tier3) || ''
+								};
+							});
+						if (meleeBonuses.length > 1) {
+							rollSection.rollBonuses = (rollSection.rollBonuses ?? []).concat(meleeBonuses);
+						}
+					}
+					if (isRanged && rangedKits.length > 1) {
+						const bestT1 = Math.max(...rangedKits.map(k => k.tier1));
+						const bestT2 = Math.max(...rangedKits.map(k => k.tier2));
+						const bestT3 = Math.max(...rangedKits.map(k => k.tier3));
+
+						const rangedBonuses = rangedKits
+							.filter(k => k.tier1 >= bestT1 || k.tier2 >= bestT2 || k.tier3 >= bestT3)
+							.map(k => {
+								return {
+									name: k.name,
+									type: k.type,
+									tier1: SheetFormatter.addSign(k.tier1) || '',
+									tier2: SheetFormatter.addSign(k.tier2) || '',
+									tier3: SheetFormatter.addSign(k.tier3) || ''
+								};
+							});
+						if (rangedBonuses.length > 1) {
+							rollSection.rollBonuses = (rollSection.rollBonuses ?? []).concat(rangedBonuses);
+						}
+					}
+				}
+				return rollSection;
 			} else {
-				const characteristics = AbilityLogic.getPowerRollCharacteristics(ability, undefined).sort(SheetFormatter.sortCharacteristics);
-				const allCharacteristics = Object.values(Characteristic).sort(SheetFormatter.sortCharacteristics);
-				const isAllCharacteristics = allCharacteristics.every((c, i) => characteristics[i] === c);
-				if (isAllCharacteristics) {
-					sheet.rollPower = 'Highest Characteristic';
-				} else {
-					sheet.rollPower = SheetFormatter.joinCommasOr(characteristics.map(c => c.toString().slice(0, 1)));
+				let effectText = SheetFormatter.abilitySection(s, refCreature);
+				effectText = SheetFormatter.enhanceMarkdown(effectText);
+
+				// Kind of hacky, but this is a one-off at the moment
+				if (CreatureLogic.isHero(creature)
+						&& ([ 'grab', 'knockback' ].includes(ability.id))
+						&& HeroLogic.getFeatures(creature as Hero).find(f => f.feature.id === 'null-1-8')) { // Psionic Martial Arts id
+					effectText = effectText.replace(/your Might/g, 'your Intuition');
 				}
+				return effectText;
 			}
-
-			sheet.rollT1Effect = SheetFormatter.formatAbilityTier(rollSection.roll.tier1, 1, ability, refCreature);
-			sheet.rollT2Effect = SheetFormatter.formatAbilityTier(rollSection.roll.tier2, 2, ability, refCreature);
-			sheet.rollT3Effect = SheetFormatter.formatAbilityTier(rollSection.roll.tier3, 3, ability, refCreature);
-
-			if (CreatureLogic.isHero(creature)) {
-				const isMelee = keywords.includes(AbilityKeyword.Melee) && keywords.includes(AbilityKeyword.Weapon);
-				const isRanged = keywords.includes(AbilityKeyword.Ranged) && keywords.includes(AbilityKeyword.Weapon);
-
-				const meleeKits = HeroLogic
-					.getKitDamageBonuses(creature)
-					.filter(dmg => dmg.type === 'melee');
-
-				const rangedKits = HeroLogic
-					.getKitDamageBonuses(creature)
-					.filter(dmg => dmg.type === 'ranged');
-
-				if (isMelee && meleeKits.length > 1) {
-					const bestT1 = Math.max(...meleeKits.map(k => k.tier1));
-					const bestT2 = Math.max(...meleeKits.map(k => k.tier2));
-					const bestT3 = Math.max(...meleeKits.map(k => k.tier3));
-
-					const meleeBonuses = meleeKits
-						.filter(k => k.tier1 >= bestT1 || k.tier2 >= bestT2 || k.tier3 >= bestT3)
-						.map(k => {
-							return {
-								name: k.name,
-								type: k.type,
-								tier1: SheetFormatter.addSign(k.tier1) || '',
-								tier2: SheetFormatter.addSign(k.tier2) || '',
-								tier3: SheetFormatter.addSign(k.tier3) || ''
-							};
-						});
-					if (meleeBonuses.length > 1) {
-						sheet.rollBonuses = (sheet.rollBonuses ?? []).concat(meleeBonuses);
-					}
-				}
-				if (isRanged && rangedKits.length > 1) {
-					const bestT1 = Math.max(...rangedKits.map(k => k.tier1));
-					const bestT2 = Math.max(...rangedKits.map(k => k.tier2));
-					const bestT3 = Math.max(...rangedKits.map(k => k.tier3));
-
-					const rangedBonuses = rangedKits
-						.filter(k => k.tier1 >= bestT1 || k.tier2 >= bestT2 || k.tier3 >= bestT3)
-						.map(k => {
-							return {
-								name: k.name,
-								type: k.type,
-								tier1: SheetFormatter.addSign(k.tier1) || '',
-								tier2: SheetFormatter.addSign(k.tier2) || '',
-								tier3: SheetFormatter.addSign(k.tier3) || ''
-							};
-						});
-					if (rangedBonuses.length > 1) {
-						sheet.rollBonuses = (sheet.rollBonuses ?? []).concat(rangedBonuses);
-					}
-				}
-			}
-		}
+		});
+		sheet.sections = sections;
 
 		return sheet;
 	};

--- a/src/logic/classic-sheet/sheet-formatter.test.ts
+++ b/src/logic/classic-sheet/sheet-formatter.test.ts
@@ -1,14 +1,18 @@
+import { Feature, FeatureAbility, FeatureChoice } from '@/models/feature';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import { Ability } from '@/models/ability';
 import { AbilityData } from '@/data/ability-data';
 import { ClassicSheetBuilder } from '@/logic/classic-sheet/classic-sheet-builder';
 import { FactoryLogic } from '@/logic/factory-logic';
-import { Feature } from '@/models/feature';
 import { FeatureType } from '@/enums/feature-type';
 import { HeroSheetBuilder } from '@/logic/hero-sheet/hero-sheet-builder';
 import { Monster } from '@/models/monster';
 import { ProjectSheet } from '@/models/classic-sheets/hero-sheet';
 import { SheetFormatter } from '@/logic/classic-sheet/sheet-formatter';
+import { conduit } from '@/data/classes/conduit/conduit';
+import { creation } from '@/data/domains/creation';
+import { demon } from '@/data/monsters/demon';
+import { dragonKnight } from '@/data/ancestries/dragon-knight';
 import { retainer } from '@/data/monsters/retainer';
 
 afterEach(() => {
@@ -524,12 +528,26 @@ describe('calculateProjectsOverviewCardSize', () => {
 });
 
 describe('calculateAbilitySize', () => {
+	const divineDragon = creation.featuresByLevel
+		.find(lvlFeatures => lvlFeatures.level === 9)?.features
+		.find(feature => feature.name === 'Divine Dragon') as FeatureAbility;
+
+	const arise = conduit.abilities
+		.find(ability => ability.id === 'conduit-ability-25') as Ability;
+
+	const rememberOath = (dragonKnight.features
+		.find(f => f.id === 'dragon-knight-feature-2') as FeatureChoice)
+		.data.options.find(f => f.feature.id === 'dragon-knight-feature-2-8')?.feature as FeatureAbility;
+
 	test.each([
-		[ AbilityData.heal, 11.2 ],
-		[ AbilityData.freeStrike, 7.2 ],
-		[ AbilityData.escapeGrab, 25.4 ],
-		[ AbilityData.clawDirt, 23.1 ],
-		[ AbilityData.advance, 9 ]
+		[ AbilityData.heal, 12.1 ],
+		[ AbilityData.freeStrikeMelee, 12 ],
+		[ AbilityData.escapeGrab, 22.5 ],
+		[ AbilityData.clawDirt, 21.5 ],
+		[ AbilityData.advance, 9.5 ],
+		[ divineDragon.data.ability, 37.5 ],
+		[ rememberOath.data.ability, 20.5 ],
+		[ arise, 16.5 ]
 	])('calculates size properly for standard abilities', (ability: Ability, expected: number) => {
 		const hero = FactoryLogic.createHero();
 		const sheet = ClassicSheetBuilder.buildAbilitySheet(ability, hero);
@@ -540,20 +558,41 @@ describe('calculateAbilitySize', () => {
 });
 
 describe('calculateFollowerSize()', () => {
-	// vi.mock('@/logic/hero-logic', () => {
-	// 	const HeroLogic = vi.fn();
-	// 	return { HeroLogic: HeroLogic };
-	// });
-
 	const humanWarrior = retainer.monsters.find(m => m.id === 'retainer-12') as Monster;
 
 	test.each([
-		[ 1, 37.5 ],
-		[ 4, 48 ],
-		[ 7, 61 ],
-		[ 10, 70 ]
+		// [ 4, 48 ],
+		// [ 7, 61 ],
+		// [ 10, 70 ],
+		[ 1, 36.5 ]
 	])('properly calculates the size of a retainer at different levels of advancement', (level, expectedSize) => {
 		const followerSheet = HeroSheetBuilder.buildRetainerSheet(humanWarrior, level);
 		expect(SheetFormatter.calculateFollowerSize(followerSheet, 54)).toBeCloseTo(expectedSize, 0);
+	});
+});
+
+describe('calculateMonsterSize()', () => {
+	const humanWarrior = retainer.monsters.find(m => m.id === 'retainer-12') as Monster;
+	const devilDefector = retainer.monsters.find(m => m.id === 'retainer-3') as Monster;
+
+	test.each([
+		[ humanWarrior, 57.5 ],
+		[ devilDefector, 60.5 ]
+	])('properly calculates the size of a retainer', (retainer, expectedSize) => {
+		const sheet = ClassicSheetBuilder.buildMonsterSheet(retainer);
+		const size = SheetFormatter.calculateMonsterSize(sheet, 54);
+		expect(Math.abs(expectedSize - size), `Expected ${expectedSize} but got ${size}`).toBeLessThan(1.1);
+	});
+
+	const soulrakerHandmaiden = demon.monsters.find(m => m.id === 'demon-3rd-8') as Monster;
+	const remasch = demon.monsters.find(m => m.id === 'demon-1st-6') as Monster;
+
+	test.each([
+		[ soulrakerHandmaiden, 53 ],
+		[ remasch, 41 ]
+	])('properly calculates the size of a monster card', (monster, expectedSize) => {
+		const sheet = ClassicSheetBuilder.buildMonsterSheet(monster);
+		const size = SheetFormatter.calculateMonsterSize(sheet, 54);
+		expect(Math.abs(expectedSize - size), `Expected ${expectedSize} but got ${size}`).toBeLessThan(1.1);
 	});
 });

--- a/src/logic/classic-sheet/sheet-formatter.ts
+++ b/src/logic/classic-sheet/sheet-formatter.ts
@@ -422,7 +422,16 @@ export class SheetFormatter {
 			case 'field': {
 				const effect = AbilityLogic.getTextEffect(section.effect, hero);
 				if (section.value !== 0) {
-					text = `\n#### ${section.name} ${section.value}${section.repeatable ? '+' : ''}:\n${effect}`;
+					if (section.name === 'Spend') {
+						const spendType = hero && HeroLogic.getHeroicResources(hero)[0]?.name;
+						let spendPost = '';
+						if (spendType) {
+							spendPost = ' ' + spendType;
+						}
+						text = `\n**${section.name} ${section.value}${section.repeatable ? '+' : ''}${spendPost}:** ${effect}`;
+					} else {
+						text = `\n#### ${section.name} ${section.value}${section.repeatable ? '+' : ''}:\n${effect}`;
+					}
 				} else {
 					text = `\n#### ${section.name}:\n${effect}`;
 				}
@@ -644,6 +653,7 @@ export class SheetFormatter {
 
 	static calculateFollowerSize = (follower: FollowerSheet, lineWidth: number): number => {
 		let size = 0;
+		// console.log(`=== Follower Size: ${follower?.name}`);
 		if (follower.classification === 'Follower') {
 			size = 6; // name, characteristics
 			size += this.countLines(`Skills: ${follower.skills?.join(', ')}`, lineWidth);
@@ -651,44 +661,78 @@ export class SheetFormatter {
 			size += 0.5;
 		} else {
 			size = 21.5; // name, stats, characteristics, stamina
+			// console.log(`---- header: ${size}`);
 			follower.abilities?.forEach(ability => {
 				size += this.calculateAbilityComponentSize(ability, lineWidth) + 1;
+				// console.log(`---- Ability ${ability.name}: ${size}`);
 			});
 			follower.features?.forEach(f => {
 				size += this.calculateFeatureSize(f, null, lineWidth, false) + 1;
+				// console.log(`---- Feature ${f.name}: ${size}`);
 			});
-			follower.advancement?.forEach(advancement => {
-				size += 1.5;
-				if (advancement.ability) {
-					size += this.calculateAbilityComponentSize(advancement.ability, lineWidth);
-				}
-				if (advancement.features?.length) {
-					advancement.features.forEach(f => {
-						size += this.calculateFeatureSize(f, null, lineWidth);
-					});
-				}
-			});
+			// follower.advancement?.forEach(advancement => {
+			// 	size += 1.5;
+			// 	if (advancement.ability) {
+			// 		size += this.calculateAbilityComponentSize(advancement.ability, lineWidth);
+			// 	}
+			// 	if (advancement.features?.length) {
+			// 		advancement.features.forEach(f => {
+			// 			size += this.calculateFeatureSize(f, null, lineWidth);
+			// 		});
+			// 	}
+			//	console.log(`---- Advancement Lvl ${advancement.level}: ${size}`);
+			// });
 		}
+		size -= 1; // no final divider
+		// console.log(`=== Total: ${size}`);
+		// console.log('===================');
 		return size;
 	};
 
 	static calculateMonsterSize = (monster: MonsterSheet, lineWidth: number, columns: number = 1): number => {
 		let size = 0;
+		const denseLineWidth = lineWidth * 1.4;
+		// console.log(`=== Monster Size: ${monster?.name}`);
 		size = 12.5; // name, stats, characteristics
 		let largestBlock = 0;
+		// console.log(`---- header: ${size}`);
 		monster.abilities?.forEach(ability => {
-			const abilitySize = this.calculateAbilityComponentSize(ability, lineWidth - 5);
+			const abilitySize = this.calculateAbilityComponentSize(ability, denseLineWidth);
 			size += abilitySize;
+			size += 1.5;
 			largestBlock = Math.max(largestBlock, abilitySize);
+			// console.log(`>> ---- Ability ${ability.name}: ${size}`);
 		});
 		monster.features?.forEach(f => {
-			const featureSize = this.calculateFeatureSize(f, null, lineWidth, false);
+			let featureSize = this.calculateFeatureSize(f, null, denseLineWidth, false);
+			if (featureSize > 15) {
+				featureSize = featureSize * 1.1;
+			}
 			size += featureSize;
+			size += 1.5;
 			largestBlock = Math.max(largestBlock, featureSize);
+			// console.log(`>> ---- Feature ${f.name}: ${size}`);
 		});
+		size -= 1.5; // no final divider
 		// ability/feature dividers
-		size += 1.6 * Math.max(0, ((monster.abilities?.length || 0) + (monster.features?.length || 0) - 1));
-		size = Math.ceil(size / columns);
+		// size += 1.6 * Math.max(0, ((monster.abilities?.length || 0) + (monster.features?.length || 0) - 1));
+
+		monster.advancement?.forEach(advancement => {
+			size += 2; // header
+			if (advancement.ability) {
+				size += this.calculateAbilityComponentSize(advancement.ability, denseLineWidth);
+			}
+			if (advancement.features?.length) {
+				advancement.features.forEach(f => {
+					size += this.calculateFeatureSize(f, null, denseLineWidth);
+				});
+			}
+			// console.log(`---- Advancement Lvl ${advancement.level}: ${size}`);
+		});
+		size += 1;// bottom padding
+		size = columns > 1 ? Math.ceil(size / columns) : size;
+		// console.log(`=== Total: ${size}`);
+		// console.log('===================');
 		return size;
 	};
 
@@ -728,26 +772,35 @@ export class SheetFormatter {
 
 	// COMPACT Ability display - e.g. for Retainers & Monsters
 	static calculateAbilityComponentSize = (ability: AbilitySheet, lineWidth: number): number => {
-		let size = 1.5; // name, usage
+		let size = 1; // name, usage
 		size += this.countLines(`${ability.keywords} ${ability.actionType}`, lineWidth);
 		size += this.countLines(`${ability.distance} ${ability.target}`, lineWidth);
 
 		const rollLineLen = Math.ceil(lineWidth - 10); // account for icons
-		size += this.countLines(ability.rollT1Effect, rollLineLen);
-		size += this.countLines(ability.rollT2Effect, rollLineLen);
-		size += this.countLines(ability.rollT3Effect, rollLineLen);
+		// console.log(`>> -- Ability header: ${size}`);
 
 		if (ability.trigger) {
-			size += this.countLines(ability.trigger, lineWidth);
+			size += 0.4 + this.countLines(ability.trigger, lineWidth);
 		}
 
-		if (ability.effect) {
-			if (ability.hasPowerRoll) {
-				size += 0.5; // extra padding when effect follows power roll
+		// console.log(`>> -- Trigger: ${size}`);
+		ability.sections.forEach((s, n) => {
+			if (typeof s === 'string') {
+				const effectSize = this.countLines(s, lineWidth, 1, 0.8);
+				// size += (ability.isNotTrueAbility ? 0 : 1.5) + effectSize;
+				size += effectSize;
+			} else {
+				size += 0.3 + this.countLines(s.rollT1Effect, rollLineLen);
+				size += 0.3 + this.countLines(s.rollT2Effect, rollLineLen);
+				size += 0.3 + this.countLines(s.rollT3Effect, rollLineLen);
 			}
-			const effectSize = this.countLines(ability.effect, lineWidth);
-			size += effectSize;
-		}
+
+			if (n > 0) {
+				size += 0.4;
+			}
+			// console.log(`>> -- Section [${n + 1}]: ${size}`);
+		});
+		// console.log(`>> -- Ability total: ${size}`);
 		return size;
 	};
 
@@ -798,27 +851,42 @@ export class SheetFormatter {
 
 	static calculateAbilitySize = (ability: AbilitySheet | undefined, lineWidth: number): number => {
 		let size = 0;
-		const rollLineLen = Math.ceil(0.8 * lineWidth) - 10;
+		// console.log(`=== Ability Size: ${ability?.name}`);
+		const rollLineLen = Math.ceil(lineWidth) - 10;
 		if (ability) {
-			size += 4; // title
-			size += this.countLines(ability.description, lineWidth);
-			size += ability.isNotTrueAbility ? 1 : 2.5; // keywords, distance, etc
-			size += ability.hasPowerRoll ? 2 : 0;
-			if (ability.hasPowerRoll) {
-				size += 0.3 + this.countLines(ability.rollT1Effect, rollLineLen);
-				size += 0.3 + this.countLines(ability.rollT2Effect, rollLineLen);
-				size += 0.3 + this.countLines(ability.rollT3Effect, rollLineLen);
-			}
+			size += ability.cost ? 4 : 3.8; // title
+			// console.log(`-- Title: ${size}`);
+			size += this.countLines(ability.description, lineWidth * 1.1);
+			// console.log(`-- Description: ${size}`);
+			size += ability.isNotTrueAbility ? 1 : 2.2; // keywords, distance, etc
+			size += ability.qualifiers?.length ? 0.8 : 0;
+			// console.log(`-- Keywords/Distance/etc.: ${size}`);
 			if (ability.trigger) {
 				size += 1 + this.countLines(ability.trigger, lineWidth);
 			}
-			if (ability.effect) {
-				if (ability.hasPowerRoll) {
-					size += 0.5; // extra padding when effect follows power roll
+			// console.log(`-- Trigger: ${size}`);
+
+			ability.sections.forEach((s, n) => {
+				if (typeof s === 'string') {
+					const effectSize = this.countLines(s, lineWidth, 1);
+					// size += (ability.isNotTrueAbility ? 0 : 1.5) + effectSize;
+					size += effectSize;
+				} else {
+					size += 1.5; // 'Power Roll + ...'
+					size += 0.15 + this.countLines(s.rollT1Effect, rollLineLen);
+					size += 0.15 + this.countLines(s.rollT2Effect, rollLineLen);
+					size += 0.15 + this.countLines(s.rollT3Effect, rollLineLen);
 				}
-				const effectSize = this.countLines(ability.effect, lineWidth, 1);
-				size += (ability.isNotTrueAbility ? 0 : 1.5) + effectSize;
-			}
+
+				if (n > 0) {
+					size += 0.4;
+				}
+				// console.log(`-- Section [${n + 1}]: ${size}`);
+			});
+
+			size += 0.5; // bottom padding
+			// console.log(`-- Full: ${size}`);
+			// console.log('============================');
 		}
 		return size;
 	};
@@ -828,7 +896,12 @@ export class SheetFormatter {
 		const result = text?.trim().replaceAll(/(!\[.+\])\(data:image.+\)/g, '$1(<img>)').split('\n').reduce((n, l) => {
 			let len = emptyLineSize;
 			if (l.length) {
-				len = Math.ceil(l.length / lineWidth) * lineFactor;
+				let calcLength = l.length;
+				// Add 10% to long text blocks to account for wrapping inconsistencies
+				if (l.length > (3 * lineWidth)) {
+					calcLength *= 1.1;
+				}
+				len = Math.ceil(calcLength / lineWidth) * lineFactor;
 				len += 0.2;// additional spacing
 			}
 			if (l.startsWith('|:---')) { // table divider
@@ -848,6 +921,8 @@ export class SheetFormatter {
 				len += 0.5;
 			} else if (l.startsWith('* ')) { // list item, will be indented
 				len = Math.ceil(l.length / (lineWidth - 3));
+			} else if (l.startsWith('>')) { // blockquote - don't include extra spacing from line 860
+				len -= 0.2;
 			}
 
 			return n + len;

--- a/src/logic/classic-sheet/sheet-layout.tsx
+++ b/src/logic/classic-sheet/sheet-layout.tsx
@@ -61,7 +61,11 @@ export class SheetLayout {
 
 	static getMonsterCardsLayout = (options: Options): CardPageLayout => {
 		// FORCE portrait
-		return this.getCardsLayoutForOrientation(options, 'portrait');
+		const layout = this.getCardsLayoutForOrientation(options, 'portrait');
+		// more conservative for monster/library cards
+		layout.linesY = 85;
+		layout.cardGap = 2;
+		return layout;
 	};
 
 	static getCardsLayoutForOrientation = (options: Options, orientation: 'portrait' | 'landscape'): CardPageLayout => {

--- a/src/logic/hero-sheet/hero-sheet-builder.test.ts
+++ b/src/logic/hero-sheet/hero-sheet-builder.test.ts
@@ -187,10 +187,10 @@ describe('buildRetainerSheet', () => {
 	const humanWarrior = retainer.monsters.find(m => m.id === 'retainer-12') as Monster;
 
 	test.each([
-		[ 1, 0 ],
-		[ 4, 1 ],
-		[ 7, 2 ],
-		[ 10, 3 ]
+		[ 1, 3 ],
+		[ 4, 2 ],
+		[ 7, 1 ],
+		[ 10, 0 ]
 	])('should limit advancement features included based on level', (level, numAdvancements) => {
 		const sheet = HeroSheetBuilder.buildRetainerSheet(humanWarrior, level);
 		expect(sheet.advancement?.length).toBe(numAdvancements);

--- a/src/logic/hero-sheet/hero-sheet-builder.ts
+++ b/src/logic/hero-sheet/hero-sheet-builder.ts
@@ -581,19 +581,19 @@ export class HeroSheetBuilder {
 		sheet.abilities = abilities.map(a => ClassicSheetBuilder.buildAbilitySheet(a, follower));
 
 		const advancement = [];
-		if ((!heroLevel || heroLevel >= 4) && follower.retainer?.level4?.type === FeatureType.Ability) {
+		if ((!heroLevel || heroLevel < 4) && follower.retainer?.level4?.type === FeatureType.Ability) {
 			advancement.push({
 				level: 4,
 				ability: ClassicSheetBuilder.buildAbilitySheet(follower.retainer.level4.data.ability, follower)
 			});
 		}
-		if ((!heroLevel || heroLevel >= 7) && follower.retainer?.level7?.type === FeatureType.Ability) {
+		if ((!heroLevel || heroLevel < 7) && follower.retainer?.level7?.type === FeatureType.Ability) {
 			advancement.push({
 				level: 7,
 				ability: ClassicSheetBuilder.buildAbilitySheet(follower.retainer.level7.data.ability, follower)
 			});
 		}
-		if ((!heroLevel || heroLevel >= 10) && follower.retainer?.level10?.type === FeatureType.Ability) {
+		if ((!heroLevel || heroLevel < 10) && follower.retainer?.level10?.type === FeatureType.Ability) {
 			advancement.push({
 				level: 10,
 				ability: ClassicSheetBuilder.buildAbilitySheet(follower.retainer.level10.data.ability, follower)

--- a/src/models/classic-sheets/ability-sheet.ts
+++ b/src/models/classic-sheets/ability-sheet.ts
@@ -12,9 +12,11 @@ export interface AbilitySheet {
 	target?: string;
 	trigger?: string;
 	qualifiers?: string[];
-	effect?: string;
 
-	hasPowerRoll: boolean;
+	sections: (string | PowerRollSection)[];
+}
+
+export interface PowerRollSection {
 	rollPower?: string;
 	rollT1Effect?: string;
 	rollT2Effect?: string;

--- a/src/models/classic-sheets/monster-sheet.ts
+++ b/src/models/classic-sheets/monster-sheet.ts
@@ -29,5 +29,11 @@ export interface MonsterSheet {
 
 	features?: Feature[];
 	abilities?: AbilitySheet[];
+
+	advancement?: {
+		level: number,
+		ability?: AbilitySheet,
+		features?: Feature[]
+	}[];
 };
 // #endregion


### PR DESCRIPTION
Fixes #918 

## Overview 
- Properly show abilities with multiple power rolls and varying section order.
- Fix Retainer display and rework Monster card size calculation

### Ability Section Display
Properly displays Ability sections in the right order, and can also now display Abilities with multiple Power Roll sections
Also Adjusted the formatting to make Abilities slightly more compact
<img width="418" height="525" alt="image" src="https://github.com/user-attachments/assets/f978e3d1-923d-4b44-9824-ebdf6829140b" />

<img width="421" height="810" alt="image" src="https://github.com/user-attachments/assets/eca1a4ab-56db-4061-af7c-28e4edbdd448" />

### Retainer Display fixes
Retainers were broken in Classic Sheet - they should be fixed now.
Hero Sheet view:
- Only shows for current level and advancement choices already made
<img width="443" height="795" alt="image" src="https://github.com/user-attachments/assets/dda6d782-39cd-4b0b-86e2-34493ced68b4" />

Library / Monster Group View:
- Shows Advancement options
<img width="897" height="844" alt="image" src="https://github.com/user-attachments/assets/c51ba883-008b-44ec-ba84-7801b4da4cd3" />
