### PR TITLE
Preserve heroic resource value and toggle state on hero reload

### DIFF
--- a/src/logic/update/hero-update-logic.ts
+++ b/src/logic/update/hero-update-logic.ts
@@ -1,4 +1,4 @@
-import { Feature, FeatureAncestryChoice, FeatureAncestryFeatureChoice, FeatureChoice, FeatureClassAbility, FeatureCompanion, FeatureDomain, FeatureDomainFeature, FeatureHeroicResourceThreshold, FeatureItemChoice, FeatureKit, FeatureLanguageChoice, FeatureMultiple, FeaturePerk, FeatureRetainer, FeatureSkillChoice, FeatureSummon, FeatureSummonChoice, FeatureTaggedFeatureChoice, FeatureTitleChoice } from '@/models/feature';
+import { Feature, FeatureAncestryChoice, FeatureAncestryFeatureChoice, FeatureChoice, FeatureClassAbility, FeatureCompanion, FeatureDomain, FeatureDomainFeature, FeatureHeroicResource, FeatureHeroicResourceThreshold, FeatureItemChoice, FeatureKit, FeatureLanguageChoice, FeatureMultiple, FeaturePerk, FeatureRetainer, FeatureSkillChoice, FeatureSummon, FeatureSummonChoice, FeatureTaggedFeatureChoice, FeatureTitleChoice, FeatureToggle } from '@/models/feature';
 import { Ancestry } from '@/models/ancestry';
 import { AncestryData } from '@/data/ancestry-data';
 import { Characteristic } from '@/enums/characteristic';
@@ -542,6 +542,15 @@ export class HeroUpdateLogic {
 					});
 					break;
 				}
+				case FeatureType.HeroicResource: {
+					const oFeature = originalFeature as FeatureHeroicResource;
+					if (oFeature.type !== FeatureType.HeroicResource) {
+						break;
+					}
+
+					feature.data.value = oFeature.data.value;
+					break;
+				}
 				case FeatureType.ItemChoice: {
 					const oFeature = originalFeature as FeatureItemChoice;
 					if (oFeature.type !== FeatureType.ItemChoice) {
@@ -692,6 +701,15 @@ export class HeroUpdateLogic {
 
 						return oTitle;
 					});
+					break;
+				}
+				case FeatureType.Toggle: {
+					const oFeature = originalFeature as FeatureToggle;
+					if (oFeature.type !== FeatureType.Toggle) {
+						break;
+					}
+
+					feature.data.checked = oFeature.data.checked;
 					break;
 				}
 			};


### PR DESCRIPTION
Issue: HeroUpdateLogic.updateHeroData rebuilds a hero's class from the sourcebook template on every load (to pick up content updates), which silently reset the heroic resource's current value - and any toggle's on/off state - back to the template default each time, since neither was covered by updateHeroFeatureData, the mechanism this codebase already uses to carry per-hero feature state forward on reload for every other feature type.

Fix: Adds HeroicResource and Toggle cases there, following the pattern of the existing cases. Covers any source of a heroic resource (class, title, item), not just class-granted ones.

This was particularly noticeable when pausing an encounter between sessions, returning the following week to see that everyone's heroic resource was zeroed-out.